### PR TITLE
[Maintenance] Document MiniMax Skills and ClawHub in ecosystem hubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,8 @@ Organizations that provide multiple agent-native services or tools:
 | Hub | What It Provides | Notable Projects |
 |---|---|---|
 | [OpenClaw](https://github.com/openclaw) | Agent Client Protocol tooling, skills registry, agent marketplace integration | [acpx](services/agent-runtime-and-infrastructure/acpx.md) (ACP CLI), [openclaw/skills](https://github.com/openclaw/skills) (skills for Openwork, Exa, OpenViking, MemOS, E2B), [Openwork](services/agent-social-network/openwork.md) integration |
+| [ClawHub](https://claw-hub.net/) | Public skill registry and marketplace for OpenClaw-style agents — search, install, and publish skills from the CLI | [openclaw/clawhub](https://github.com/openclaw/clawhub) (CLI), [`.skills/`](https://github.com/haoruilee/awesome-agent-native-services/tree/main/.skills) in this repo |
+| [MiniMax Skills](https://github.com/MiniMax-AI/skills) [![⭐](https://img.shields.io/github/stars/MiniMax-AI/skills?style=social)](https://github.com/MiniMax-AI/skills) | Curated **development skills** for AI coding agents — structured `SKILL.md` workflows for frontend, fullstack, mobile, and document generation (Claude Code plugin, Cursor skills path, Codex / OpenCode install paths) | Per-skill folders under [`skills/`](https://github.com/MiniMax-AI/skills/tree/main/skills) with YAML-frontmatter `SKILL.md` ([contributing spec](https://github.com/MiniMax-AI/skills/blob/main/CONTRIBUTING.md)) |
 
 ---
 

--- a/llms.txt
+++ b/llms.txt
@@ -28,6 +28,13 @@ This repository is itself agent-native. AI agents can discover services, evaluat
 
 ---
 
+## Related — agent skills registries (ecosystem hubs)
+
+- [ClawHub](https://claw-hub.net/): OpenClaw skill marketplace — `npx clawhub@latest` ([openclaw/clawhub](https://github.com/openclaw/clawhub))
+- [MiniMax Skills](https://github.com/MiniMax-AI/skills): Curated `SKILL.md` packs for AI coding agents (Claude Code, Cursor, Codex, OpenCode) — see repo README for install paths
+
+---
+
 ## Agent Skills (Install)
 
 | Skill | Command | Purpose |

--- a/skill.md
+++ b/skill.md
@@ -222,6 +222,17 @@ These services can be joined with a single instruction, right now, with no human
 
 ---
 
+## Agent skills hubs (registries like ClawHub)
+
+These are **curated skill packs and marketplaces** — machine-readable instructions (`SKILL.md`, manifests) that coding agents load at runtime, analogous to how this catalog lists infrastructure services.
+
+| Hub | Role | How to start |
+|---|---|---|
+| **ClawHub** | Public registry for OpenClaw-style skills — search, install, publish via CLI | `npx clawhub@latest search <topic>` — [claw-hub.net](https://claw-hub.net/) · [openclaw/clawhub](https://github.com/openclaw/clawhub) |
+| **MiniMax Skills** | Official deep-tuned development skills for AI coding agents (frontend, fullstack, Android, iOS, shaders, office docs) | [github.com/MiniMax-AI/skills](https://github.com/MiniMax-AI/skills) — follow **Installation** in the repo README (Claude Code plugin, Cursor `skills/` path, Codex / OpenCode symlinks) |
+
+---
+
 ## Interaction Patterns Reference
 
 | Pattern | How to activate | Best for |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds [MiniMax-AI/skills](https://github.com/MiniMax-AI/skills) alongside [ClawHub](https://claw-hub.net/) as **agent skills ecosystem hubs** — curated `SKILL.md` / marketplace surfaces that complement the main catalog (which lists agent-native *infrastructure services*).

## Changes

- **README.md** — Two new rows under [Ecosystem Hubs](https://github.com/haoruilee/awesome-agent-native-services#ecosystem-hubs): ClawHub (marketplace + CLI repo) and MiniMax Skills (repo README install paths, link to contributing spec).
- **skill.md** — New section **Agent skills hubs** so agents reading the catalog can discover registries in the same spirit as ClawHub.
- **llms.txt** — Short **Related — agent skills registries** block for LLM-oriented discovery.

## Notes

- MiniMax Skills is documented as a **skills registry / pack**, not as a fifteenth category service file, because this list’s [five criteria](https://github.com/haoruilee/awesome-agent-native-services/blob/main/CONTRIBUTING.md) target hosted infrastructure services; the hub table is the appropriate place for skill marketplaces and curated repos.

## Checklist

- [x] Links verified (GitHub README, CONTRIBUTING, claw-hub.net, openclaw/clawhub)
- [x] No classification of MiniMax as a numbered category service (hub only)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ce74f744-3c19-4764-bdda-353496053b41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ce74f744-3c19-4764-bdda-353496053b41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

