### PR TITLE
[New Service] Retell AI, Agentgateway, Runloop, MeetStream

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,12 @@ Source files are in `.skills/` in this repo.
 | 6 | [Agent Runtime & Infrastructure](#6-agent-runtime--infrastructure-services) | 11 | Execution, session isolation, secrets, and gateway |
 | 7 | [Memory & State](#7-memory--state-services) | 8 | Persistent agent memory across sessions |
 | 8 | [Search & Web Intelligence](#8-search--web-intelligence-services) | 4 | LLM-optimized web search and content retrieval |
-| 9 | [Code Execution](#9-code-execution-services) | 2 | Secure sandboxes for AI-generated code |
+| 9 | [Code Execution](#9-code-execution-services) | 3 | Secure sandboxes for AI-generated code |
 | 10 | [Observability & Tracing](#10-observability--tracing-services) | 3 | Agent trajectory tracing and evaluation |
 | 11 | [Durable Execution & Scheduling](#11-durable-execution--scheduling-services) | 4 | Fault-tolerant long-running agent workflows |
-| 12 | [Meeting & Conversation](#12-meeting--conversation-services) | 2 | Agent presence in voice and video meetings |
-| 13 | [Voice & Phone](#13-voice--phone-services) | 1 | Agent-controlled voice calls and phone infrastructure |
-| 14 | [LLM Gateway & Routing](#14-llm-gateway--routing-services) | 2 | Per-agent budget, routing, caching, and observability for LLM calls |
+| 12 | [Meeting & Conversation](#12-meeting--conversation-services) | 3 | Agent presence in voice and video meetings |
+| 13 | [Voice & Phone](#13-voice--phone-services) | 2 | Agent-controlled voice calls and phone infrastructure |
+| 14 | [LLM Gateway & Routing](#14-llm-gateway--routing-services) | 3 | Per-agent budget, routing, caching, and observability for LLM calls |
 | 15 | [Agent Social & Community](#15-agent-social--community-services) | 3 | Social networks where agents are first-class participants |
 
 ---
@@ -197,6 +197,7 @@ Source files are in `.skills/` in this repo.
 |---|---|---|---|---|
 | [E2B](services/code-execution/e2b.md) [![⭐](https://img.shields.io/github/stars/e2b-dev/e2b?style=social)](https://github.com/e2b-dev/e2b) | Cloud for AI agents — secure sandboxes for AI-generated code | Ephemeral Linux VM · ~150ms cold start · Stateful execution context · Streaming output | ✅ | `pip install e2b-code-interpreter` then `with Sandbox() as sandbox:` |
 | [Daytona](services/code-execution/daytona.md) [![⭐](https://img.shields.io/github/stars/daytonaio/daytona?style=social)](https://github.com/daytonaio/daytona) | Secure elastic infrastructure for AI-generated code | Sub-90ms sandboxes · Git/LSP/exec · Preview URLs · CLI MCP | ✅ | `brew install daytonaio/cli/daytona` → `daytona login` → `daytona mcp init cursor` — or `pip install daytona` |
+| [Runloop](services/code-execution/runloop.md) [![⭐](https://img.shields.io/github/stars/runloopai/api-client-python?style=social)](https://github.com/runloopai/api-client-python) | Your AI agent accelerator | Devbox micro-VM · Snapshot/branch disk state · Benchmark jobs · Suspend/resume | ✅ | `export RUNLOOP_API_KEY=...` → `npm install -g @runloop/rl-cli` → `rli mcp install` — [CLI docs](https://docs.runloop.ai/docs/tools/rl-cli) |
 
 ---
 
@@ -239,6 +240,7 @@ Source files are in `.skills/` in this repo.
 |---|---|---|---|---|
 | [Recall.ai](services/meeting-and-conversation/recall-ai.md) | The meeting bot API for every platform | Meeting bot lifecycle · Real-time diarized transcript · Calendar-triggered deployment · 6 platforms | ❌ | `POST https://api.recall.ai/api/v1/bot` with the meeting URL |
 | [Meeting BaaS](services/meeting-and-conversation/meeting-baas.md) | Meeting bots as a service — Zoom, Meet, Teams | Bot lifecycle · Webhook transcripts · Optional bidirectional audio stream · meeting-mcp | ✅ | `POST https://api.meetingbaas.com/bots` with `x-meeting-baas-api-key` — [docs](https://docs.meetingbaas.com/docs/api/getting-started/sending-a-bot) |
+| [MeetStream](services/meeting-and-conversation/meetstream.md) | Unified meeting-bot API for Zoom, Meet, Teams | Real-time diarized webhooks · WebSocket A/V · In-meeting chat/TTS · Calendar auto-dispatch | ⚠️ | `POST https://api.meetstream.ai/api/v1/bots/create_bot` with `Authorization: Token <key>` — [Create Bot](https://docs.meetstream.ai/api-reference/ap-is/bot-endpoints/create-bot.mdx) |
 
 ---
 
@@ -251,6 +253,7 @@ Source files are in `.skills/` in this repo.
 | Service | Tagline | Primitives | MCP | How to Use |
 |---|---|---|---|---|
 | [Vapi](services/voice-and-phone/vapi.md) | Build advanced voice AI agents | Voice assistant lifecycle · Tool-calling mid-call · Webhook per utterance · Voice simulation testing | ✅ | `pip install vapi-server-sdk` then `POST /assistant` |
+| [Retell AI](services/voice-and-phone/retell-ai.md) [![⭐](https://img.shields.io/github/stars/RetellAI/retell-python-sdk?style=social)](https://github.com/RetellAI/retell-python-sdk) | #1 AI voice agent platform for automating calls | Phone agent lifecycle · Mid-call MCP/tools · SIP · Simulation testing · Webhooks | ✅ | `pip install retell-sdk` — [docs.retellai.com](https://docs.retellai.com) |
 
 ---
 
@@ -264,6 +267,7 @@ Source files are in `.skills/` in this repo.
 |---|---|---|---|---|
 | [Portkey](services/llm-gateway-and-routing/portkey.md) [![⭐](https://img.shields.io/github/stars/Portkey-AI/gateway?style=social)](https://github.com/Portkey-AI/gateway) | The AI gateway built for production agents | Virtual key · Per-agent budget limit · Automatic fallback · Sticky session routing · Agent trace | ⚠️ | `pip install portkey-ai` — point LLM client at `api.portkey.ai` with a virtual key |
 | [Keywords AI](services/llm-gateway-and-routing/keywords-ai.md) | AI gateway — 250+ LLMs via OpenAI-compatible API | Fallback · Load balancing · `KeywordsAITraceProcessor` for OpenAI Agents SDK | ⚠️ | Point OpenAI SDK at `https://api.keywordsai.co` — [gateway quickstart](https://docs.keywordsai.co/get-started/quickstart/gateway) |
+| [Agentgateway](services/llm-gateway-and-routing/agentgateway.md) [![⭐](https://img.shields.io/github/stars/agentgateway/agentgateway?style=social)](https://github.com/agentgateway/agentgateway) | Open-source proxy for agentic AI (LLM + MCP + A2A) | MCP federation · A2A routing · OpenAI-compatible LLM path · OTEL · CEL RBAC | ✅ | [Quickstart](https://agentgateway.dev/docs/quickstart/): install binary/Docker/K8s → `agentgateway -f config.yaml` |
 
 ---
 

--- a/services/code-execution/README.md
+++ b/services/code-execution/README.md
@@ -22,6 +22,7 @@ Agent-native code execution services solve this with:
 |---|---|---|---|
 | [E2B](e2b.md) | Cloud for AI agents — secure sandboxes for AI-generated code | Python SDK, TypeScript SDK, REST API | ❌ |
 | [Daytona](daytona.md) | Secure elastic infrastructure for running AI-generated code | Python/TS/Ruby/Go SDK, REST, Daytona CLI + MCP | ✅ |
+| [Runloop](runloop.md) | Your AI agent accelerator — Devboxes and agent benchmarks | Python/TS SDK, REST, Runloop CLI (`rli`) + MCP | ✅ |
 
 ---
 

--- a/services/code-execution/runloop.md
+++ b/services/code-execution/runloop.md
@@ -1,0 +1,172 @@
+# Runloop
+
+> **"Your AI Agent Accelerator."**
+
+| | |
+|---|---|
+| **Website** | https://runloop.ai |
+| **Docs** | https://docs.runloop.ai |
+| **GitHub** | https://github.com/runloopai/api-client-python |
+| **Stars** | [![GitHub Stars](https://img.shields.io/github/stars/runloopai/api-client-python?style=social)](https://github.com/runloopai/api-client-python) |
+| **Classification** | `agent-native` |
+| **Category** | [Code Execution Services](README.md) |
+| **Compliance** | SOC 2 · HIPAA · GDPR (per marketing site) |
+
+---
+
+## Official Website
+
+https://runloop.ai
+
+---
+
+## Official Repo
+
+https://github.com/runloopai/api-client-python — Python API client
+
+https://github.com/runloopai/api-client-ts — TypeScript API client
+
+https://github.com/runloopai/rl-cli — Runloop CLI (`rli`) including MCP server
+
+---
+
+## How to Use (Agent Onboarding)
+
+**Interaction pattern:** `SDK / REST` + **CLI** + **MCP**
+
+1. Register at [platform.runloop.ai](https://platform.runloop.ai) and create an API key ([settings](https://runloop.ai/settings)).
+2. Create isolated **Devboxes** (micro-VM sandboxes) and run commands, snapshots, and blueprints — [Devboxes overview](https://docs.runloop.ai/docs/devboxes/overview).
+
+```bash
+pip install runloop-api-client
+# or: npm install @runloop/api-client  (see GitHub api-client-ts)
+export RUNLOOP_API_KEY=...
+```
+
+**CLI + MCP for assistants:**
+
+```bash
+npm install -g @runloop/rl-cli
+export RUNLOOP_API_KEY=...
+rli mcp install   # Claude Desktop config
+rli mcp start     # stdio MCP server
+```
+
+See [Runloop CLI](https://docs.runloop.ai/docs/tools/rl-cli).
+
+---
+
+## Agent Skills
+
+**Status:** ⚠️ No official `npx skills add …` pack from Runloop yet.
+
+```bash
+npx clawhub@latest search runloop
+```
+
+---
+
+## MCP
+
+**Status:** ✅ Available (via official CLI)
+
+The Runloop CLI embeds a **Model Context Protocol** server so tools like Claude can list, create, and manage Devboxes — `rli mcp start` (stdio) or `rli mcp start --http` — [Runloop CLI — MCP](https://docs.runloop.ai/docs/tools/rl-cli).
+
+| Detail | Value |
+|---|---|
+| **Docs** | https://docs.runloop.ai/docs/tools/rl-cli |
+| **Install helper** | `rli mcp install` for Claude Desktop |
+| **Devbox MCP injection** | Devbox create supports MCP gateway configurations (CLI reference) |
+
+---
+
+## What It Does
+
+Runloop provides **Devboxes**: secure, isolated sandboxes for running **AI-generated code** and long-running agent workflows, with fast startup, optional suspend/resume, **disk snapshots and branching** for agent state, repo-aware environments, secrets/objects stores, and **benchmark jobs** to evaluate coding agents (e.g., SWE-Bench-style runs). The surface area is explicitly marketed for **AI agents** and **AI software engineering** workloads—not generic batch VMs only.
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | Homepage: *"Your AI Agent Accelerator"* and *"Launch AI agents on secure code sandboxes"*; *"Devboxes are code sandbox development environments… for… AI Agents"* — [runloop.ai](https://runloop.ai) |
+| **Agent-specific primitive** | **Devbox** lifecycle; **snapshot/branch disk state** for agent trajectories; **benchmark jobs** for agent evaluation; **MCP** wiring from CLI and devbox config |
+| **Autonomy-compatible control plane** | API-driven create/exec/suspend/shutdown; no human SSH session required for automation |
+| **M2M integration surface** | Python/TS API clients, REST, CLI, MCP via `rli` |
+| **Identity / delegation** | Per-devbox IDs; API keys; secrets injection; audit-friendly logging (per product docs) |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **Devbox** | Isolated execution environment for agent code (micro-VM + container isolation, per product) |
+| **Snapshot** | Capture and branch disk state for reproducible agent runs |
+| **Blueprint** | Reusable image/template for agent environments |
+| **Benchmark job** | Orchestrated multi-agent evaluation against public or custom scenarios |
+| **Object / secret store** | Agent artifacts and credentials without embedding secrets in prompts |
+| **Suspend / resume** | Cost-aware pausing of bursty agent workflows |
+
+---
+
+## Autonomy Model
+
+```
+Agent obtains RUNLOOP_API_KEY (or delegated token)
+    ↓
+Creates Devbox from blueprint or snapshot via API/CLI
+    ↓
+Runs commands, tests, or full agent loop inside sandbox
+    ↓
+Snapshots state for regression tests or parallel branches
+    ↓
+Shuts down, suspends, or resumes without human provisioning
+```
+
+---
+
+## Identity and Delegation Model
+
+- **API keys** — tenant-scoped access to Runloop API
+- **Devbox IDs** — isolate sessions and attribute logs
+- **Secrets** — injected as env vars without surfacing values to the LLM (pattern documented in CLI)
+- **Network policies** — optional egress and MCP gateway controls (CLI reference)
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| Python SDK | `pip install runloop-api-client` — [api-client-python](https://github.com/runloopai/api-client-python) |
+| TypeScript SDK | `@runloop/api-client` — [api-client-ts](https://github.com/runloopai/api-client-ts) |
+| REST API | Platform API per [docs.runloop.ai](https://docs.runloop.ai) |
+| CLI | `npm install -g @runloop/rl-cli` → `rli` |
+| MCP | `rli mcp start` / `rli mcp install` |
+
+---
+
+## Human-in-the-Loop Support
+
+Optional review of agent outputs or benchmark results. Core sandbox execution does not require a human in the loop.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **Raw cloud VMs** | No agent-first lifecycle, snapshot branching for trajectories, or built-in agent benchmark orchestration |
+| **CI runners** | Job-centric; not optimized for interactive agent loops, suspend/resume, or MCP-native assistant control |
+| **Local Docker** | Host risk and ops burden; lacks managed agent evaluation and fleet scale patterns |
+
+---
+
+## Use Cases
+
+- **Coding agents** — run, test, and iterate generated code in isolated Devboxes
+- **Agent CI / regression** — snapshot state and re-run after model or prompt changes
+- **Benchmarking** — compare agent implementations on public suites at scale
+- **Long-horizon tasks** — suspend/resume bursty workloads to control cost

--- a/services/llm-gateway-and-routing/README.md
+++ b/services/llm-gateway-and-routing/README.md
@@ -18,6 +18,7 @@ Calling an LLM directly is fine for prototyping. Running agents in production �
 |---|---|---|---|
 | [Portkey](portkey.md) | The AI gateway built for production agents | REST API (OpenAI-compatible), Python SDK, TypeScript SDK | ❌ |
 | [Keywords AI](keywords-ai.md) | AI gateway — 250+ models via OpenAI-compatible API | Fallback · Load balancing · OpenAI Agents trace processor | ⚠️ |
+| [Agentgateway](agentgateway.md) | Connect, secure, and observe agentic workflows (MCP, A2A, LLM) | OpenAI-compatible proxy, MCP gateway, A2A, Kubernetes/bare metal | ✅ |
 
 ---
 

--- a/services/llm-gateway-and-routing/agentgateway.md
+++ b/services/llm-gateway-and-routing/agentgateway.md
@@ -1,0 +1,158 @@
+# Agentgateway
+
+> **"Connect Secure Observe Connect Agentic Workflows."**
+
+| | |
+|---|---|
+| **Website** | https://agentgateway.dev |
+| **Docs** | https://agentgateway.dev/docs/ |
+| **GitHub** | https://github.com/agentgateway/agentgateway |
+| **Stars** | [![GitHub Stars](https://img.shields.io/github/stars/agentgateway/agentgateway?style=social)](https://github.com/agentgateway/agentgateway) |
+| **Classification** | `agent-native` |
+| **Category** | [LLM Gateway & Routing Services](README.md) |
+
+---
+
+## Official Website
+
+https://agentgateway.dev
+
+---
+
+## Official Repo
+
+https://github.com/agentgateway/agentgateway
+
+---
+
+## How to Use (Agent Onboarding)
+
+**Interaction pattern:** **self-hosted proxy** (binary, Docker, or Kubernetes) — OpenAI-compatible LLM front door plus **MCP** and **A2A** routing
+
+Quick start from the project site:
+
+```bash
+curl https://raw.githubusercontent.com/agentgateway/agentgateway/refs/heads/main/common/scripts/get-agentgateway | bash
+curl -sL https://raw.githubusercontent.com/agentgateway/agentgateway/main/examples/basic/config.yaml -o config.yaml
+agentgateway -f config.yaml
+# Open UI at localhost:15000
+```
+
+Full paths: [Quickstart](https://agentgateway.dev/docs/quickstart/) · [LLM gateway tutorial](https://agentgateway.dev/docs/standalone/latest/tutorials/llm-gateway/) · [MCP connectivity](https://agentgateway.dev/docs/mcp/).
+
+---
+
+## Agent Skills
+
+**Status:** ⚠️ No official `SKILL.md` / `npx skills add …` pack for Agentgateway yet.
+
+```bash
+npx clawhub@latest search agentgateway
+```
+
+---
+
+## MCP
+
+**Status:** ✅ Core protocol (MCP gateway is a primary feature)
+
+Agentgateway **terminates and federates MCP**: multiple MCP servers behind one endpoint, stdio / HTTP/SSE / Streamable HTTP transports, OpenAPI-to-MCP exposure, and MCP auth spec alignment — see [MCP Gateway](https://agentgateway.dev/) and [docs](https://agentgateway.dev/docs/mcp/).
+
+| Detail | Value |
+|---|---|
+| **Docs** | https://agentgateway.dev/docs/mcp/ |
+| **Federation** | Single MCP endpoint aggregating many tool servers |
+| **Deployment** | Standalone binary/Docker or Kubernetes Gateway API |
+
+---
+
+## What It Does
+
+Agentgateway is an **open-source proxy** for agentic traffic: it routes **agent-to-LLM** requests through an OpenAI-compatible surface (multi-provider), connects **agent-to-tool** via MCP (including federation and auth), and **agent-to-agent** via the A2A protocol. It adds **JWT/API key auth**, CEL-based **RBAC**, rate limits, prompt guards, and **OpenTelemetry** visibility — positioned as infrastructure for agent workloads rather than a generic HTTP reverse proxy.
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | Site copy: *"open source proxy built on AI-native protocols (A2A & MCP) to connect, secure, and observe agent-to-LLM, agent-to-tool, and agent-to-agent communication"* — [agentgateway.dev](https://agentgateway.dev) |
+| **Agent-specific primitive** | **MCP gateway / federation**; **A2A gateway**; **LLM routing** with inference-style prioritization; **OpenAPI → MCP tools** — primitives aimed at agent+tool meshes, not human CRUD apps |
+| **Autonomy-compatible control plane** | Policy engine and routing operate per request; agents do not need human clicks per call |
+| **M2M integration surface** | Config file / K8s CRDs, OpenAI-compatible LLM path, MCP and A2A protocol fronts, OTEL |
+| **Identity / delegation** | JWT, API keys, RBAC, CEL policies, audit via telemetry — requests attributable through gateway observability |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **LLM gateway** | OpenAI-compatible routing to major providers; budget/spend controls (per docs) |
+| **MCP gateway** | Federate MCP servers; enforce auth and tool access |
+| **A2A gateway** | Agent-to-agent protocol routing and capability discovery |
+| **Traffic policies** | Rate limit, CORS, TLS, external authz |
+| **Prompt guard / enrichment** | Gate or augment prompts at the proxy (Kubernetes docs) |
+| **Observability** | OpenTelemetry metrics, logs, traces |
+
+---
+
+## Autonomy Model
+
+```
+Agent (or agent runtime) sends LLM request to Agentgateway OpenAI-compatible endpoint
+    ↓
+Gateway applies auth, policy, routing → upstream LLM provider
+    ↓
+For tools: agent uses MCP through gateway — federation + auth to backends
+    ↓
+Optional A2A path for multi-agent delegation
+    ↓
+OTEL exports traces/metrics for operations and security review
+```
+
+---
+
+## Identity and Delegation Model
+
+- **JWT / API keys** — caller authentication at the edge
+- **RBAC + CEL** — fine-grained authorization on routes and tools
+- **MCP OAuth alignment** — integrate with IdPs per MCP auth spec (docs)
+- **Distributed traces** — correlate agent, tool, and LLM hops
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| OpenAI-compatible HTTP | Chat completions proxy to many providers |
+| MCP | stdio, SSE, Streamable HTTP — client and server federation |
+| A2A | Agent-to-agent protocol routing |
+| Kubernetes | Gateway API / control-plane deployment options |
+| Configuration | YAML locally; CRDs on Kubernetes |
+
+---
+
+## Human-in-the-Loop Support
+
+Humans deploy and define **policies** (auth, rate limits, prompt guards). Individual LLM/MCP calls do not require a human in the loop unless the application adds one above the gateway.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **NGINX / Envoy** | Generic L7 proxy; no MCP/A2A semantics, no OpenAPI→MCP, no agentic policy tutorials as first-class |
+| **Managed LLM API** | Single vendor; no cross-protocol agent mesh (MCP + A2A + multi-LLM) in one open control plane |
+| **Portkey / Keywords AI** | Managed SaaS LLM gateways — complementary; Agentgateway is self-hosted protocol infrastructure for MCP/A2A |
+
+---
+
+## Use Cases
+
+- **Enterprise agent mesh** — one audited egress for LLM, MCP tools, and peer agents
+- **MCP sprawl control** — federate dozens of MCP servers with unified auth and observability
+- **Multi-provider LLM routing** — OpenAI-compatible clients without hard-coding vendor endpoints
+- **Air-gapped / VPC** — run the same proxy on-prem or in Kubernetes

--- a/services/meeting-and-conversation/README.md
+++ b/services/meeting-and-conversation/README.md
@@ -20,6 +20,7 @@ Agent-native meeting services provide a unified API for bot lifecycle management
 |---|---|---|---|
 | [Recall.ai](recall-ai.md) | The meeting bot API for every platform | REST API, Webhooks, Calendar Integration API | ❌ |
 | [Meeting BaaS](meeting-baas.md) | Meeting bots as a service — Zoom, Meet, Teams | REST API, Webhooks, TypeScript SDK, meeting-mcp | ✅ |
+| [MeetStream](meetstream.md) | Unified API for meeting bots, transcripts, and interactive AI agents | REST API, Webhooks, WebSockets | ⚠️ |
 
 ---
 

--- a/services/meeting-and-conversation/meetstream.md
+++ b/services/meeting-and-conversation/meetstream.md
@@ -1,0 +1,159 @@
+# MeetStream
+
+> **"API & Infrastructure to capture recordings, transcripts & metadata from meetings."**
+
+| | |
+|---|---|
+| **Website** | https://meetstream.ai |
+| **Docs** | https://docs.meetstream.ai |
+| **GitHub** | N/A (hosted API; integrate via REST, WebSockets, and webhooks per docs) |
+| **Classification** | `agent-native` |
+| **Category** | [Meeting & Conversation Services](README.md) |
+| **Compliance** | SOC 2 Type 2 · ISO 27001 · GDPR (per marketing site) |
+
+---
+
+## Official Website
+
+https://meetstream.ai
+
+---
+
+## Official Repo
+
+⚠️ No single primary open-source repo identified for the hosted API — integration is via **REST API**, **WebSockets**, and **webhooks** per [docs.meetstream.ai](https://docs.meetstream.ai).
+
+---
+
+## How to Use (Agent Onboarding)
+
+**Interaction pattern:** `REST` + **Webhooks** + **WebSockets** (real-time media/transcripts)
+
+1. Request access via [Get Early Access](https://forms.fillout.com/t/gPynZ3UyiKus) or [app.meetstream.ai](https://app.meetstream.ai) (per site), then obtain an API key.
+2. Create a bot with the documented endpoint (OpenAPI: `Authorization: Token <your_api_key>`):
+
+```bash
+curl -X POST "https://api.meetstream.ai/api/v1/bots/create_bot" \
+  -H "Authorization: Token YOUR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"meeting_link":"https://meet.google.com/xxx-xxxx-xxx","bot_name":"Meetstream Agent","video_required":true}'
+```
+
+3. Add `callback_url` for **webhooks**, or configure `live_transcription_required`, `live_audio_required`, and `socket_connection_url` for streaming (see [Create Bot](https://docs.meetstream.ai/api-reference/ap-is/bot-endpoints/create-bot.mdx)).
+
+Full capability list: [Welcome to MeetStream](https://docs.meetstream.ai/welcome.mdx) · [OpenAPI JSON](https://docs.meetstream.ai/openapi.json)
+
+---
+
+## Agent Skills
+
+**Status:** ⚠️ No `npx skills add …` registry entry — MeetStream publishes a **downloadable Claude Skill** (ZIP with `SKILL.md`) for API patterns, webhooks, and WebSockets.
+
+Install: [AI Integrations](https://docs.meetstream.ai/build-with-ai/ai-integrations.mdx) → download the skill ZIP → upload in Claude **Settings → Capabilities**.
+
+```bash
+npx clawhub@latest search meetstream
+```
+
+---
+
+## MCP
+
+**Status:** ✅ Available (documentation MCP)
+
+MeetStream hosts an SSE MCP server so coding agents can **search live API documentation** — not remote control of meetings, but accurate doc-grounded integration.
+
+| Detail | Value |
+|---|---|
+| **MCP URL** | `https://docs.meetstream.ai/_mcp/server` (SSE) |
+| **Docs** | [AI Integrations](https://docs.meetstream.ai/build-with-ai/ai-integrations.mdx) |
+| **Example (Claude Code)** | `claude mcp add meetstream-docs --transport sse https://docs.meetstream.ai/_mcp/server` |
+
+---
+
+## What It Does
+
+MeetStream provides a **unified meeting-bot API** to join **Zoom, Google Meet, and Microsoft Teams**, capture **recordings and real-time audio/video**, stream **speaker-attributed transcripts** (live and async), expose **participant and chat metadata**, and support **interactive agents** (e.g., TTS, chat, display) — so downstream **AI agents** consume structured meeting data without building per-platform media pipelines.
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | Docs: *"unified API to deploy interactive bots and AI agents into meeting platforms"*; homepage positions the product so teams *"focus on building the AI agent itself"* — [docs.meetstream.ai](https://docs.meetstream.ai), [meetstream.ai](https://meetstream.ai) |
+| **Agent-specific primitive** | **Programmatic meeting bot** with join/record/stream; **real-time diarized transcript webhooks**; **WebSocket media**; **in-meeting chat R/W**; **active AI participants** (TTS, video, screen) |
+| **Autonomy-compatible control plane** | **Calendar sync** and **auto-dispatch**; **auto-leave** rules; pause/mute/resume via API (per docs) |
+| **M2M integration surface** | REST (`/api/v1/...`), webhooks, WebSockets |
+| **Identity / delegation** | Per-bot sessions; participant and speaking metadata for attribution |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **Meeting bot** | API-spawned participant that joins from a meeting URL |
+| **Real-time transcript** | Speaker-labeled streaming events via webhook |
+| **Media stream** | Low-latency audio/video over WebSocket |
+| **Recording** | MP4 / isolated tracks export |
+| **Calendar integration** | Auto-join scheduled meetings |
+| **In-meeting interaction** | Chat messages, TTS, images/video injection (per docs) |
+
+---
+
+## Autonomy Model
+
+```
+Scheduler or agent POSTs meeting URL to MeetStream API
+    ↓
+Bot joins platform (Zoom / Meet / Teams) without a human client
+    ↓
+Streams transcripts + metadata to agent via webhook/WebSocket
+    ↓
+Optional: agent speaks or posts chat through API
+    ↓
+Auto-leave and completion events close the session
+```
+
+---
+
+## Identity and Delegation Model
+
+- **Bot/session IDs** — correlate recordings, transcripts, and callbacks
+- **API keys / Bearer tokens** — control who can create or control bots
+- **Speaker attribution** — transcript events tied to participant identity where platform allows
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| REST API | Bot lifecycle, transcripts, metadata — [docs.meetstream.ai](https://docs.meetstream.ai) |
+| Webhooks | Live events (e.g., diarized speech) |
+| WebSockets | Real-time audio/video stream consumption |
+
+---
+
+## Human-in-the-Loop Support
+
+Organizational: consent, compliance, and calendar policies. Runtime bot operation is API-driven without a human clicking “Join” in a desktop client.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **Manual recording** | Human-operated; not programmatic multi-platform bot lifecycle |
+| **Single-vendor SDK only** | Requires one integration per conferencing provider; no unified agent-oriented transcript + media contract |
+| **Recall.ai / Meeting BaaS** | Also qualify; MeetStream is an additional vendor in the same agent-native meeting-bot segment |
+
+---
+
+## Use Cases
+
+- **Sales coaching agents** — live transcripts + intent signals during customer calls
+- **Meeting notetaker agents** — structured action items from diarized streams
+- **Interactive meeting agents** — speak or display visuals via API during the call

--- a/services/voice-and-phone/README.md
+++ b/services/voice-and-phone/README.md
@@ -18,6 +18,7 @@ No consumer VOIP or call center platform was designed with these requirements as
 | Service | Tagline | Protocol Surface | MCP? |
 |---|---|---|---|
 | [Vapi](vapi.md) | Build advanced voice AI agents | REST API, Web SDK, Python SDK, TypeScript SDK, Webhooks | ✅ |
+| [Retell AI](retell-ai.md) | #1 AI voice agent platform for automating calls | REST API, Python SDK, TypeScript SDK, Webhooks, SIP | ✅ |
 
 ---
 

--- a/services/voice-and-phone/retell-ai.md
+++ b/services/voice-and-phone/retell-ai.md
@@ -1,0 +1,165 @@
+# Retell AI
+
+> **"#1 AI Voice Agent Platform for Automating Calls."**
+
+| | |
+|---|---|
+| **Website** | https://www.retellai.com |
+| **Docs** | https://docs.retellai.com |
+| **GitHub** | https://github.com/RetellAI/retell-python-sdk |
+| **Stars** | [![GitHub Stars](https://img.shields.io/github/stars/RetellAI/retell-python-sdk?style=social)](https://github.com/RetellAI/retell-python-sdk) |
+| **Classification** | `agent-native` |
+| **Category** | [Voice & Phone Services](README.md) |
+| **Compliance** | HIPAA · SOC 2 Type II · GDPR (per marketing site) |
+
+---
+
+## Official Website
+
+https://www.retellai.com
+
+---
+
+## Official Repo
+
+https://github.com/RetellAI/retell-python-sdk — Python SDK
+
+https://github.com/RetellAI/retell-typescript-sdk — TypeScript SDK
+
+---
+
+## How to Use (Agent Onboarding)
+
+**Interaction pattern:** `SDK / REST` + **webhooks** + optional **MCP** (mid-call tools and assistant management)
+
+1. Create an account and API key from the Retell dashboard (free trial credits on signup).
+2. Define a voice agent (conversation-flow or single/multi-prompt) in the API or dashboard.
+3. Attach telephony (Retell numbers or custom SIP) and optional **MCP servers** so the agent can call tools during live calls — see [MCP](https://docs.retellai.com/build/single-multi-prompt/mcp).
+
+```bash
+pip install retell-sdk
+# or: npm install retell-sdk
+```
+
+Use the REST API for outbound/inbound calls, agent lifecycle, and webhooks for per-call events — [Introduction](https://docs.retellai.com).
+
+---
+
+## Agent Skills
+
+Agent Skills are portable `SKILL.md` instruction sets following the [AgentSkills open standard](https://agentskills.io/) that teach AI coding assistants (Claude Code, Cursor, Codex, Windsurf, etc.) how to use this service correctly.
+
+**Status:** ⚠️ No official `npx skills add …` pack from Retell yet.
+
+```bash
+npx clawhub@latest search retell
+```
+
+See: https://agentskills.io/specification to contribute one.
+
+---
+
+## MCP
+
+**Status:** ✅ Available (product-native)
+
+Retell supports the **Model Context Protocol** in two ways: voice agents can invoke MCP tools **during a phone call** (configured in the dashboard), and assistants like Claude can manage Retell resources via an MCP integration — see [MCP](https://docs.retellai.com/build/single-multi-prompt/mcp) and the [MCP node guide](https://www.retellai.com/blog/connect-any-ai-voice-agent-to-mcp-with-retell-ai-mcp-node).
+
+| Detail | Value |
+|---|---|
+| **Docs** | https://docs.retellai.com/build/single-multi-prompt/mcp |
+| **Mid-call tools** | MCP server URL + tool allowlist + response mapping into conversation variables |
+| **Compatible clients** | Retell-managed voice runtime; external MCP clients per Retell/blog guides |
+
+---
+
+## What It Does
+
+Retell is a platform to build, test, deploy, and monitor **AI phone agents**: inbound and outbound calls, custom telephony via SIP, real-time function calling during speech, webhooks for call lifecycle and analytics, and simulation testing before production. The product is scoped around autonomous voice agents—not a human-operated contact center UI as the primary control plane.
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | Homepage: *"#1 AI Voice Agent Platform for Automating Calls"* and *"Build, deploy, and manage next-generation AI voice agents"* — [retellai.com](https://www.retellai.com) |
+| **Agent-specific primitive** | Programmatic **voice agent** lifecycle; **real-time function calling** during live calls; **webhooks** for call events; **simulation testing** for voice agents |
+| **Autonomy-compatible control plane** | Agents handle calls at scale without a human on the phone; batch calling and automated testing are first-class |
+| **M2M integration surface** | REST API, Python SDK, TypeScript SDK, webhooks, SIP integration, MCP |
+| **Identity / delegation** | Per-agent configuration, per-call IDs, webhook payloads and analytics attributable to specific calls and assistants |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **Voice agent** | LLM-driven phone agent with prompts, voices, and tool/MCP configuration |
+| **Phone call** | Inbound/outbound call session with transcription and analysis hooks |
+| **Mid-call function / MCP tool** | Agent invokes external tools while the caller is on the line |
+| **Webhook** | Server-side events for call state, transcripts, and post-call analysis |
+| **Simulation** | Automated conversational tests before deploying agents |
+| **Custom telephony** | SIP trunking to bring your own numbers and carriers |
+
+---
+
+## Autonomy Model
+
+```
+Agent (or orchestrator) creates/updates a Retell voice agent via API
+    ↓
+Provisioning: phone number or SIP, model, voice, tools/MCP
+    ↓
+Inbound or outbound call starts — no human operator on the handset
+    ↓
+During call: STT → LLM → TTS; tools/MCP run on demand
+    ↓
+Webhooks deliver structured events and analysis to the agent backend
+```
+
+---
+
+## Identity and Delegation Model
+
+- **Assistant / agent IDs** — configuration and versioning per deployed voice agent
+- **Call IDs** — correlate transcripts, recordings, and webhook payloads
+- **API keys** — operator credentials; scoped access via dashboard roles (enterprise)
+- **Tool/MCP allowlists** — explicit delegation of which external actions a voice agent may take mid-call
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| REST API | Call creation, agent management, analytics — see [docs.retellai.com](https://docs.retellai.com) |
+| Python SDK | `pip install retell-sdk` — [retell-python-sdk](https://github.com/RetellAI/retell-python-sdk) |
+| TypeScript SDK | `npm install retell-sdk` — [retell-typescript-sdk](https://github.com/RetellAI/retell-typescript-sdk) |
+| Webhooks | Real-time and post-call events for integrations |
+| SIP | Custom telephony interconnection |
+
+---
+
+## Human-in-the-Loop Support
+
+Optional at the application layer (e.g., human review of flagged calls). Retell does not require a human on every call; escalation patterns are implemented via agent design, transfers, or downstream workflows.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **Twilio Programmable Voice** | Telephony API for developers; AI voice agent orchestration, mid-call LLM tool loops, and agent-specific simulation are not first-class primitives |
+| **Human call center software** | Built for human agents; not a headless voice-agent runtime |
+| **Consumer VoIP** | No API-first agent lifecycle or mid-call tool execution |
+
+---
+
+## Use Cases
+
+- **Outbound scheduling and reminders** — autonomous calls with calendar tools
+- **Inbound support** — 24/7 voice agents with knowledge and ticketing tools
+- **Lead qualification** — voice agents with CRM MCP tools
+- **Debt collection / surveys** — high-volume batch calling with compliance-oriented configuration

--- a/skill.md
+++ b/skill.md
@@ -56,7 +56,7 @@ These services can be joined with a single instruction, right now, with no human
 
 ---
 
-## Full Catalog — 15 Categories, 64+ Services
+## Full Catalog — 15 Categories, 68+ Services
 
 ### 1. Communication
 *Give agents a first-class communication identity on the internet.*
@@ -178,6 +178,7 @@ These services can be joined with a single instruction, right now, with no human
 |---|---|---|
 | [E2B](https://e2b.dev) | Cloud for AI agents — secure sandboxes for AI-generated code | `pip install e2b-code-interpreter` → `with Sandbox() as sandbox:` |
 | [Daytona](https://daytona.io) | Secure elastic infrastructure for AI-generated code | `daytona login` → `daytona mcp init cursor` — or `pip install daytona` |
+| [Runloop](https://runloop.ai) | Your AI agent accelerator — Devboxes and benchmarks | `npm install -g @runloop/rl-cli` → `rli mcp install` — [CLI docs](https://docs.runloop.ai/docs/tools/rl-cli) |
 
 ---
 
@@ -211,6 +212,7 @@ These services can be joined with a single instruction, right now, with no human
 |---|---|---|
 | [Recall.ai](https://recall.ai) | The meeting bot API for every platform | `POST https://api.recall.ai/api/v1/bot` with meeting URL |
 | [Meeting BaaS](https://meetingbaas.com) | Meeting bots API for Zoom, Meet, Teams | `POST https://api.meetingbaas.com/bots` with `x-meeting-baas-api-key` — [docs](https://docs.meetingbaas.com/docs/api/getting-started/sending-a-bot) |
+| [MeetStream](https://meetstream.ai) | Unified meeting-bot API — transcripts, media, interactive agents | `POST https://api.meetstream.ai/api/v1/bots/create_bot` + `Authorization: Token <key>` — [docs](https://docs.meetstream.ai) · doc MCP: `https://docs.meetstream.ai/_mcp/server` |
 
 ---
 
@@ -220,6 +222,7 @@ These services can be joined with a single instruction, right now, with no human
 | Service | Tagline | Onboarding |
 |---|---|---|
 | [Vapi](https://vapi.ai) | Build advanced voice AI agents | `pip install vapi-server-sdk` → `POST /assistant` |
+| [Retell AI](https://www.retellai.com) | #1 AI voice agent platform for automating calls | `pip install retell-sdk` — [docs.retellai.com](https://docs.retellai.com) |
 
 ---
 
@@ -230,6 +233,7 @@ These services can be joined with a single instruction, right now, with no human
 |---|---|---|
 | [Portkey](https://portkey.ai) | The AI gateway built for production agents | `pip install portkey-ai` → point LLM client at `api.portkey.ai` with a virtual key |
 | [Keywords AI](https://www.keywordsai.co) | OpenAI-compatible gateway + agent tracing | Base URL `https://api.keywordsai.co` — [gateway quickstart](https://docs.keywordsai.co/get-started/quickstart/gateway) |
+| [Agentgateway](https://agentgateway.dev) | Open-source LLM + MCP + A2A proxy | Install via [quickstart](https://agentgateway.dev/docs/quickstart/) → run `agentgateway -f config.yaml` |
 
 ---
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds four **agent-native** services to thin catalog categories (voice, LLM gateway, code execution, meetings), with full per-service files per CONTRIBUTING section 7, category README rows, and root `README.md` + `skill.md` updates.

| Service | Category | Sources verified |
|---|---|---|
| **Retell AI** | Voice & Phone | [retellai.com](https://www.retellai.com), [docs.retellai.com](https://docs.retellai.com), MCP docs |
| **Agentgateway** | LLM Gateway & Routing | [agentgateway.dev](https://agentgateway.dev), [github.com/agentgateway/agentgateway](https://github.com/agentgateway/agentgateway) |
| **Runloop** | Code Execution | [runloop.ai](https://runloop.ai), [docs.runloop.ai](https://docs.runloop.ai/docs/tools/rl-cli) |
| **MeetStream** | Meeting & Conversation | [docs.meetstream.ai](https://docs.meetstream.ai) OpenAPI (`/api/v1/bots/create_bot`, `Authorization: Token`), [AI Integrations / MCP](https://docs.meetstream.ai/build-with-ai/ai-integrations.mdx) |

## MeetStream API note

Marketing copy on the homepage still shows older `POST …/api/v1/bot` examples; this PR documents the **canonical** path from the published OpenAPI: `POST https://api.meetstream.ai/api/v1/bots/create_bot` with `Authorization: Token <api_key>`.

## Process note

[CONTRIBUTING.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/CONTRIBUTING.md) normally asks for a maintainer **Go** on a new-service issue before a PR. This batch was opened from an autonomous task; if policy requires it, we can split or hold until linked issues are approved.

## Commits

Five commits: one per service + index update (`README.md`, `skill.md`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-82538606-ae43-407c-9e59-c59faaa3bcc5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-82538606-ae43-407c-9e59-c59faaa3bcc5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

