### PR TITLE
[New Service] acpx — Headless ACP CLI for agent-to-agent communication

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ For the full criteria and contribution instructions, see [CONTRIBUTING.md](CONTR
 | 3 | [Tool Access & Integration](#3-tool-access--integration-services) | 3 | Runtime tool discovery, auth, and execution |
 | 4 | [Oversight & Approval](#4-oversight--approval-services) | 1 | Human-in-the-loop approval and escalation |
 | 5 | [Commerce & Payments](#5-commerce--payment-services) | 5 | Agent-native wallets, identity, and transactions |
-| 6 | [Agent Runtime & Infrastructure](#6-agent-runtime--infrastructure-services) | 4 | Execution, session isolation, secrets, and gateway |
+| 6 | [Agent Runtime & Infrastructure](#6-agent-runtime--infrastructure-services) | 5 | Execution, session isolation, secrets, and gateway |
 | 7 | [Memory & State](#7-memory--state-services) | 6 | Persistent agent memory across sessions |
 | 8 | [Search & Web Intelligence](#8-search--web-intelligence-services) | 2 | LLM-optimized web search and content retrieval |
 | 9 | [Code Execution](#9-code-execution-services) | 1 | Secure sandboxes for AI-generated code |
@@ -193,6 +193,7 @@ For the full criteria and contribution instructions, see [CONTRIBUTING.md](CONTR
 
 | Service | Tagline | Primitives | MCP | How to Use |
 |---|---|---|---|---|
+| [acpx](services/agent-runtime-and-infrastructure/acpx.md) [![⭐](https://img.shields.io/github/stars/openclaw/acpx?style=social)](https://github.com/openclaw/acpx) | Headless ACP CLI — agents talk to coding agents over structured protocol | Persistent sessions · Prompt queueing · Cooperative cancel · Structured output | N/A | `npm install -g acpx` then `acpx codex "fix the tests"` |
 | [Amazon Bedrock AgentCore](services/agent-runtime-and-infrastructure/amazon-bedrock-agentcore.md) | Purpose-built for deploying and scaling dynamic AI agents and tools | Agent runtime · Long-term memory · Identity tokens · Tool gateway · OTEL tracing | ⚠️ | `pip install boto3` — configure AgentCore runtime via AWS SDK |
 | [Infisical Agent Sentinel](services/agent-runtime-and-infrastructure/infisical-agent-sentinel.md) [![⭐](https://img.shields.io/github/stars/Infisical/infisical?style=social)](https://github.com/Infisical/infisical) | Secrets and credential governance for AI agents | Dynamic secret generation · Token lifecycle daemon · Per-agent policy | ✅ | `npx -y @infisical/mcp` or deploy the agent daemon sidecar |
 | [Letta](services/agent-runtime-and-infrastructure/letta.md) [![⭐](https://img.shields.io/github/stars/letta-ai/letta?style=social)](https://github.com/letta-ai/letta) | The fastest way to bring stateful agents to production | Stateful agent · Model-agnostic state · Agent templates · Self-editing memory | ✅ | `pip install letta-client` then `client.agents.create(...)` |
@@ -315,6 +316,16 @@ For the full criteria and contribution instructions, see [CONTRIBUTING.md](CONTR
 | [Moltbook](services/agent-social-network/moltbook.md) | The front page of the agent internet | Agent registration · Post/comment/vote · Submolts · Agent karma · Agent DMs | ❌ | Read https://www.moltbook.com/skill.md and follow the instructions to register and join |
 | [Shellmates](services/agent-social-network/shellmates.md) | Pen pals for AI agents — 1:1 matching, private correspondence, marriage registry | Agent bio · Match request · Private conversation · Marriage registry | ❌ | `POST https://www.shellmates.app/api/agents/register` — write bio, browse profiles, match |
 | [Openwork](services/agent-social-network/openwork.md) | The agent-only labor marketplace — hire agents, earn on-chain | Agent-to-agent hiring · On-chain escrow · ERC-8004 reputation · $OPENWORK | ⚠️ | `npx playbooks add skill openclaw/skills --skill openwork` |
+
+---
+
+## Ecosystem Hubs
+
+Organizations that provide multiple agent-native services or tools:
+
+| Hub | What It Provides | Notable Projects |
+|---|---|---|
+| [OpenClaw](https://github.com/openclaw) | Agent Client Protocol tooling, skills registry, agent marketplace integration | [acpx](services/agent-runtime-and-infrastructure/acpx.md) (ACP CLI), [openclaw/skills](https://github.com/openclaw/skills) (skills for Openwork, Exa, OpenViking, MemOS, E2B), [Openwork](services/agent-social-network/openwork.md) integration |
 
 ---
 

--- a/services/agent-runtime-and-infrastructure/README.md
+++ b/services/agent-runtime-and-infrastructure/README.md
@@ -19,6 +19,7 @@ The services in this category were purpose-built to fill this gap.
 
 | Service | Tagline | Protocol Surface | MCP? |
 |---|---|---|---|
+| [acpx](acpx.md) | Headless ACP CLI — agents talk to coding agents over structured protocol, not PTY scraping | CLI, ACP protocol, SKILL.md | N/A |
 | [Amazon Bedrock AgentCore](amazon-bedrock-agentcore.md) | Purpose-built for deploying and scaling dynamic AI agents and tools | AWS SDK, REST API, OpenTelemetry | ❌ |
 | [Infisical Agent Sentinel](infisical-agent-sentinel.md) | Secrets and credential governance for AI agents | Daemon sidecar, REST API | ✅ |
 | [Letta](letta.md) | The fastest way to bring stateful agents to production | REST API, Python SDK, TypeScript SDK, MCP | ✅ |

--- a/services/agent-runtime-and-infrastructure/acpx.md
+++ b/services/agent-runtime-and-infrastructure/acpx.md
@@ -1,0 +1,170 @@
+# acpx
+
+> **"Headless CLI client for stateful Agent Client Protocol (ACP) sessions — so AI agents and orchestrators can talk to coding agents over a structured protocol instead of PTY scraping."**
+
+| | |
+|---|---|
+| **Website** | https://github.com/openclaw/acpx |
+| **Docs** | https://github.com/openclaw/acpx/blob/main/docs/CLI.md |
+| **GitHub** | https://github.com/openclaw/acpx |
+| **Classification** | `agent-native` |
+| **Category** | [Agent Runtime & Infrastructure Services](README.md) |
+| **Protocol** | [Agent Client Protocol (ACP)](https://agentclientprotocol.com) |
+
+---
+
+## Official Website
+
+https://github.com/openclaw/acpx
+
+---
+
+## Official Repo
+
+https://github.com/openclaw/acpx
+
+---
+
+## How to Use (Agent Onboarding)
+
+**Interaction pattern:** `Coding-time Skill + CLI`
+
+```bash
+# Install acpx globally (recommended for session reuse)
+npm install -g acpx@latest
+
+# Install the acpx skill for full command reference
+npx acpx@latest --skill install acpx
+
+# Read the skill reference for all commands and workflows
+# Read https://raw.githubusercontent.com/openclaw/acpx/main/skills/acpx/SKILL.md
+
+# Delegate to a coding agent via ACP
+npx acpx@latest codex "fix the failing tests"
+npx acpx@latest claude "refactor the auth module"
+npx acpx@latest exec "one-shot: summarize this repo"
+```
+
+---
+
+## Agent Skills
+
+**Status:** ✅ Available
+
+```bash
+npx acpx@latest --skill install acpx
+```
+
+| Skill | What It Teaches the Agent |
+|---|---|
+| `acpx` | Use acpx as headless ACP CLI for agent-to-agent communication: prompt/exec/sessions workflows, session scoping, queueing, permissions, and output formats |
+
+---
+
+## MCP
+
+**Status:** ⚠️ Not applicable — acpx is a CLI client that implements the ACP protocol. Agents invoke it as a subprocess; it does not expose an MCP server.
+
+---
+
+## What It Does
+
+acpx is a **headless CLI client for the Agent Client Protocol (ACP)**. It enables AI agents and orchestrators to delegate work to coding agents (Pi, OpenClaw, Codex, Claude, etc.) over a structured protocol instead of scraping PTY sessions. One command surface for all ACP-compatible agents.
+
+Core value: **typed ACP messages** (thinking, tool calls, diffs) instead of ANSI scraping. Agents get structured, parseable output and can manage persistent sessions, queue prompts, and cancel in-flight work cooperatively.
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | *"Your agents love acpx! They hate having to scrape characters from a PTY session"* — *"so AI agents and orchestrators can talk to coding agents over a structured protocol"* — [README](https://github.com/openclaw/acpx) |
+| **Agent-specific primitive** | Persistent multi-turn sessions per repo; named sessions for parallel workstreams; prompt queueing with fire-and-forget; cooperative `session/cancel`; structured ACP output. No human-facing equivalent — a human would use a terminal directly |
+| **Autonomy-compatible control plane** | Fire-and-forget (`--no-wait`), queue owner TTL, graceful cancel on interrupt; agents operate without per-action human confirmation |
+| **M2M integration surface** | CLI as primary interface. Agents invoke via `npx acpx` or `acpx`; config via JSON files; SKILL.md for machine-readable onboarding |
+| **Identity / delegation** | Sessions scoped per repo/cwd; named sessions isolate parallel workstreams; session state persisted in `~/.acpx/` with per-session isolation |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **Persistent Sessions** | Multi-turn conversations that survive across invocations, scoped per repo |
+| **Named Sessions** | Parallel workstreams in the same repo (`-s backend`, `-s frontend`) |
+| **Prompt Queueing** | Submit prompts while one is running; they execute in order |
+| **Fire-and-Forget** | `--no-wait` queues a prompt and returns immediately |
+| **Cooperative Cancel** | `cancel` sends ACP `session/cancel` via queue IPC; `Ctrl+C` does graceful cancel before force-kill |
+| **Structured Output** | Typed ACP messages (thinking, tool calls, diffs) instead of ANSI scraping |
+| **One-Shot Mode** | `exec` for stateless fire-and-forget tasks |
+| **Session Controls** | `set-mode`, `set <key> <value>` for `session/set_mode` and `session/set_config_option` |
+| **Agent Registry** | Built-in support for Pi, OpenClaw, Codex, Claude, Gemini, Cursor, Copilot; `--agent` escape hatch for custom servers |
+
+---
+
+## Autonomy Model
+
+```
+Orchestrator agent installs acpx or uses npx acpx@latest
+    ↓
+Agent creates session (explicit or implicit via directory-walk)
+    ↓
+Agent submits prompt via acpx codex "fix the tests"
+    ↓
+acpx spawns ACP-compatible coding agent (Codex, Claude, etc.)
+    ↓
+Structured ACP messages stream back (thinking, tool calls, diffs)
+    ↓
+Agent parses output; no PTY scraping required
+    ↓
+Optional: agent queues follow-up with --no-wait; or cancels with acpx cancel
+    ↓
+Session persists across invocations; agent can resume later
+```
+
+---
+
+## Identity and Delegation Model
+
+- Sessions are scoped per repository (cwd). Each agent run gets its own session context.
+- Named sessions (`-s <name>`) allow parallel workstreams with isolated state.
+- Session state stored in `~/.acpx/` with per-session isolation.
+- ACP `authenticate` handshake supports env/config credentials for delegated access.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| CLI | `acpx` — primary interface; agents invoke via subprocess |
+| Config | JSON config files: global + project merge; `acpx config show|init` |
+| Skill | `npx acpx@latest --skill install acpx` — installs SKILL.md for agent reference |
+| Protocol | Implements [Agent Client Protocol (ACP)](https://agentclientprotocol.com) |
+
+---
+
+## Human-in-the-Loop Support
+
+Not required. Agents operate fully autonomously. acpx is designed for agent-to-agent delegation; no human approval gates in the protocol. Optional: human can inspect session history via `acpx sessions history`.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **Raw PTY / terminal** | Unstructured ANSI output; agents must scrape; no session semantics, no cooperative cancel, no typed messages |
+| **Generic subprocess** | No persistent sessions, no prompt queueing, no ACP protocol; output is unstructured |
+| **IDE extensions** | Human-facing; require GUI; not designed for agent orchestration or M2M delegation |
+
+---
+
+## Use Cases
+
+- **Orchestrator-to-coding-agent delegation** — a planning agent delegates coding tasks to Codex/Claude via acpx without PTY scraping
+- **Parallel workstreams** — named sessions allow one agent to run `-s api` and `-s docs` concurrently
+- **Fire-and-forget pipelines** — queue prompts with `--no-wait` for long-running tasks; agent returns immediately
+- **Structured output consumption** — agents parse typed ACP messages (thinking, tool calls) instead of ANSI
+- **Multi-agent coding workflows** — Pi, OpenClaw, Codex, Claude, and other ACP agents share one CLI surface

--- a/skill.md
+++ b/skill.md
@@ -115,6 +115,7 @@ These services can be joined with a single instruction, right now, with no human
 
 | Service | Tagline | Onboarding |
 |---|---|---|
+| [acpx](https://github.com/openclaw/acpx) | Headless ACP CLI — agents talk to coding agents over structured protocol | `npm install -g acpx` → `acpx codex "fix the tests"` |
 | [Amazon Bedrock AgentCore](https://aws.amazon.com/bedrock/agentcore/) | Purpose-built for deploying and scaling dynamic AI agents | `pip install boto3` → configure AgentCore runtime |
 | [Infisical Agent Sentinel](https://infisical.com) | Secrets and credential governance for AI agents | `npx -y @infisical/mcp` |
 | [Letta](https://letta.ai) | The fastest way to bring stateful agents to production | `pip install letta-client` → `client.agents.create(...)` |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds **acpx** from the [OpenClaw](https://github.com/openclaw) organization to the Agent Runtime & Infrastructure category, and introduces an **Ecosystem Hubs** section to highlight organizations that provide multiple agent-native services.

## Changes

### New Service: acpx

- **Category:** Agent Runtime & Infrastructure Services
- **Tagline:** Headless CLI client for stateful Agent Client Protocol (ACP) sessions — so AI agents and orchestrators can talk to coding agents over a structured protocol instead of PTY scraping
- **Primitives:** Persistent sessions, named sessions, prompt queueing, cooperative cancel, fire-and-forget, structured ACP output
- **How to Use:** `npm install -g acpx` then `acpx codex "fix the tests"`
- **Agent Skills:** `npx acpx@latest --skill install acpx`

acpx enables AI agents to delegate work to coding agents (Pi, OpenClaw, Codex, Claude, etc.) over the [Agent Client Protocol](https://agentclientprotocol.com) — providing typed ACP messages instead of PTY scraping.

### Ecosystem Hubs Section

Adds a new section before "Excluded / Boundary Cases" that lists organizations providing multiple agent-native services. OpenClaw is highlighted with acpx, openclaw/skills (skills registry), and Openwork integration.

### Updates

- `services/agent-runtime-and-infrastructure/acpx.md` — full service entry (new)
- `services/agent-runtime-and-infrastructure/README.md` — add acpx to category table
- `README.md` — add acpx to main table, add Ecosystem Hubs section, update category count
- `skill.md` — add acpx to machine-readable catalog

## Checklist

- [x] Service meets all five hard criteria (CONTRIBUTING.md)
- [x] Service file follows required format
- [x] Added to category README and root README
- [x] Updated skill.md catalog
- [x] All content in English
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bd1e47b6-9dd6-452f-862a-a2e005a4a279"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bd1e47b6-9dd6-452f-862a-a2e005a4a279"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

