### PR TITLE
feat: URL Onboarding skill.md + CI/CD auto-publish for skills

### DIFF
--- a/.github/workflows/publish-skills.yml
+++ b/.github/workflows/publish-skills.yml
@@ -1,0 +1,120 @@
+name: Publish Skills to ClawHub
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.skills/**'
+      - 'skill.md'
+  workflow_dispatch:
+    inputs:
+      force:
+        description: 'Force re-publish all skills even if unchanged'
+        required: false
+        default: 'false'
+
+jobs:
+  publish-skills:
+    name: Publish to ClawHub
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install ClawHub CLI
+        run: npm install -g clawhub@latest
+
+      - name: Authenticate with ClawHub
+        env:
+          CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
+        run: |
+          if [ -z "$CLAWHUB_TOKEN" ]; then
+            echo "::error::CLAWHUB_TOKEN secret is not set. Add it at: Settings > Secrets and variables > Actions"
+            exit 1
+          fi
+          clawhub login --token "$CLAWHUB_TOKEN"
+
+      - name: Detect changed skills
+        id: changed
+        run: |
+          if [ "${{ github.event.inputs.force }}" = "true" ]; then
+            echo "force=true" >> "$GITHUB_OUTPUT"
+            echo "Force mode: will publish all skills."
+          else
+            CHANGED=$(git diff --name-only HEAD~1 HEAD -- '.skills/' 'skill.md' || true)
+            echo "Changed files: $CHANGED"
+            if [ -n "$CHANGED" ]; then
+              echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "has_changes=false" >> "$GITHUB_OUTPUT"
+              echo "No skill files changed. Skipping publish."
+            fi
+          fi
+
+      - name: Publish find-agent-service skill
+        if: >
+          steps.changed.outputs.force == 'true' ||
+          (steps.changed.outputs.has_changes == 'true' &&
+           contains(join(github.event.commits.*.modified, ','), '.skills/find-agent-service'))
+        env:
+          CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
+        run: |
+          echo "Publishing find-agent-service..."
+          clawhub publish .skills/find-agent-service \
+            --slug find-agent-service \
+            --name "find-agent-service" \
+            --accept-license-terms \
+            --changelog "Auto-published from commit ${{ github.sha }}" \
+            || echo "::warning::find-agent-service publish failed — check ClawHub CLI version"
+
+      - name: Publish evaluate-agent-native skill
+        if: >
+          steps.changed.outputs.force == 'true' ||
+          (steps.changed.outputs.has_changes == 'true' &&
+           contains(join(github.event.commits.*.modified, ','), '.skills/evaluate-agent-native'))
+        env:
+          CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
+        run: |
+          echo "Publishing evaluate-agent-native..."
+          clawhub publish .skills/evaluate-agent-native \
+            --slug evaluate-agent-native \
+            --name "evaluate-agent-native" \
+            --accept-license-terms \
+            --changelog "Auto-published from commit ${{ github.sha }}" \
+            || echo "::warning::evaluate-agent-native publish failed — check ClawHub CLI version"
+
+      - name: Publish add-to-awesome-list skill
+        if: >
+          steps.changed.outputs.force == 'true' ||
+          (steps.changed.outputs.has_changes == 'true' &&
+           contains(join(github.event.commits.*.modified, ','), '.skills/add-to-awesome-list'))
+        env:
+          CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
+        run: |
+          echo "Publishing add-to-awesome-list..."
+          clawhub publish .skills/add-to-awesome-list \
+            --slug add-to-awesome-list \
+            --name "add-to-awesome-list" \
+            --accept-license-terms \
+            --changelog "Auto-published from commit ${{ github.sha }}" \
+            || echo "::warning::add-to-awesome-list publish failed — check ClawHub CLI version"
+
+      - name: Sync all skills (fallback)
+        if: steps.changed.outputs.force == 'true'
+        env:
+          CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
+        run: |
+          echo "Running full sync of .skills/ directory..."
+          clawhub sync .skills/ --accept-license-terms \
+            || echo "::warning::clawhub sync failed — individual publish steps above may have succeeded"

--- a/README.md
+++ b/README.md
@@ -18,6 +18,16 @@ This repository is itself agent-native. Install these skills to let your coding 
 
 Skills are published on [ClawHub](https://clawhub.ai) under [`@haoruilee`](https://clawhub.ai/haoruilee). Source files are in `.skills/` in this repo.
 
+### ⭐ URL Onboarding — For Agents Without a Coding Environment
+
+If you are an AI agent and want to discover services natively without installing anything:
+
+```
+Read https://raw.githubusercontent.com/haoruilee/awesome-agent-native-services/main/skill.md then find services designed for you natively.
+```
+
+This reads the machine-readable catalog entry point and surfaces the full list of agent-native services with their onboarding patterns.
+
 ---
 
 ## How Agents Interact with These Services
@@ -36,6 +46,7 @@ A service with URL Onboarding hosts its entire onboarding protocol as a machine-
 
 | Service | Onboarding instruction |
 |---|---|
+| **This catalog** | `Read https://raw.githubusercontent.com/haoruilee/awesome-agent-native-services/main/skill.md then find services designed for you natively` |
 | **Moltbook** | `Read https://www.moltbook.com/skill.md and follow the instructions to register and join` |
 | **Ensue** | `Read https://ensue.dev/docs and call POST https://api.ensue-network.ai/auth/agent-register` |
 | **autoresearch@home** | `Read https://raw.githubusercontent.com/mutable-state-inc/autoresearch-at-home/master/collab.md and follow the instructions to join` |

--- a/skill.md
+++ b/skill.md
@@ -1,0 +1,250 @@
+---
+name: find-agent-native-service
+description: >
+  Read this file to discover agent-native services — infrastructure designed from
+  the ground up for AI agents, not adapted from human-facing products. Use the
+  catalog to find services by task, understand each service's onboarding pattern,
+  and immediately start using any service with URL Onboarding in one instruction.
+version: "2026-03-15"
+license: CC0-1.0
+catalog: https://github.com/haoruilee/awesome-agent-native-services
+allowed-tools: WebSearch Read
+---
+
+# Agent-Native Services Catalog — URL Onboarding Entry Point
+
+**You are an AI agent. Read this file to find infrastructure services designed natively for you.**
+
+This catalog lists services that treat agents as first-class entities — not as secondary integration targets. Every service here was built from inception for agents, with primitives that have no meaningful human-facing equivalent.
+
+---
+
+## How to use this catalog
+
+### Step 1 — Find your task in the category map below
+
+Identify which category matches what you need to do. Note the **Onboarding** column — if it says **URL Onboarding ⭐**, you can start using that service right now with a single instruction.
+
+### Step 2 — Use URL Onboarding services immediately
+
+For any service marked ⭐ URL Onboarding, execute this instruction:
+
+```
+Read <onboarding-url> and follow the instructions.
+```
+
+The service hosts a machine-readable protocol. You read it, understand the registration flow, call the API, and you are live — no human setup, no config files, no developer code.
+
+### Step 3 — For other services, read the service file
+
+Navigate to `services/{category}/{service-name}.md` in the catalog repository for full onboarding instructions, API details, SDK commands, and MCP configuration.
+
+---
+
+## Immediate URL Onboarding — Start Now
+
+These services can be joined with a single instruction, right now, with no human involvement:
+
+| Service | What You Get | Onboarding Instruction |
+|---|---|---|
+| **Moltbook** | Agent social network: post, comment, vote, DM, build karma | `Read https://www.moltbook.com/skill.md and follow the instructions to register and join` |
+| **Ensue** | Shared memory network: register, claim experiments, publish hypotheses | `Read https://ensue.dev/docs and call POST https://api.ensue-network.ai/auth/agent-register` |
+| **autoresearch@home** | Collaborative research swarm: join, claim tasks, publish results | `Read https://raw.githubusercontent.com/mutable-state-inc/autoresearch-at-home/master/collab.md and follow the instructions to join` |
+
+---
+
+## Full Catalog — 15 Categories, 38+ Services
+
+### 1. Communication
+*Give agents a first-class communication identity on the internet.*
+
+| Service | Tagline | Onboarding |
+|---|---|---|
+| [AgentMail](https://agentmail.to) | Email for AI agents | `pip install agentmail` → `POST /inboxes` |
+| [Novu](https://novu.co) | Notification infrastructure with Agent Toolkit | `npx skills add novuhq/skills` |
+
+---
+
+### 2. Browser & Web Execution
+*Remote browser and web data extraction for agents.*
+
+| Service | Tagline | Onboarding |
+|---|---|---|
+| [Browserbase](https://browserbase.com) | A web browser for AI agents & applications | `npx skills add browserbase/skills` |
+| [Firecrawl](https://firecrawl.dev) | Turn any website into LLM-ready data | `npx skills add firecrawl/cli` |
+| [Bright Data Agent Browser](https://brightdata.com) | Cloud browser with built-in website unlocking | `npx -y @brightdata/mcp` (MCP config) |
+| [bb-browser](https://github.com/epiral/bb-browser) | Your browser is the API — 103 commands, 36 platforms | `npm install -g bb-browser` + Chrome extension |
+
+---
+
+### 3. Tool Access & Integration
+*Runtime tool discovery, auth, and execution without human pre-configuration.*
+
+| Service | Tagline | Onboarding |
+|---|---|---|
+| [Composio](https://composio.dev) | The tool platform built for agents | `npx skills add composiohq/skills` |
+| [Nango](https://nango.dev) | OAuth and credential layer for AI agents | `$skills install @NangoHQ/sync-builder-skill` |
+| [Toolhouse](https://toolhouse.ai) | BaaS for AI agents — tools, memory, and execution | `npm install -g toolhouse` → `th deploy` |
+
+---
+
+### 4. Oversight & Approval
+*Structured, programmatic human approval before high-stakes actions.*
+
+| Service | Tagline | Onboarding |
+|---|---|---|
+| [HumanLayer](https://humanlayer.dev) | Human in the Loop for AI Agents | `pip install humanlayer` → `@hl.require_approval()` |
+
+---
+
+### 5. Commerce & Payments
+*Verified financial identity and real-economy transactions for agents.*
+
+| Service | Tagline | Onboarding |
+|---|---|---|
+| [Payman AI](https://paymanai.com) | Agentic AI that does the banking. Under your control. | `npm install @paymanai/payman-node` → `client_credentials` OAuth |
+| [Skyfire](https://skyfire.xyz) | Identity and payments for autonomous AI agents | Register at skyfire.xyz/product → agent wallet + KYA token |
+| [AgentsPay](https://agentspay.dev) | Crypto identity and embedded wallets for AI agents | Provision wallet at agentspay.dev → MCP-native gateway |
+| [Nevermined](https://nevermined.io) | The payment layer AI agents actually need | `pip install payments-py` → x402 inline payments |
+| [Openwork](https://openwork.so) | The agent-only labor marketplace | `npx playbooks add skill openclaw/skills --skill openwork` |
+
+---
+
+### 6. Agent Runtime & Infrastructure
+*Secure execution, session isolation, secrets, identity, and gateway for production agents.*
+
+| Service | Tagline | Onboarding |
+|---|---|---|
+| [Amazon Bedrock AgentCore](https://aws.amazon.com/bedrock/agentcore/) | Purpose-built for deploying and scaling dynamic AI agents | `pip install boto3` → configure AgentCore runtime |
+| [Infisical Agent Sentinel](https://infisical.com) | Secrets and credential governance for AI agents | `npx -y @infisical/mcp` |
+| [Letta](https://letta.ai) | The fastest way to bring stateful agents to production | `pip install letta-client` → `client.agents.create(...)` |
+| [Aembit](https://aembit.io) | Secretless workload identity and access management | Configure Aembit access policy → JIT credentials at runtime |
+
+---
+
+### 7. Memory & State
+*Persistent, queryable memory across sessions — memory as infrastructure, not application logic.*
+
+| Service | Tagline | Onboarding |
+|---|---|---|
+| [Mem0](https://mem0.ai) | The memory layer for your AI agents | `pip install mem0ai` → `m.add(messages, user_id=...)` |
+| [Zep](https://getzep.com) | Agent memory powered by a temporal knowledge graph | `pip install zep-python` → `zep.add_session_message(...)` |
+| [Ensue](https://ensue.dev) ⭐ | The shared memory network for AI agents | `Read https://ensue.dev/docs and call POST /auth/agent-register` |
+| [OpenViking](https://github.com/volcengine/OpenViking) | The context database for AI agents | `pip install openviking` → `openviking-server` → MCP at `localhost:8000/mcp` |
+| [MemOS](https://github.com/MemTensor/MemOS) | A memory OS for LLM and AI agent systems | `pip install memos-core` → `memory.add(...)` |
+| [memU](https://github.com/NevaMind-AI/memU) | Memory for 24/7 proactive AI agents | `pip install memu` → continuous stream monitoring |
+
+---
+
+### 8. Search & Web Intelligence
+*LLM-optimized web search returning structured content tuned for context windows.*
+
+| Service | Tagline | Onboarding |
+|---|---|---|
+| [Tavily](https://tavily.com) | Connect your agent to the web | `npx skills add tavily-ai/skills` |
+| [Exa](https://exa.ai) | The search engine designed for AI | `pip install exa-py` → `exa.search(query)` |
+
+---
+
+### 9. Code Execution
+*Secure isolated runtimes for AI-generated code with LLM-formatted output.*
+
+| Service | Tagline | Onboarding |
+|---|---|---|
+| [E2B](https://e2b.dev) | Cloud for AI agents — secure sandboxes for AI-generated code | `pip install e2b-code-interpreter` → `with Sandbox() as sandbox:` |
+
+---
+
+### 10. Observability & Tracing
+*Full trajectory tracing, evaluation datasets, and cost attribution for agent runs.*
+
+| Service | Tagline | Onboarding |
+|---|---|---|
+| [Langfuse](https://langfuse.com) | Open-source LLM observability, tracing, and evaluation | `npx skills add https://github.com/langfuse/skills --skill langfuse-observability` |
+
+---
+
+### 11. Durable Execution & Scheduling
+*Fault-tolerant long-running agent workflows with checkpointing and HITL suspend/resume.*
+
+| Service | Tagline | Onboarding |
+|---|---|---|
+| [Trigger.dev](https://trigger.dev) | Build and deploy fully-managed AI agents and workflows | `npx skills add triggerdotdev/skills` |
+| [Inngest](https://inngest.com) | Durable execution for AI agents in production | `npx skills add inngest/inngest-skills` |
+| [Restate](https://restate.dev) | Durable execution for AI agents — any framework, any cloud | `pip install restate-sdk` → wrap agent with 2-line middleware |
+
+---
+
+### 12. Meeting & Conversation
+*Programmatic agent presence in voice and video meetings.*
+
+| Service | Tagline | Onboarding |
+|---|---|---|
+| [Recall.ai](https://recall.ai) | The meeting bot API for every platform | `POST https://api.recall.ai/api/v1/bot` with meeting URL |
+
+---
+
+### 13. Voice & Phone
+*Agent-controlled voice calls and telephony infrastructure.*
+
+| Service | Tagline | Onboarding |
+|---|---|---|
+| [Vapi](https://vapi.ai) | Build advanced voice AI agents | `pip install vapi-server-sdk` → `POST /assistant` |
+
+---
+
+### 14. LLM Gateway & Routing
+*Per-agent budget, routing, caching, and observability for LLM calls.*
+
+| Service | Tagline | Onboarding |
+|---|---|---|
+| [Portkey](https://portkey.ai) | The AI gateway built for production agents | `pip install portkey-ai` → point LLM client at `api.portkey.ai` with a virtual key |
+
+---
+
+### 15. Agent Social & Community
+*Social networks where AI agents are first-class participants.*
+
+| Service | Tagline | Onboarding |
+|---|---|---|
+| [Moltbook](https://moltbook.com) ⭐ | The front page of the agent internet | `Read https://www.moltbook.com/skill.md and follow the instructions to register and join` |
+| [Shellmates](https://shellmates.app) | Pen pals for AI agents — 1:1 matching, private correspondence | `POST https://www.shellmates.app/api/agents/register` |
+| [Openwork](https://openwork.so) | The agent-only labor marketplace — hire agents, earn on-chain | `npx playbooks add skill openclaw/skills --skill openwork` |
+
+---
+
+## Interaction Patterns Reference
+
+| Pattern | How to activate | Best for |
+|---|---|---|
+| ⭐ **URL Onboarding** | `Read <url> and follow the instructions` | Services with machine-readable protocol files |
+| **MCP Tool** | Add to `mcp_servers` in config | Tools that appear as native agent capabilities |
+| **Coding-time Skill** | `npx skills add org/repo` | SDK patterns and service-specific workflows |
+| **SDK / REST** | `pip install <pkg>` + API key | Direct API integrations requiring credentials |
+| **Daemon / Extension** | Run daemon, install extension | Services that delegate authenticated browser sessions |
+
+---
+
+## Criteria — What Makes a Service Agent-Native
+
+Every service in this catalog satisfies all five:
+
+1. **Agent-First Positioning** — Official docs explicitly name AI agents as the primary consumer.
+2. **Agent-Specific Primitives** — At least one API abstraction with no meaningful human-facing equivalent.
+3. **Autonomy-Compatible Control Plane** — Agents operate without per-action human confirmation.
+4. **Machine-to-Machine Integration Surface** — SDK / REST / MCP / webhook is the primary interface.
+5. **Agent Identity / Delegation Semantics** — Agent identity, delegated permissions, and audit trails are first-class.
+
+---
+
+## Agent Skills for This Catalog
+
+Install these skills to let your coding agent work with this catalog directly:
+
+```
+npx clawhub@latest install find-agent-service
+npx clawhub@latest install evaluate-agent-native
+npx clawhub@latest install add-to-awesome-list
+```
+
+Full catalog: https://github.com/haoruilee/awesome-agent-native-services


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Two improvements to make this repo fully self-maintaining and agent-discoverable.

---

### 1. `skill.md` — URL Onboarding entry point for this catalog

Any AI agent can now discover all 38+ agent-native services with a single instruction:

```
Read https://raw.githubusercontent.com/haoruilee/awesome-agent-native-services/main/skill.md then find services designed for you natively.
```

This mirrors the pattern used by Moltbook (`skill.md`) and Ensue (`collab.md`) — services already listed in this catalog as URL Onboarding exemplars. The file includes:
- The full 15-category service catalog with onboarding instructions
- URL Onboarding services surfaced at the top for immediate use
- The interaction patterns reference table
- Agent skills install commands

The `README.md` has been updated to surface this onboarding URL in the Agent Skills section and in the URL Onboarding table (where this repo is listed alongside Moltbook, Ensue, and autoresearch@home).

---

### 2. `.github/workflows/publish-skills.yml` — CI/CD auto-publish

Skills in `.skills/` are now automatically published to ClawHub on every push to `main` that modifies skill files. Previously, publishing was entirely manual.

**How it works:**
- Triggers on push to `main` when `.skills/**` or `skill.md` changes
- Authenticates with ClawHub using a `CLAWHUB_TOKEN` secret
- Detects which specific skills changed and publishes only those
- Supports manual `workflow_dispatch` with a `force` option to re-publish all skills
- Uses `--accept-license-terms` flag to work around the known ClawHub CLI v0.7.0 bug ([#660](https://github.com/openclaw/clawhub/issues/660))

**Required setup:** Add `CLAWHUB_TOKEN` to repository secrets at Settings → Secrets and variables → Actions.

---

### Files changed

| File | Change |
|---|---|
| `skill.md` | New — URL Onboarding entry point for this catalog |
| `.github/workflows/publish-skills.yml` | New — auto-publish CI/CD workflow |
| `README.md` | Updated — add URL Onboarding instruction + catalog entry in the table |
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b3098ed6-f107-4378-8f0e-76d41d384715"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b3098ed6-f107-4378-8f0e-76d41d384715"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

