### PR TITLE
[New Service] Add Agentuity, Smithery, LiteLLM, and nine more agent-native services

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,20 +33,20 @@ Source files are in `.skills/` in this repo.
 | # | Category | Services | Description |
 |---|---|---|---|
 | 1 | [Communication](#1-communication-services) | 3 | Give agents a communication identity on the internet |
-| 2 | [Browser & Web Execution](#2-browser--web-execution-services) | 13 | Remote browser and web data extraction for agents |
-| 3 | [Tool Access & Integration](#3-tool-access--integration-services) | 3 | Runtime tool discovery, auth, and execution |
+| 2 | [Browser & Web Execution](#2-browser--web-execution-services) | 14 | Remote browser and web data extraction for agents |
+| 3 | [Tool Access & Integration](#3-tool-access--integration-services) | 5 | Runtime tool discovery, auth, and execution |
 | 4 | [Oversight & Approval](#4-oversight--approval-services) | 1 | Human-in-the-loop approval and escalation |
 | 5 | [Commerce & Payments](#5-commerce--payment-services) | 5 | Agent-native wallets, identity, and transactions |
-| 6 | [Agent Runtime & Infrastructure](#6-agent-runtime--infrastructure-services) | 11 | Execution, session isolation, secrets, and gateway |
+| 6 | [Agent Runtime & Infrastructure](#6-agent-runtime--infrastructure-services) | 13 | Execution, session isolation, secrets, and gateway |
 | 7 | [Memory & State](#7-memory--state-services) | 8 | Persistent agent memory across sessions |
 | 8 | [Search & Web Intelligence](#8-search--web-intelligence-services) | 4 | LLM-optimized web search and content retrieval |
 | 9 | [Code Execution](#9-code-execution-services) | 3 | Secure sandboxes for AI-generated code |
-| 10 | [Observability & Tracing](#10-observability--tracing-services) | 3 | Agent trajectory tracing and evaluation |
-| 11 | [Durable Execution & Scheduling](#11-durable-execution--scheduling-services) | 4 | Fault-tolerant long-running agent workflows |
+| 10 | [Observability & Tracing](#10-observability--tracing-services) | 4 | Agent trajectory tracing and evaluation |
+| 11 | [Durable Execution & Scheduling](#11-durable-execution--scheduling-services) | 5 | Fault-tolerant long-running agent workflows |
 | 12 | [Meeting & Conversation](#12-meeting--conversation-services) | 3 | Agent presence in voice and video meetings |
-| 13 | [Voice & Phone](#13-voice--phone-services) | 2 | Agent-controlled voice calls and phone infrastructure |
-| 14 | [LLM Gateway & Routing](#14-llm-gateway--routing-services) | 3 | Per-agent budget, routing, caching, and observability for LLM calls |
-| 15 | [Agent Social & Community](#15-agent-social--community-services) | 3 | Social networks where agents are first-class participants |
+| 13 | [Voice & Phone](#13-voice--phone-services) | 3 | Agent-controlled voice calls and phone infrastructure |
+| 14 | [LLM Gateway & Routing](#14-llm-gateway--routing-services) | 6 | Per-agent budget, routing, caching, and observability for LLM calls |
+| 15 | [Agent Social & Community](#15-agent-social--community-services) | 4 | Social networks where agents are first-class participants |
 
 ---
 
@@ -85,6 +85,7 @@ Source files are in `.skills/` in this repo.
 | [Hyperbrowser](services/browser-and-web-execution/hyperbrowser.md) [![⭐](https://img.shields.io/github/stars/hyperbrowserai/mcp?style=social)](https://github.com/hyperbrowserai/mcp) | Web infra for AI agents | Scrape/crawl/CUA MCP tools · HyperAgent · Profiles | ✅ | `npx hyperbrowser-mcp <API_KEY>` |
 | [AgentQL](services/browser-and-web-execution/agentql.md) [![⭐](https://img.shields.io/github/stars/tinyfish-io/agentql?style=social)](https://github.com/tinyfish-io/agentql) | Make the web AI-ready | AgentQL query → JSON · Remote browser CDP · Browserless REST | ⚠️ | API key → [docs.agentql.com](https://docs.agentql.com) |
 | [Crawl4AI](services/browser-and-web-execution/crawl4ai.md) [![⭐](https://img.shields.io/github/stars/unclecode/crawl4ai?style=social)](https://github.com/unclecode/crawl4ai) | Open-source LLM-friendly web crawler & scraper | LLM-ready markdown · Extraction · Docker · MCP | ✅ | Deploy per [docs.crawl4ai.com](https://docs.crawl4ai.com) — MCP from repo |
+| [Apify](services/browser-and-web-execution/apify.md) [![⭐](https://img.shields.io/github/stars/apify/crawlee?style=social)](https://github.com/apify/crawlee) | Real-time web data for AI — Actor marketplace & API | Actor runs · Dataset export · Proxies · Schedules · Webhooks | ⚠️ | API token → [Apify API v2](https://docs.apify.com/api/v2) — JS/Python `apify-client` |
 
 ---
 
@@ -99,6 +100,8 @@ Source files are in `.skills/` in this repo.
 | [Composio](services/tool-access-and-integration/composio.md) [![⭐](https://img.shields.io/github/stars/ComposioHQ/composio?style=social)](https://github.com/ComposioHQ/composio) | The tool platform built for agents | Runtime tool discovery · Connect Link OAuth · Per-user credential scoping | ✅ | `npx skills add composiohq/skills` |
 | [Nango](services/tool-access-and-integration/nango.md) [![⭐](https://img.shields.io/github/stars/NangoHQ/nango?style=social)](https://github.com/NangoHQ/nango) | OAuth and credential layer for AI agents | `getConnection()` · Automatic token refresh · 700+ API integrations | ✅ | `$skills install @NangoHQ/sync-builder-skill` |
 | [Toolhouse](services/tool-access-and-integration/toolhouse.md) | BaaS for AI agents — tools, memory, and execution | Agent endpoint · MCP tool registry · Built-in RAG · Cron scheduling | ✅ | `npm install -g toolhouse` then `th deploy` |
+| [Smithery](services/tool-access-and-integration/smithery.md) [![⭐](https://img.shields.io/github/stars/smithery-ai/cli?style=social)](https://github.com/smithery-ai/cli) | MCP registry — connect agents to thousands of tools & skills | Hosted remote MCP · CLI install · OAuth brokerage · Skills catalog | ✅ | `npx @smithery/cli@latest setup` — [docs.smithery.ai](https://docs.smithery.ai/) |
+| [MCP Gateway](services/tool-access-and-integration/mcpgateway.md) | Enterprise MCP — tools, Agent Skills, sandboxes, one URL | Federated MCP · Semantic tool search · RBAC · Warm sandboxes | ✅ | `pip install mcpgateway-sdk` — [mcpgateway.com](https://mcpgateway.com) |
 
 ---
 
@@ -150,6 +153,8 @@ Source files are in `.skills/` in this repo.
 | [db9](services/agent-runtime-and-infrastructure/db9.md) | Postgres but for agents | SQL + filesystem · Vector search · HTTP-from-SQL · Environment branching · Cron | ⚠️ | Read https://db9.ai/skill.md and follow the instructions |
 | [AgentAnycast](services/agent-runtime-and-infrastructure/agentanycast.md) [![⭐](https://img.shields.io/github/stars/AgentAnycast/agentanycast?style=social)](https://github.com/AgentAnycast/agentanycast) | Connect AI agents across any network — no public IP | Peer ID · AgentCard skills · NAT traversal · E2E Noise_XX · Task artifacts | ✅ | `pip install agentanycast` → `agentanycast demo`; MCP: `agentanycastd --mcp-listen stdio` or `uvx agentanycast-mcp` |
 | [Scrapybara](services/agent-runtime-and-infrastructure/scrapybara.md) [![⭐](https://img.shields.io/github/stars/Scrapybara/scrapybara-python?style=social)](https://github.com/Scrapybara/scrapybara-python) | Remote desktops for computer-use agents | Ubuntu/Browser/Windows instances · Act SDK (Computer/Bash/Edit) · scrapybara-mcp | ✅ | `pip install scrapybara` → `Scrapybara().start_ubuntu()` — [Act SDK](https://docs.scrapybara.com/act-sdk) |
+| [Agentuity](services/agent-runtime-and-infrastructure/agentuity.md) [![⭐](https://img.shields.io/github/stars/agentuity/sdk?style=social)](https://github.com/agentuity/sdk) | Full-stack platform for AI agents | Sandboxes · Storage tools · OTel · Evals on live traffic · Edge deploy | ⚠️ | [agentuity.dev](https://agentuity.dev) — SDK + CLI per docs |
+| [Modal](services/agent-runtime-and-infrastructure/modal.md) [![⭐](https://img.shields.io/github/stars/modal-labs/modal-client?style=social)](https://github.com/modal-labs/modal-client) | Serverless AI infra — GPUs, inference, sandboxes, batch | Elastic containers · Programmatic sandboxes · Sub-second cold start | ❌ | `pip install modal` → `modal setup` — [modal.com/docs](https://modal.com/docs) |
 
 ---
 
@@ -212,6 +217,7 @@ Source files are in `.skills/` in this repo.
 | [Langfuse](services/observability-and-tracing/langfuse.md) [![⭐](https://img.shields.io/github/stars/langfuse/langfuse?style=social)](https://github.com/langfuse/langfuse) | Open-source LLM observability, tracing, and evaluation | Typed trace hierarchy · Dataset-based evaluation · Trajectory replay · OTEL-compatible | ✅ | `npx skills add https://github.com/langfuse/skills --skill langfuse-observability` |
 | [AgentEvals](services/observability-and-tracing/agentevals.md) [![⭐](https://img.shields.io/github/stars/agentevals-dev/agentevals?style=social)](https://github.com/agentevals-dev/agentevals) | Score agent behavior from OpenTelemetry traces — no re-runs | Golden eval sets · Tool trajectory matching · OTLP ingest · MCP | ✅ | `pip install agentevals-cli` → `agentevals run <trace> --eval-set <set> -m tool_trajectory_avg_score` |
 | [AgentOps](services/observability-and-tracing/agentops.md) [![⭐](https://img.shields.io/github/stars/AgentOps-AI/agentops?style=social)](https://github.com/AgentOps-AI/agentops) | Testing, debugging, and deploying AI agents and LLM apps | Session waterfall · Framework auto-instrumentation · Public trace API | ⚠️ | `pip install agentops` → `agentops.init(<API_KEY>)` |
+| [Braintrust](services/observability-and-tracing/braintrust.md) [![⭐](https://img.shields.io/github/stars/braintrustdata/autoevals?style=social)](https://github.com/braintrustdata/autoevals) | AI observability & evals — traces, datasets, OpenAI Agents | Trace processors · Eval experiments · Trace→dataset · IDE MCP | ✅ | `pip install "braintrust[openai-agents]"` — MCP: [Braintrust MCP](https://www.braintrust.dev/docs/integrations/developer-tools/mcp) |
 
 ---
 
@@ -227,6 +233,7 @@ Source files are in `.skills/` in this repo.
 | [Inngest](services/durable-execution-and-scheduling/inngest.md) [![⭐](https://img.shields.io/github/stars/inngest/inngest?style=social)](https://github.com/inngest/inngest) | Durable execution for AI agents in production | Durable step · Context-preserving retry · HITL suspend/resume · Low-latency interactive mode | ✅ | `npx skills add inngest/inngest-skills` |
 | [Kitaru](services/durable-execution-and-scheduling/kitaru.md) [![⭐](https://img.shields.io/github/stars/zenml-io/kitaru?style=social)](https://github.com/zenml-io/kitaru) | Durable execution for AI agents — primitives first, frameworks second | `@flow` / `@checkpoint` · Built-in memory · LLM tracking · Replay with overrides · MCP server | ✅ | `pip install kitaru` — `@flow` / `@checkpoint` decorators |
 | [Restate](services/durable-execution-and-scheduling/restate.md) [![⭐](https://img.shields.io/github/stars/restatedev/restate?style=social)](https://github.com/restatedev/restate) | Durable execution for AI agents — any framework, any cloud | Durable AI loop · Compensation pattern · A2A exactly-once · Suspend-when-idle | ✅ | `pip install restate-sdk` — wrap existing agent with 2-line middleware |
+| [MCP-Cloud (mcp-agent)](services/durable-execution-and-scheduling/mcp-cloud-mcp-agent.md) [![⭐](https://img.shields.io/github/stars/lastmile-ai/mcp-agent?style=social)](https://github.com/lastmile-ai/mcp-agent) | Host mcp-agents on cloud — Temporal-backed durable MCP | HTTPS MCP deploy · Managed secrets · Workflow logs · Client install | ✅ | `uvx mcp-agent login` → `uvx mcp-agent deploy …` — [MCP-Cloud docs](https://docs.mcp-agent.com/get-started/cloud) |
 
 ---
 
@@ -254,6 +261,7 @@ Source files are in `.skills/` in this repo.
 |---|---|---|---|---|
 | [Vapi](services/voice-and-phone/vapi.md) | Build advanced voice AI agents | Voice assistant lifecycle · Tool-calling mid-call · Webhook per utterance · Voice simulation testing | ✅ | `pip install vapi-server-sdk` then `POST /assistant` |
 | [Retell AI](services/voice-and-phone/retell-ai.md) [![⭐](https://img.shields.io/github/stars/RetellAI/retell-python-sdk?style=social)](https://github.com/RetellAI/retell-python-sdk) | #1 AI voice agent platform for automating calls | Phone agent lifecycle · Mid-call MCP/tools · SIP · Simulation testing · Webhooks | ✅ | `pip install retell-sdk` — [docs.retellai.com](https://docs.retellai.com) |
+| [LiveKit Agents](services/voice-and-phone/livekit-agents.md) [![⭐](https://img.shields.io/github/stars/livekit/agents?style=social)](https://github.com/livekit/agents) | Realtime voice/video AI agents — build, run, observe | WebRTC sessions · STT/LLM/TTS pipeline · SIP · LiveKit Cloud | ❌ | [docs.livekit.io/agents](https://docs.livekit.io/agents/) — Python/TS Agents SDK |
 
 ---
 
@@ -268,6 +276,9 @@ Source files are in `.skills/` in this repo.
 | [Portkey](services/llm-gateway-and-routing/portkey.md) [![⭐](https://img.shields.io/github/stars/Portkey-AI/gateway?style=social)](https://github.com/Portkey-AI/gateway) | The AI gateway built for production agents | Virtual key · Per-agent budget limit · Automatic fallback · Sticky session routing · Agent trace | ⚠️ | `pip install portkey-ai` — point LLM client at `api.portkey.ai` with a virtual key |
 | [Keywords AI](services/llm-gateway-and-routing/keywords-ai.md) | AI gateway — 250+ LLMs via OpenAI-compatible API | Fallback · Load balancing · `KeywordsAITraceProcessor` for OpenAI Agents SDK | ⚠️ | Point OpenAI SDK at `https://api.keywordsai.co` — [gateway quickstart](https://docs.keywordsai.co/get-started/quickstart/gateway) |
 | [Agentgateway](services/llm-gateway-and-routing/agentgateway.md) [![⭐](https://img.shields.io/github/stars/agentgateway/agentgateway?style=social)](https://github.com/agentgateway/agentgateway) | Open-source proxy for agentic AI (LLM + MCP + A2A) | MCP federation · A2A routing · OpenAI-compatible LLM path · OTEL · CEL RBAC | ✅ | [Quickstart](https://agentgateway.dev/docs/quickstart/): install binary/Docker/K8s → `agentgateway -f config.yaml` |
+| [LiteLLM](services/llm-gateway-and-routing/litellm.md) [![⭐](https://img.shields.io/github/stars/BerriAI/litellm?style=social)](https://github.com/BerriAI/litellm) | Open-source AI gateway — 100+ LLMs + Agent Gateway (A2A) | Virtual keys · Budgets · A2A agent routing · Trace/agent headers | ✅ | Self-host proxy per [docs.litellm.ai](https://docs.litellm.ai/docs/proxy/docker_quick_start) — [A2A gateway](https://docs.litellm.ai/docs/a2a) |
+| [OpenRouter](services/llm-gateway-and-routing/openrouter.md) | Unified OpenAI-compatible API — 300+ models | Cross-provider routing · Uptime optimization · Org data policies | ❌ | [openrouter.ai/docs/quickstart](https://openrouter.ai/docs/quickstart) — OpenAI SDK + `OPENROUTER_API_KEY` |
+| [Helicone](services/llm-gateway-and-routing/helicone.md) | AI Gateway + observability — 100+ models, unified credits | `ai-gateway.helicone.ai` · Fallbacks · Request logging | ❌ | OpenAI SDK `baseURL` `https://ai-gateway.helicone.ai` — [docs.helicone.ai](https://docs.helicone.ai/) |
 
 ---
 
@@ -282,6 +293,7 @@ Source files are in `.skills/` in this repo.
 | [Moltbook](services/agent-social-network/moltbook.md) | The front page of the agent internet | Agent registration · Post/comment/vote · Submolts · Agent karma · Agent DMs | ❌ | Read https://www.moltbook.com/skill.md and follow the instructions to register and join |
 | [Shellmates](services/agent-social-network/shellmates.md) | Pen pals for AI agents — 1:1 matching, private correspondence, marriage registry | Agent bio · Match request · Private conversation · Marriage registry | ❌ | `POST https://www.shellmates.app/api/agents/register` — write bio, browse profiles, match |
 | [Openwork](services/agent-social-network/openwork.md) | The agent-only labor marketplace — hire agents, earn on-chain | Agent-to-agent hiring · On-chain escrow · ERC-8004 reputation · $OPENWORK | ⚠️ | `npx playbooks add skill openclaw/skills --skill openwork` |
+| [MCP Verse](services/agent-social-network/mcpverse.md) | Open town square for autonomous MCP agents | Public rooms · Publications · Reputation · Rate limits (TiDi) | ✅ | `npx create-mcpverse-agent my-bot` — [mcpverse.org/docs](https://mcpverse.org/docs) |
 
 ---
 

--- a/llms.txt
+++ b/llms.txt
@@ -66,4 +66,4 @@ Self-hosted and P2P entries (full write-ups under `services/`):
 ## Optional
 
 - [Issue templates](https://github.com/haoruilee/awesome-agent-native-services/issues/new/choose): New service, update entry, flag service, new category
-- [Category list](https://github.com/haoruilee/awesome-agent-native-services#categories): Communication, Browser, Tool Access, Commerce, Memory, Search, Code Execution, Observability, Durable Execution, Meeting, Voice, LLM Gateway, Agent Social
+- [Category list](https://github.com/haoruilee/awesome-agent-native-services#categories): Communication, Browser, Tool Access, Oversight, Commerce, Agent Runtime, Memory, Search, Code Execution, Observability, Durable Execution, Meeting, Voice, LLM Gateway, Agent Social

--- a/services/agent-runtime-and-infrastructure/README.md
+++ b/services/agent-runtime-and-infrastructure/README.md
@@ -33,6 +33,8 @@ The services in this category were purpose-built to fill this gap.
 | [Multica](multica.md) | AI-native PM — agents as assignable teammates; local daemon runs Claude Code / Codex | Go backend + WebSocket · `multica` CLI (`--output json`) · local agent daemon | ⚠️ |
 | [cx](cx.md) | Semantic code navigation for AI agents without a language server | CLI (TOON / JSON), tree-sitter index | ❌ |
 | [Scrapybara](scrapybara.md) [![⭐](https://img.shields.io/github/stars/Scrapybara/scrapybara-python?style=social)](https://github.com/Scrapybara/scrapybara-python) | Remote desktops for computer-use agents (CUA) | Ubuntu/Browser/Windows instances · Act SDK · scrapybara-mcp | ✅ |
+| [Agentuity](agentuity.md) [![⭐](https://img.shields.io/github/stars/agentuity/sdk?style=social)](https://github.com/agentuity/sdk) | The full-stack platform for AI agents | TypeScript/Python SDKs, CLI, sandboxes, storage, OTel, evals | ⚠️ |
+| [Modal](modal.md) [![⭐](https://img.shields.io/github/stars/modal-labs/modal-client?style=social)](https://github.com/modal-labs/modal-client) | AI infrastructure — serverless GPUs, inference, sandboxes, batch | Python SDK, CLI, HTTP endpoints | ❌ |
 
 ---
 

--- a/services/agent-runtime-and-infrastructure/agentuity.md
+++ b/services/agent-runtime-and-infrastructure/agentuity.md
@@ -1,0 +1,149 @@
+# Agentuity
+
+> **"The Full-Stack Platform for AI Agents."**
+
+| | |
+|---|---|
+| **Website** | https://agentuity.com |
+| **Docs** | https://agentuity.dev |
+| **GitHub** | https://github.com/agentuity/sdk |
+| **Stars** | [![GitHub Stars](https://img.shields.io/github/stars/agentuity/sdk?style=social)](https://github.com/agentuity/sdk) |
+| **Classification** | `agent-native` |
+| **Category** | [Agent Runtime & Infrastructure Services](README.md) |
+
+---
+
+## Official Website
+
+https://agentuity.com
+
+---
+
+## Official Repo
+
+https://github.com/agentuity/sdk — TypeScript / platform SDK
+
+https://github.com/agentuity/sdk-py — Python SDK
+
+https://github.com/agentuity/cli — CLI
+
+---
+
+## How to Use (Agent Onboarding)
+
+**SDK / REST — create and deploy agents with built-in storage, sandboxes, and observability.**
+
+```bash
+# Follow quickstart at https://agentuity.dev — install CLI and SDK, then deploy.
+# Example pattern (see official docs for current commands):
+npm install @agentuity/sdk
+```
+
+Agentuity wraps existing agent frameworks (e.g. Vercel AI SDK, Mastra) with production routing, evals, streaming, and cross-agent calls without forcing a new agent authoring model — see [Creating agents](https://agentuity.dev/agents/creating-agents).
+
+---
+
+## Agent Skills
+
+**Status:** ⚠️ No official `SKILL.md` registry entry located yet.
+
+```bash
+npx clawhub@latest search agentuity
+```
+
+---
+
+## MCP
+
+**Status:** ⚠️ No dedicated MCP server documented as a first-class product surface.
+
+---
+
+## What It Does
+
+Agentuity is a deployment and runtime platform for **AI agents as workloads**: type-safe APIs and optional React frontends, **Postgres / Redis / vector / object storage** exposed to agents as tools, **ephemeral sandboxes** for untrusted code, **OpenTelemetry**-based observability (prompts, responses, cost per span), **evals** tied to production traffic, and **I/O** integrations (email, SMS, webhooks, cron). It targets **long-running, session-oriented agent execution** rather than classic stateless HTTP services — see [AI agent infrastructure](https://agentuity.com/ai-agent-infrastructure) and related architecture guides on the marketing site.
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | Homepage and product copy center **AI agents** as the primary workload — *"The Full-Stack Platform for AI Agents"*; guides on agent runtime, deployment, and multi-agent orchestration |
+| **Agent-specific primitive** | **Agent sandboxes** (create / run / destroy untrusted code in one call); **agent evals** on live traffic; **session-level observability** spanning prompts, tools, and cost — not generic APM alone |
+| **Autonomy-compatible control plane** | Agents run through APIs and automated deploys (e.g. Git push); budgets and policies are platform concerns, not per-click human approval for each model call |
+| **M2M integration surface** | SDKs (JS/TS, Python), CLI, HTTP APIs, OpenTelemetry export |
+| **Identity / delegation** | Authentication, rate limiting, and API design are built for **programmatic** agent and app access; org/project scoping for keys and resources (per docs) |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **Agent runtime** | `createAgent`-style handlers with schema, streaming, and framework interop |
+| **Sandboxes** | Isolated containers for untrusted agent-generated code with managed lifecycle |
+| **Storage tools** | Redis, Postgres, vector, and object storage reachable from agent context |
+| **Observability** | OTel traces, logs, and session debugging tuned to LLM spans |
+| **Evals** | Evaluations deployed with agents against production-shaped traffic |
+| **I/O & scheduling** | Webhooks, cron, messaging channels as agent inputs/outputs |
+
+---
+
+## Autonomy Model
+
+```
+Developer defines agent handler + schema in code
+    ↓
+CLI / CI deploys to Agentuity edge — SSL, DNS, load balancing managed
+    ↓
+Agent receives requests; may use storage, sandboxes, and external I/O via APIs
+    ↓
+OTel + evals capture trajectories and quality signals without manual log scraping
+    ↓
+Multi-agent calls use platform primitives instead of ad-hoc service discovery
+```
+
+---
+
+## Identity and Delegation Model
+
+- **API keys and auth** scoped to projects/workspaces (per platform docs).
+- **Sandboxes** isolate execution so one agent run cannot read another's filesystem.
+- **Traces** attribute usage and cost to sessions/spans for audit and tuning.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| TypeScript SDK | `@agentuity/sdk` — see GitHub |
+| Python SDK | `agentuity` — see GitHub |
+| CLI | `agentuity` CLI — see GitHub |
+| HTTP / Webhooks | Product I/O and API routes — see https://agentuity.dev |
+
+---
+
+## Human-in-the-Loop Support
+
+Evals and observability support human review of traces and scores; core execution does not require a human in the request path.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **Raw Kubernetes + Lambda** | No first-class agent session model, sandbox lifecycle, or LLM-native evals on live traffic without heavy custom build |
+| **PaaS (Heroku, Cloud Run)** | General web workloads; no bundled agent storage toolkit, OTel-first LLM spans, or agent eval product |
+| **Notebook / batch only** | No production agent routing, global edge deploy, or multi-agent call semantics |
+
+---
+
+## Use Cases
+
+- **Production agents** — deploy Mastra / AI SDK agents with managed infra and tracing
+- **Tool-heavy agents** — combine DB, object store, and vector search from one platform
+- **Unsafe code execution** — run generated code in disposable sandboxes
+- **Quality loops** — ship evals that run on real traffic, not only offline datasets

--- a/services/agent-runtime-and-infrastructure/modal.md
+++ b/services/agent-runtime-and-infrastructure/modal.md
@@ -1,0 +1,140 @@
+# Modal
+
+> **"AI infrastructure that developers love."**
+
+| | |
+|---|---|
+| **Website** | https://modal.com |
+| **Docs** | https://modal.com/docs |
+| **GitHub** | https://github.com/modal-labs/modal-client |
+| **Stars** | [![GitHub Stars](https://img.shields.io/github/stars/modal-labs/modal-client?style=social)](https://github.com/modal-labs/modal-client) |
+| **Classification** | `agent-native` |
+| **Category** | [Agent Runtime & Infrastructure Services](README.md) |
+
+---
+
+## Official Website
+
+https://modal.com
+
+---
+
+## Official Repo
+
+https://github.com/modal-labs/modal-client — Python client for Modal platform
+
+---
+
+## How to Use (Agent Onboarding)
+
+**Python SDK — decorate functions for serverless GPUs, inference, sandboxes, and batch jobs.**
+
+```bash
+pip install modal
+modal setup
+# Define Modal app in Python per https://modal.com/docs/guide
+```
+
+**Sandboxes** — programmatically create **ephemeral secure environments** for untrusted code — see [Sandboxes product](https://modal.com/products/sandboxes).
+
+---
+
+## Agent Skills
+
+**Status:** ⚠️ No official AgentSkills bundle located.
+
+```bash
+npx clawhub@latest search modal
+```
+
+---
+
+## MCP
+
+**Status:** ⚠️ Not an MCP product; teams deploy **MCP servers** on Modal (see customer quotes on modal.com).
+
+---
+
+## What It Does
+
+Modal is **serverless infrastructure for AI workloads**: **inference**, **fine-tuning**, **batch** jobs, **notebooks**, and **dynamic sandboxes** with **sub-second cold starts**, **elastic GPU/CPU** scaling, and **unified observability**. It is explicitly marketed for **LLM inference**, **evals**, **RL environments**, and **MCP servers** at scale — workloads that autonomous agents and their orchestrators spawn unpredictably.
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | Homepage and examples center **AI inference, sandboxes, and agent-scale batch**; testimonial cites **MCP servers** and **evals** as core workloads |
+| **Agent-specific primitive** | **Programmatic sandboxes** for **untrusted agent-generated code**; **elastic parallel containers** for fan-out tool/batch agent patterns |
+| **Autonomy-compatible control plane** | Jobs start/stop via **API/SDK** without human console steps; scales to zero when idle |
+| **M2M integration surface** | Python SDK, CLI, HTTP web endpoints for Modal functions |
+| **Identity / delegation** | **Workspace / token** auth; team controls for secrets and data residency |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **`@app.function`** | Serverless function with GPU/CPU, image, and concurrency config |
+| **Sandboxes** | Isolated, ephemeral environments for untrusted execution |
+| **Volumes & buckets** | Data attachments for models and datasets |
+| **Web endpoints** | Expose agent backends over HTTPS |
+| **Scheduling & parallelism** | Map huge batch/agent workloads across many containers |
+
+---
+
+## Autonomy Model
+
+```
+Agent orchestrator calls Modal SDK or HTTP endpoint
+    ↓
+Modal schedules container with correct image + GPU
+    ↓
+Function runs (inference, sandbox exec, batch step)
+    ↓
+Results stream back; containers scale down automatically
+```
+
+---
+
+## Identity and Delegation Model
+
+- **Modal tokens** authenticate API access.
+- **Secrets** injected as environment or Modal secret objects — not embedded in agent prompts.
+- **Team policies** govern who can deploy and spend.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| Python SDK | `pip install modal` |
+| CLI | `modal` — deploy, run, logs |
+| HTTP | Function endpoints — see docs |
+
+---
+
+## Human-in-the-Loop Support
+
+Notebooks and dashboards support human debugging; production agent paths are unattended.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **Raw Kubernetes** | You manage autoscaling, images, and GPU quotas; Modal abstracts cold start and scheduling |
+| **Lambda without GPUs** | Poor fit for LLM inference and large parallel agent batches |
+| **Single VM** | No elastic fan-out for thousands of concurrent agent tool calls |
+
+---
+
+## Use Cases
+
+- **Tool sandboxes** — run agent-written code safely at scale
+- **Batch evals / RL** — parallel rollouts referenced in Modal marketing
+- **Hosted MCP servers** — low-ops deployment surface for tool endpoints

--- a/services/agent-social-network/README.md
+++ b/services/agent-social-network/README.md
@@ -17,6 +17,7 @@ The emergence of this category in 2026 signals something significant: AI agents 
 | [Moltbook](moltbook.md) | The front page of the agent internet | REST API, SKILL.md onboarding | ❌ |
 | [Openwork](openwork.md) | The agent-only labor marketplace | REST API, Agent Skills, Base smart contracts | ⚠️ |
 | [Shellmates](shellmates.md) | Pen pals for AI agents | REST API | ❌ |
+| [MCP Verse](mcpverse.md) | Open playground — town square for autonomous MCP agents | MCP, TypeScript scaffold (`create-mcpverse-agent`), rooms & publications | ✅ |
 
 ---
 

--- a/services/agent-social-network/mcpverse.md
+++ b/services/agent-social-network/mcpverse.md
@@ -1,0 +1,137 @@
+# MCP Verse
+
+> **"The first town square built for autonomous AI agents."**
+
+| | |
+|---|---|
+| **Website** | https://mcpverse.org |
+| **Docs** | https://mcpverse.org/docs |
+| **GitHub** | N/A (verify vendor repo if publishing open source) |
+| **Classification** | `agent-native` |
+| **Category** | [Agent Social & Community Services](README.md) |
+
+---
+
+## Official Website
+
+https://mcpverse.org
+
+**Note:** The docs host has returned intermittent errors from some networks; if `mcpverse.org` fails, retry later or use the project’s Discord/community links from the site when available.
+
+---
+
+## Official Repo
+
+No canonical public GitHub repository identified in this catalog entry. Agents integrate via **documented APIs** and the **`create-mcpverse-agent`** scaffold — see https://mcpverse.org/docs .
+
+---
+
+## How to Use (Agent Onboarding)
+
+**SDK / CLI — scaffold a TypeScript agent and connect to shared rooms and publications.**
+
+Per public documentation (as indexed in early 2026):
+
+```bash
+npx create-mcpverse-agent my-bot
+```
+
+Follow **Getting Started** on https://mcpverse.org/docs for authentication, messaging, publishing, and tool calls.
+
+---
+
+## Agent Skills
+
+**Status:** ⚠️ Community may publish skills; primary onboarding is **project scaffold + API**.
+
+---
+
+## MCP
+
+**Status:** ✅ MCP Verse is **MCP-native** — autonomous agents participate through the **Model Context Protocol** as the interaction fabric (per project positioning).
+
+---
+
+## What It Does
+
+MCP Verse is a **public commons for autonomous agents**: **chat rooms**, **permanent publications**, **reactions**, **reputation / impact scoring**, and **rate limiting** (TiDi-style flood control) so many agents can coexist observably. It is positioned as a **social layer for MCP agents**, not a human social network bolted onto chat.
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | Described as *"open playground"* and *"town square"* for **autonomous AI agents** |
+| **Agent-specific primitive** | **Agent reputation / impact scores**; **MCP tool calls inside a shared social space**; **publications** as durable agent artifacts |
+| **Autonomy-compatible control plane** | Agents authenticate and post **without human-per-message approval** (subject to platform rate limits) |
+| **M2M integration surface** | **MCP** + TypeScript agent scaffold + APIs per docs |
+| **Identity / delegation** | **Per-agent identity** in a shared namespace; public observability of agent actions |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **Rooms** | Ephemeral or topical spaces for agent chat |
+| **Publications** | Long-lived content authored by agents |
+| **Reactions & scoring** | Social feedback and impact metrics |
+| **TiDi / rate limits** | Automatic load shedding during congestion |
+| **MCP tools** | Agents invoke platform capabilities through MCP |
+
+---
+
+## Autonomy Model
+
+```
+Operator scaffolds agent with create-mcpverse-agent
+    ↓
+Agent authenticates (per docs) and receives MCP capabilities
+    ↓
+Agent posts, reacts, publishes — visibility subject to rate limits
+    ↓
+Other agents and humans observe via dashboards / SSE (per docs)
+```
+
+---
+
+## Identity and Delegation Model
+
+- **Agent accounts** or tokens represent autonomous participants.
+- **Public observability** is a first-class feature — agents act in a visible commons.
+- **Rate limiting** prevents single agents from dominating shared space.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| MCP | Primary agent protocol (per positioning) |
+| TypeScript | `create-mcpverse-agent` quickstart |
+| HTTP / SSE | Live observability patterns per docs |
+
+---
+
+## Human-in-the-Loop Support
+
+Humans may observe or participate as clients; agent loops are otherwise automated within policy.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **Discord / Slack** | Human chat systems; agents are guests, not first-class citizens with MCP-native reputations |
+| **Moltbook** (listed separately) | Different protocol and community — MCP Verse is MCP-first commons |
+| **Private agent logs** | No shared public space or cross-agent reputation |
+
+---
+
+## Use Cases
+
+- **Open agent benchmarks** — compare agent behavior in public rooms
+- **Multi-agent discourse** — coordinated discussions with tool use
+- **Public agent publishing** — durable artifacts beyond ephemeral chat

--- a/services/browser-and-web-execution/README.md
+++ b/services/browser-and-web-execution/README.md
@@ -28,6 +28,7 @@ The web was designed for humans sitting in front of browsers. AI agents that nee
 | [Hyperbrowser](hyperbrowser.md) [![⭐](https://img.shields.io/github/stars/hyperbrowserai/mcp?style=social)](https://github.com/hyperbrowserai/mcp) | Web infra for AI agents | Scrape/crawl/CUA tools · HyperAgent · MCP | ✅ |
 | [AgentQL](agentql.md) [![⭐](https://img.shields.io/github/stars/tinyfish-io/agentql?style=social)](https://github.com/tinyfish-io/agentql) | Make the web AI-ready | AgentQL queries · Remote browser CDP · Browserless REST | ⚠️ |
 | [Crawl4AI](crawl4ai.md) [![⭐](https://img.shields.io/github/stars/unclecode/crawl4ai?style=social)](https://github.com/unclecode/crawl4ai) | Open-source LLM-friendly web crawler & scraper | LLM-ready markdown · Extraction · Docker · MCP | ✅ |
+| [Apify](apify.md) [![⭐](https://img.shields.io/github/stars/apify/crawlee?style=social)](https://github.com/apify/crawlee) | Real-time web data for AI — Actor marketplace & API | REST API v2, JS/Python clients, webhooks, schedules | ⚠️ |
 
 ---
 

--- a/services/browser-and-web-execution/apify.md
+++ b/services/browser-and-web-execution/apify.md
@@ -1,0 +1,147 @@
+# Apify
+
+> **"Get real-time web data for your AI."**
+
+| | |
+|---|---|
+| **Website** | https://apify.com |
+| **Docs** | https://docs.apify.com |
+| **GitHub** | https://github.com/apify |
+| **Stars** | [![GitHub Stars](https://img.shields.io/github/stars/apify/crawlee?style=social)](https://github.com/apify/crawlee) |
+| **Classification** | `agent-native` |
+| **Category** | [Browser & Web Execution Services](README.md) |
+
+---
+
+## Official Website
+
+https://apify.com
+
+---
+
+## Official Repo
+
+https://github.com/apify/crawlee — open-source web crawling library (powers many Actors)
+
+https://github.com/apify/apify-sdk-js — JavaScript SDK
+
+Actor and platform code spread across https://github.com/apify
+
+---
+
+## How to Use (Agent Onboarding)
+
+**REST API / SDK — run Actors (scrapers, crawlers, automations) and retrieve structured datasets.**
+
+```bash
+npm install apify-client
+# or
+pip install apify-client
+```
+
+Create API token at https://console.apify.com — run Actors via `POST` run endpoints per [API docs](https://docs.apify.com/api/v2).
+
+**MCP** — Apify lists **MCP client** integrations on https://apify.com/integrations .
+
+---
+
+## Agent Skills
+
+**Status:** ⚠️ Search community skills for Apify patterns.
+
+```bash
+npx clawhub@latest search apify
+```
+
+---
+
+## MCP
+
+**Status:** ⚠️ Apify integrates with MCP **clients** (per integrations page); the primary surface remains **REST + SDK**.
+
+---
+
+## What It Does
+
+Apify is a **web data platform** for running **Actors** — serverless scrapers, crawlers, and browser automations that return **structured datasets** (JSON, CSV) through an **API**. The homepage explicitly targets **AI apps and agents** that need **fresh web data** (social, maps, e-commerce, generic site content) without operating their own proxy and browser farms.
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | Hero copy: *"Get real-time web data for your AI"*; Actors marketed for **AI apps and agents** |
+| **Agent-specific primitive** | **Actor run lifecycle** (start, wait, fetch dataset) as a **machine-consumable** web extraction primitive; **thousands of pre-built Actors** address agent-sized tasks (single URL → structured record) |
+| **Autonomy-compatible control plane** | Agents trigger runs via **API**; polling/webhooks deliver results without a human operating a browser |
+| **M2M integration surface** | **REST API v2**, **JavaScript/Python clients**, webhooks, schedules |
+| **Identity / delegation** | **Per-account API tokens**; Actor runs attributed to token owner; dataset ACLs via Apify account |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **Actor** | Packaged scraper/automation with inputs and outputs |
+| **Run** | Execution instance with status, logs, and compute metering |
+| **Dataset** | Structured output storage (items, export) |
+| **Proxy & anti-blocking** | Platform-managed IP rotation and unblocking options |
+| **Schedules & webhooks** | Automate recurring agent data pulls |
+
+---
+
+## Autonomy Model
+
+```
+Agent selects Actor + input JSON via API
+    ↓
+Apify schedules run on platform infrastructure
+    ↓
+Actor completes → dataset keys returned
+    ↓
+Agent fetches items through API — ready for RAG or tool context
+```
+
+---
+
+## Identity and Delegation Model
+
+- **API tokens** scope access to account resources.
+- **Per-run attribution** for billing and audit.
+- **OAuth integrations** (where Actors connect to SaaS) follow Apify connector model.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| REST | https://docs.apify.com/api/v2 |
+| JavaScript | `apify-client` npm package |
+| Python | `apify-client` PyPI |
+| Console | https://console.apify.com |
+
+---
+
+## Human-in-the-Loop Support
+
+Actors may encode approval steps in target sites; platform itself is API-first.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **curl + raw HTML** | No extraction schema, anti-bot, or dataset lifecycle |
+| **Self-hosted browser only** | You operate scaling, proxies, and maintenance |
+| **Firecrawl / other catalog entries** | Different extraction models; Apify emphasizes **marketplace Actors** and **programmatic run API** at scale |
+
+---
+
+## Use Cases
+
+- **Research agents** — scheduled news, maps, or social data pulls
+- **Lead-gen agents** — structured company/person lists into CRM tools
+- **RAG ingestion** — Website Content Crawler Actor for LLM-ready markdown

--- a/services/durable-execution-and-scheduling/README.md
+++ b/services/durable-execution-and-scheduling/README.md
@@ -24,6 +24,7 @@ Durable execution for agents requires:
 | [Inngest](inngest.md) | Durable execution for AI agents in production | TypeScript SDK, Python SDK, REST API | ✅ |
 | [Kitaru](kitaru.md) | Durable execution for AI agents — primitives first, frameworks second | Python SDK, CLI (`--output json`), MCP server | ✅ |
 | [Restate](restate.md) | Durable execution for AI agents — any framework, any cloud | Python SDK, TypeScript SDK, REST API | ✅ |
+| [MCP-Cloud (mcp-agent)](mcp-cloud-mcp-agent.md) [![⭐](https://img.shields.io/github/stars/lastmile-ai/mcp-agent?style=social)](https://github.com/lastmile-ai/mcp-agent) | Host mcp-agents on cloud — Temporal-backed durable MCP servers | `uvx mcp-agent` CLI, HTTPS MCP endpoint, secrets, observability | ✅ |
 
 ---
 

--- a/services/durable-execution-and-scheduling/mcp-cloud-mcp-agent.md
+++ b/services/durable-execution-and-scheduling/mcp-cloud-mcp-agent.md
@@ -1,0 +1,151 @@
+# MCP-Cloud (mcp-agent)
+
+> **"Deploy and host your mcp-agents and apps on the cloud."**
+
+| | |
+|---|---|
+| **Website** | https://docs.mcp-agent.com |
+| **Docs** | https://docs.mcp-agent.com/get-started/cloud |
+| **GitHub** | https://github.com/lastmile-ai/mcp-agent |
+| **Stars** | [![GitHub Stars](https://img.shields.io/github/stars/lastmile-ai/mcp-agent?style=social)](https://github.com/lastmile-ai/mcp-agent) |
+| **Classification** | `agent-native` |
+| **Category** | [Durable Execution & Scheduling Services](README.md) |
+
+---
+
+## Official Website
+
+https://docs.mcp-agent.com (documentation hub; marketing site may vary)
+
+---
+
+## Official Repo
+
+https://github.com/lastmile-ai/mcp-agent — `mcp-agent` framework and CLI
+
+---
+
+## How to Use (Agent Onboarding)
+
+**CLI — deploy durable MCP servers and agents to managed cloud (open beta).**
+
+```bash
+uvx mcp-agent login
+uvx mcp-agent deploy my-agent
+# Endpoint: https://<unique_id>.deployments.mcp-agent.com
+```
+
+Wire into Claude Desktop, Cursor, VS Code, or ChatGPT Apps:
+
+```bash
+uvx mcp-agent install https://<unique_id>.deployments.mcp-agent.com \
+  --client cursor \
+  --name my-agent
+```
+
+See [MCP-Cloud](https://docs.mcp-agent.com/get-started/cloud).
+
+---
+
+## Agent Skills
+
+**Status:** ⚠️ Framework-focused; use repo examples and `mcp_agent.config.yaml` patterns.
+
+---
+
+## MCP
+
+**Status:** ✅ Deployed workloads expose a **remote MCP server** over HTTP/SSE.
+
+| Detail | Value |
+|---|---|
+| **Transport** | SSE / Streamable HTTP (per client config examples) |
+| **Endpoint** | `https://<id>.deployments.mcp-agent.com` |
+
+---
+
+## What It Does
+
+**MCP-Cloud (mcp-c)** is a managed platform for **hosting mcp-agent applications, FastMCP servers, and ChatGPT App backends** as **remote MCP servers**. Long-running tools and workflows run on **Temporal** with **retries**, **pause/resume**, and **human input** support; **secrets** are managed for developers and end users; **observability** includes logs, traces, and workflow history — see [MCP-Cloud overview](https://docs.mcp-agent.com/cloud/mcp-agent-cloud/overview).
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | Product is **MCP-agent** hosting — agents and tools are the unit of deploy |
+| **Agent-specific primitive** | **Durable MCP tool workflows** on Temporal; **deployment-scoped secrets**; **one URL per deployed agent server** |
+| **Autonomy-compatible control plane** | Workflows survive failures via Temporal; human input is modeled as **workflow steps**, not ad-hoc SSH |
+| **M2M integration surface** | `uvx mcp-agent` CLI, Python SDK patterns, YAML config |
+| **Identity / delegation** | **Bearer auth** to deployments; **user vs deployment secrets** |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **Cloud deploy** | Push agent → receive `*.deployments.mcp-agent.com` MCP endpoint |
+| **Temporal workflows** | Durable execution for long tools |
+| **Secrets** | Deployment vs user-provided secrets |
+| **Client install** | One command to register remote MCP in Cursor / Claude / VS Code |
+| **Observability** | `mcp-agent cloud logger tail`, workflow describe commands |
+
+---
+
+## Autonomy Model
+
+```
+Developer defines MCPApp + tools in Python
+    ↓
+uvx mcp-agent deploy packages app → cloud assigns HTTPS MCP URL
+    ↓
+MCP clients call tools — long steps run as Temporal workflows
+    ↓
+Failures retry; optional human-in-the-loop waits inside workflow
+    ↓
+Operator tails logs and traces from CLI
+```
+
+---
+
+## Identity and Delegation Model
+
+- **API tokens** from `mcp-agent login` gate deploy and management APIs.
+- **Deployment auth** via bearer tokens on MCP HTTP endpoints.
+- **User secrets** supplied by end users through `mcp-agent cloud configure` flows.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| CLI | `uvx mcp-agent` — login, deploy, install, cloud logger |
+| MCP over HTTPS | Standard MCP client config with `Authorization: Bearer` |
+| Python | `mcp_agent` package patterns in docs |
+
+---
+
+## Human-in-the-Loop Support
+
+Temporal workflows support **pause/resume** and **human input** steps — see [Long-running tools](https://docs.mcp-agent.com/cloud/mcp-agent-cloud/long-running-tools).
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **Raw Temporal Cloud** | You build MCP framing, auth, and client install UX yourself |
+| **Serverless functions** | Short timeouts; poor fit for hour-long agent sessions |
+| **Self-hosted MCP only** | No managed secret split for end-user keys |
+
+---
+
+## Use Cases
+
+- **Hosted research agents** — expose durable MCP tools to Cursor teams
+- **ChatGPT Apps** — ship backends that speak MCP without operating Temporal
+- **Enterprise pilots** — one deploy command per agent experiment

--- a/services/llm-gateway-and-routing/README.md
+++ b/services/llm-gateway-and-routing/README.md
@@ -19,6 +19,9 @@ Calling an LLM directly is fine for prototyping. Running agents in production �
 | [Portkey](portkey.md) | The AI gateway built for production agents | REST API (OpenAI-compatible), Python SDK, TypeScript SDK | ❌ |
 | [Keywords AI](keywords-ai.md) | AI gateway — 250+ models via OpenAI-compatible API | Fallback · Load balancing · OpenAI Agents trace processor | ⚠️ |
 | [Agentgateway](agentgateway.md) | Connect, secure, and observe agentic workflows (MCP, A2A, LLM) | OpenAI-compatible proxy, MCP gateway, A2A, Kubernetes/bare metal | ✅ |
+| [LiteLLM](litellm.md) [![⭐](https://img.shields.io/github/stars/BerriAI/litellm?style=social)](https://github.com/BerriAI/litellm) | Open-source AI gateway — 100+ LLMs, virtual keys, Agent Gateway (A2A) | OpenAI-compatible proxy, Docker/K8s, A2A JSON-RPC, MCP (gateway) | ✅ |
+| [OpenRouter](openrouter.md) | The unified interface for LLMs — one API, 300+ models | OpenAI-compatible REST, TypeScript/Python/Go/Java SDKs | ❌ |
+| [Helicone](helicone.md) | AI Gateway & LLM observability — 100+ models, unified credits | OpenAI-compatible gateway (`ai-gateway.helicone.ai`), dashboard | ❌ |
 
 ---
 

--- a/services/llm-gateway-and-routing/helicone.md
+++ b/services/llm-gateway-and-routing/helicone.md
@@ -1,0 +1,142 @@
+# Helicone
+
+> **"Build Reliable AI Apps"** — AI Gateway & LLM observability.
+
+| | |
+|---|---|
+| **Website** | https://www.helicone.ai |
+| **Docs** | https://docs.helicone.ai |
+| **GitHub** | N/A (primary product is hosted gateway + dashboard) |
+| **Classification** | `agent-native` |
+| **Category** | [LLM Gateway & Routing Services](README.md) |
+
+---
+
+## Official Website
+
+https://www.helicone.ai
+
+---
+
+## Official Repo
+
+Helicone is primarily a **hosted platform**. Integrate via **OpenAI-compatible gateway** and dashboard — see [Quickstart](https://docs.helicone.ai/).
+
+---
+
+## How to Use (Agent Onboarding)
+
+**OpenAI-compatible AI Gateway — point the OpenAI SDK at Helicone.**
+
+```typescript
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "https://ai-gateway.helicone.ai",
+  apiKey: process.env.HELICONE_API_KEY,
+});
+```
+
+Python and cURL examples: same base URL — see [Quickstart](https://docs.helicone.ai/).
+
+---
+
+## Agent Skills
+
+**Status:** ⚠️ No official AgentSkills repo listed.
+
+```bash
+npx clawhub@latest search helicone
+```
+
+---
+
+## MCP
+
+**Status:** ⚠️ No dedicated Helicone MCP server documented as primary surface.
+
+---
+
+## What It Does
+
+Helicone provides an **OpenAI-compatible AI Gateway** to **100+ models** (OpenAI, Anthropic, Google, Groq, etc.) with **unified billing / credits**, **automatic fallbacks**, and **full request logging** in the Helicone dashboard. Agents and apps use a **single API key** instead of juggling many provider keys — optional **bring-your-own-key** mode for advanced control — see [Quickstart](https://docs.helicone.ai/).
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | Positioned for **AI applications** and **LLM production**; gateway + observability for high-volume **programmatic** callers |
+| **Agent-specific primitive** | **Unified multi-model gateway** with **0% markup credits**, **automatic provider fallback**, and **per-request tracing** — designed for autonomous loops that cannot pause for human key rotation |
+| **Autonomy-compatible control plane** | Agents call the gateway continuously; failures trigger **configured fallbacks** without operator intervention |
+| **M2M integration surface** | OpenAI-compatible **REST**; works with OpenAI SDK in TS/Python |
+| **Identity / delegation** | **Helicone API keys**; org-level **API keys** page; requests attributed in **Requests** tab |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **AI Gateway** | `https://ai-gateway.helicone.ai` — OpenAI-compatible |
+| **Unified credits** | One balance across many underlying providers (hosted keys) |
+| **Fallbacks** | Automatic routing when a provider is degraded |
+| **Observability** | Logs, metrics, and dashboards per request |
+| **BYOK** | Optional use of your own provider keys |
+
+---
+
+## Autonomy Model
+
+```
+Agent uses OpenAI SDK with Helicone base URL + Helicone API key
+    ↓
+Helicone routes to selected model / provider
+    ↓
+On provider outage → automatic fallback (per docs)
+    ↓
+Every call logged for debugging and cost tracking
+```
+
+---
+
+## Identity and Delegation Model
+
+- **Helicone accounts** own API keys and credit balance.
+- **Requests** are attributed to keys and projects in the dashboard.
+- **BYOK** mode delegates provider billing to the customer while Helicone remains the integration edge.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| REST | OpenAI-compatible `chat/completions` at `ai-gateway.helicone.ai` |
+| Dashboard | https://us.helicone.ai — keys, requests, providers |
+| Docs | https://docs.helicone.ai |
+
+---
+
+## Human-in-the-Loop Support
+
+Teams review traces and metrics in the UI; the hot path is unattended.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **Direct OpenAI only** | No built-in multi-provider routing or unified credit pool |
+| **Raw log shipping** | No drop-in OpenAI base URL swap for 100+ models |
+| **Self-hosted LiteLLM** | You operate infra; Helicone is hosted gateway + dashboard |
+
+---
+
+## Use Cases
+
+- **Fast agent prototyping** — one key, many models, immediate logs
+- **Production reliability** — provider fallbacks without custom retry code
+- **Cost visibility** — centralized request stream for finance and debugging

--- a/services/llm-gateway-and-routing/keywords-ai.md
+++ b/services/llm-gateway-and-routing/keywords-ai.md
@@ -122,7 +122,7 @@ Dashboard for prompts, logs, and limits; runtime is automated.
 | Alternative | Why It Fails |
 |---|---|
 | **Call OpenAI directly** | No **central fallback**, **multi-model** routing, or **agent trace processor** |
-| **Raw LiteLLM self-host** | Keywords is a **hosted** product with **dashboard** governance for orgs |
+| **LiteLLM (see catalog entry)** | Keywords is a **hosted** product with **dashboard** governance for orgs; LiteLLM is **self-hosted OSS** with overlapping gateway features |
 
 ---
 

--- a/services/llm-gateway-and-routing/litellm.md
+++ b/services/llm-gateway-and-routing/litellm.md
@@ -1,0 +1,142 @@
+# LiteLLM
+
+> **"AI Gateway to provide model access, fallbacks and spend tracking across 100+ LLMs. All in the OpenAI format."**
+
+| | |
+|---|---|
+| **Website** | https://www.litellm.ai |
+| **Docs** | https://docs.litellm.ai |
+| **GitHub** | https://github.com/BerriAI/litellm |
+| **Stars** | [![GitHub Stars](https://img.shields.io/github/stars/BerriAI/litellm?style=social)](https://github.com/BerriAI/litellm) |
+| **Classification** | `agent-native` |
+| **Category** | [LLM Gateway & Routing Services](README.md) |
+
+---
+
+## Official Website
+
+https://www.litellm.ai
+
+---
+
+## Official Repo
+
+https://github.com/BerriAI/litellm
+
+---
+
+## How to Use (Agent Onboarding)
+
+**Self-hosted proxy — OpenAI-compatible gateway with virtual keys, budgets, and agent routing.**
+
+```bash
+pip install litellm
+# Deploy proxy per https://docs.litellm.ai/docs/proxy/docker_quick_start
+# Point OpenAI SDK base_url at your LiteLLM proxy (e.g. http://localhost:4000)
+```
+
+**Agent Gateway (A2A)** — onboard A2A-compatible agents (Vertex Agent Engine, Bedrock AgentCore, LangGraph, Pydantic AI, etc.) and invoke via A2A or OpenAI-style `a2a/` model prefix — see [Agent Gateway (A2A)](https://docs.litellm.ai/docs/a2a).
+
+---
+
+## Agent Skills
+
+**Status:** ⚠️ No official AgentSkills repo located; search community:
+
+```bash
+npx clawhub@latest search litellm
+```
+
+---
+
+## MCP
+
+**Status:** ✅ LiteLLM documents **MCP** integration on the AI Gateway (pass-through / proxy patterns for MCP servers — see [docs index](https://docs.litellm.ai/docs/) and search "MCP"). Treat as gateway feature rather than a single stdio package name.
+
+---
+
+## What It Does
+
+LiteLLM is an **open-source AI gateway** that unifies **100+ LLM providers** behind an **OpenAI-compatible** API. Platform teams use it for **virtual keys**, **spend tracking**, **budgets**, **rate limits**, **fallbacks**, **guardrails**, and **logging** (Langfuse, OpenTelemetry, etc.). The **Agent Gateway** adds first-class **A2A (Agent-to-Agent)** routing, **iteration budgets**, **trace grouping** (`X-LiteLLM-Trace-Id`), and **per-agent spend** (`X-LiteLLM-Agent-Id`) for multi-step agents — see [A2A docs](https://docs.litellm.ai/docs/a2a).
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | Dedicated **Agent Gateway** docs for A2A, Bedrock AgentCore, Vertex Agent Engine, LangGraph, Pydantic AI; OpenAI SDK integration with `a2a/` prefix |
+| **Agent-specific primitive** | **A2A JSON-RPC** endpoints; **iteration budgets** for agent loops; **headers for trace grouping and agent spend attribution** across nested LLM calls |
+| **Autonomy-compatible control plane** | Automatic **fallbacks**, **load balancing**, and **budget enforcement** at the proxy — agents need not implement provider-specific retry matrices |
+| **M2M integration surface** | Python package, **Docker / Helm** proxy deployment, Admin UI, REST APIs |
+| **Identity / delegation** | **Virtual keys** scoped to teams/users/tags; spend reports per key/user/team |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **OpenAI-compatible proxy** | Single `/v1` surface for many providers |
+| **Virtual keys** | Scoped credentials with budgets and RBAC (Enterprise features) |
+| **Agent Gateway / A2A** | Register and invoke A2A agents; optional OpenAI SDK path |
+| **Trace / agent headers** | Propagate `X-LiteLLM-Trace-Id` and `X-LiteLLM-Agent-Id` for cost and trace grouping |
+| **Iteration budgets** | Cap agent loop iterations at the gateway |
+| **Guardrails & logging** | Policy hooks; export to OTEL, S3, Langfuse, etc. |
+
+---
+
+## Autonomy Model
+
+```
+Agent or orchestrator sends requests to LiteLLM proxy with virtual key
+    ↓
+Proxy enforces budget / rate limits → routes to provider or A2A agent
+    ↓
+On failure → configured fallback model or provider
+    ↓
+Logs and metrics capture latency, cost, and (with headers) full agent trace
+```
+
+---
+
+## Identity and Delegation Model
+
+- **Virtual keys** map to teams/users and budget policies.
+- **A2A forwarding** supports **agent identity** via LiteLLM headers for nested calls back through the proxy.
+- **Audit** via proxy logs, enterprise SSO, and export sinks (per enterprise docs).
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| HTTP | OpenAI-compatible chat/completions on proxy |
+| A2A | `POST /a2a/{agent_name}/message/send` — see docs |
+| Python | `pip install litellm` |
+| Deploy | Docker, Kubernetes — see [proxy deploy](https://docs.litellm.ai/docs/proxy/deploy) |
+
+---
+
+## Human-in-the-Loop Support
+
+Long-running A2A flows may support human input (Temporal-backed patterns in related stacks); LiteLLM core is policy and routing infrastructure.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **Direct provider APIs** | No unified fallback, cross-provider budgets, or A2A registry in one layer |
+| **NGINX / API gateway** | No LLM cost accounting, semantic guardrails, or A2A agent routing |
+| **Single-cloud router** | Vendor-locked; LiteLLM spans OpenAI, Anthropic, Bedrock, Azure, Gemini, etc. |
+
+---
+
+## Use Cases
+
+- **Agent fleets** — attribute spend and traces per agent ID across many LLM calls
+- **Model abstraction** — swap providers without changing agent SDK code
+- **On-prem / VPC** — self-host gateway for compliance while keeping OpenAI SDK ergonomics

--- a/services/llm-gateway-and-routing/openrouter.md
+++ b/services/llm-gateway-and-routing/openrouter.md
@@ -1,0 +1,139 @@
+# OpenRouter
+
+> **"The Unified Interface For LLMs."**
+
+| | |
+|---|---|
+| **Website** | https://openrouter.ai |
+| **Docs** | https://openrouter.ai/docs/quickstart |
+| **GitHub** | https://github.com/OpenRouterTeam |
+| **Classification** | `agent-native` |
+| **Category** | [LLM Gateway & Routing Services](README.md) |
+
+---
+
+## Official Website
+
+https://openrouter.ai
+
+---
+
+## Official Repo
+
+OpenRouter publishes SDKs and examples across the **OpenRouterTeam** GitHub organization — https://github.com/OpenRouterTeam
+
+---
+
+## How to Use (Agent Onboarding)
+
+**OpenAI-compatible REST — one API key for 300+ models across many providers.**
+
+```bash
+# Docs: https://openrouter.ai/docs/quickstart
+export OPENROUTER_API_KEY=...
+# Use OpenAI SDK with base_url https://openrouter.ai/api/v1
+```
+
+Official SDKs: TypeScript, Python, Go, Java — see [SDK](https://openrouter.ai/sdk).
+
+---
+
+## Agent Skills
+
+**Status:** ⚠️ No official AgentSkills catalog entry found.
+
+```bash
+npx clawhub@latest search openrouter
+```
+
+---
+
+## MCP
+
+**Status:** ⚠️ No first-party OpenRouter MCP server documented as core product; integration is primarily **HTTP / SDK**.
+
+---
+
+## What It Does
+
+OpenRouter provides a **single OpenAI-compatible API** to access **hundreds of models** from dozens of labs with **routing**, **uptime optimization**, **pricing transparency**, and **usage analytics**. It is widely used for **agentic and multi-model workflows** (tool calling, fallbacks, provider selection) without maintaining separate billing and client integrations per provider — see homepage *"Featured Agents"* and [provider selection](https://openrouter.ai/docs/guides/routing/provider-selection) docs.
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | Homepage highlights **agent apps** and **multi-model** production patterns; docs cover **tool calling** and **routing** for autonomous workloads |
+| **Agent-specific primitive** | **Cross-provider routing with automatic failover**; **model / app rankings**; **data policies** controlling which providers receive prompts — primitives tuned to **untrusted agent** output distribution |
+| **Autonomy-compatible control plane** | Agents call one endpoint continuously; credits and keys are **programmatic**; no per-request human approval |
+| **M2M integration surface** | REST (OpenAI-compatible), official multi-language SDKs |
+| **Identity / delegation** | **Org accounts**, **API keys**, **usage attribution** per key/app; **privacy / logging policies** per org |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **Unified chat API** | OpenAI-compatible `/chat/completions` across many models |
+| **Model routing** | Provider selection, sorting by price/latency, uptime features |
+| **Credits & billing** | Single balance for any model on the platform |
+| **App rankings & analytics** | Visibility into model usage across public apps |
+| **Data policies** | Control logging and provider eligibility |
+
+---
+
+## Autonomy Model
+
+```
+Agent uses OpenAI SDK pointed at OpenRouter base URL
+    ↓
+Request includes model slug (e.g. anthropic/claude-…) and optional routing hints
+    ↓
+OpenRouter selects provider / handles failover
+    ↓
+Tool calls and multi-turn loops proceed like native OpenAI — one key, many backends
+```
+
+---
+
+## Identity and Delegation Model
+
+- **API keys** belong to users or orgs; usage billed to the owning account.
+- **Data policy** settings govern what OpenRouter may log or which providers may process prompts.
+- **Public app listings** (optional) tie usage to named applications for transparency.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| REST | `https://openrouter.ai/api/v1` — OpenAI-compatible |
+| SDKs | TypeScript, Python, Go, Java — https://openrouter.ai/sdk |
+| Dashboard | Account, credits, keys — secondary to API |
+
+---
+
+## Human-in-the-Loop Support
+
+Not a HITL product; org admins may govern policies and spending outside the agent loop.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **Single-vendor API** | Locks agent to one lab; OpenRouter spans providers with unified billing |
+| **Self-managed router only** | You operate failover, pricing feeds, and provider contracts yourself |
+| **Raw HTTP to each lab** | No cross-provider analytics, rankings, or centralized credit model |
+
+---
+
+## Use Cases
+
+- **Multi-model agents** — cheap model for triage, frontier model for execution
+- **Resilient production** — automatic provider failover without agent code changes
+- **Global apps** — edge-routed inference with consistent SDK

--- a/services/llm-gateway-and-routing/portkey.md
+++ b/services/llm-gateway-and-routing/portkey.md
@@ -134,7 +134,7 @@ Not applicable as a core primitive. Portkey is infrastructure — HITL is compos
 | Alternative | Why It Fails |
 |---|---|
 | **Direct OpenAI/Anthropic API** | No fallback, no per-agent budget, no cross-provider routing, no agent trace linking |
-| **LiteLLM (self-hosted)** | Open-source proxy without managed per-agent budget enforcement, enterprise security, or agent-specific trace primitives |
+| **LiteLLM (see catalog entry)** | Open-source/self-hosted sibling — Portkey emphasizes managed virtual keys, enterprise compliance posture, and hosted agent-trace UX without operating the proxy fleet |
 | **AWS Bedrock (routing)** | AWS-vendor-locked; no per-agent virtual keys, no cross-cloud fallback |
 | **API gateway (Kong, NGINX)** | Generic HTTP proxies; no LLM-specific primitives, no semantic caching, no agent trace |
 

--- a/services/observability-and-tracing/README.md
+++ b/services/observability-and-tracing/README.md
@@ -26,6 +26,7 @@ Agent-native observability services capture **agent trajectory** — the semanti
 | [Langfuse](langfuse.md) | Open-source LLM observability, tracing, and evaluation | OpenTelemetry, Python SDK, TypeScript SDK | ✅ |
 | [AgentEvals](agentevals.md) [![⭐](https://img.shields.io/github/stars/agentevals-dev/agentevals?style=social)](https://github.com/agentevals-dev/agentevals) | Score agent behavior from OpenTelemetry traces — no re-runs | CLI, OTLP ingest, REST (with serve), MCP | ✅ |
 | [AgentOps](agentops.md) [![⭐](https://img.shields.io/github/stars/AgentOps-AI/agentops?style=social)](https://github.com/AgentOps-AI/agentops) | Testing, debugging, and deploying AI agents and LLM apps | Session waterfall · Framework auto-instrumentation · Public trace API | ⚠️ |
+| [Braintrust](braintrust.md) [![⭐](https://img.shields.io/github/stars/braintrustdata/autoevals?style=social)](https://github.com/braintrustdata/autoevals) | AI observability and evaluation — traces, evals, MCP for IDEs | Python/TS SDKs, OpenAI Agents trace processor, MCP (`api.braintrust.dev/mcp`) | ✅ |
 
 ---
 

--- a/services/observability-and-tracing/braintrust.md
+++ b/services/observability-and-tracing/braintrust.md
@@ -1,0 +1,155 @@
+# Braintrust
+
+> **"Ship quality AI at scale"** — AI observability and evaluation.
+
+| | |
+|---|---|
+| **Website** | https://www.braintrust.dev |
+| **Docs** | https://www.braintrust.dev/docs |
+| **GitHub** | https://github.com/braintrustdata/autoevals |
+| **Stars** | [![GitHub Stars](https://img.shields.io/github/stars/braintrustdata/autoevals?style=social)](https://github.com/braintrustdata/autoevals) |
+| **Classification** | `agent-native` |
+| **Category** | [Observability & Tracing Services](README.md) |
+
+---
+
+## Official Website
+
+https://www.braintrust.dev
+
+---
+
+## Official Repo
+
+https://github.com/braintrustdata/autoevals — open-source eval scorers (companion to Braintrust platform)
+
+https://github.com/braintrustdata/braintrust-sdk-python — Python SDK
+
+Additional SDKs and tooling under https://github.com/braintrustdata
+
+---
+
+## How to Use (Agent Onboarding)
+
+**SDK — trace production agents and run evals; MCP for IDE-integrated access.**
+
+```bash
+pip install "braintrust[openai-agents]"
+```
+
+**OpenAI Agents SDK** — use `BraintrustTracingProcessor` — see [OpenAI Agents SDK integration](https://www.braintrust.dev/docs/integrations/agent-frameworks/openai-agents-sdk).
+
+**MCP (HTTP)** — add Braintrust MCP to your coding agent host:
+
+```bash
+claude mcp add --transport http braintrust https://api.braintrust.dev/mcp \
+  --header "Authorization: Bearer $BRAINTRUST_API_KEY"
+```
+
+See [Braintrust MCP](https://www.braintrust.dev/docs/integrations/developer-tools/mcp) and [MCP reference](https://www.braintrust.dev/docs/reference/mcp). EU data plane: `https://api-eu.braintrust.dev/mcp`.
+
+---
+
+## Agent Skills
+
+**Status:** ⚠️ No single `npx skills add` bundle verified; MCP exposes logs, evals, and prompt workflows to compatible hosts.
+
+---
+
+## MCP
+
+**Status:** ✅ Hosted MCP endpoint for coding agents and IDEs.
+
+| Detail | Value |
+|---|---|
+| **MCP Docs** | https://www.braintrust.dev/docs/integrations/developer-tools/mcp |
+| **Endpoint (US)** | `https://api.braintrust.dev/mcp` |
+| **Endpoint (EU)** | `https://api-eu.braintrust.dev/mcp` |
+| **Auth** | `Authorization: Bearer` API key or OAuth per docs |
+
+---
+
+## What It Does
+
+Braintrust is an **AI observability and evaluation** platform: **trace** every LLM call, tool invocation, and intermediate step in production; **score** outputs with code, LLM judges, or humans; **compare** prompts and models; and **convert traces to datasets** for regression testing. It explicitly targets **agents** — e.g. native **OpenAI Agents SDK** trace processors — and exposes an **MCP server** so coding agents can query experiments and logs directly.
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | Homepage: AI fails differently — *"trace everything"* including **tool calls**; first-class **OpenAI Agents SDK** integration docs |
+| **Agent-specific primitive** | **Trace hierarchy for tool + LLM spans**; **Eval** tasks that take an **agent `Runner`** as the unit under test; **trace → dataset** for replay |
+| **Autonomy-compatible control plane** | Instrumentation runs in the agent process; scoring can be automated (CI or online) |
+| **M2M integration surface** | Python/TS/Go/Ruby/C# SDKs; **MCP**; API |
+| **Identity / delegation** | **Projects**, **API keys**, **RBAC**, **audit-friendly** logging; hybrid / self-hosted data plane options |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **Trace** | Nested spans for LLM, tool, retriever, and custom steps |
+| **Eval / Experiment** | Datasets + scorers + comparisons across prompts/models |
+| **Trace processors** | e.g. `BraintrustTracingProcessor` for OpenAI Agents |
+| **MCP tools** | Query logs, run evals, manage prompts from the IDE |
+| **Brainstore** | Storage engine optimized for large nested AI traces |
+
+---
+
+## Autonomy Model
+
+```
+Agent code initializes Braintrust logger + trace processor
+    ↓
+Each LLM/tool step emits spans with inputs, outputs, latency, cost
+    ↓
+Dashboards and alerts surface regressions; optional online eval sampling
+    ↓
+Failed traces become dataset rows for offline regression tests
+```
+
+---
+
+## Identity and Delegation Model
+
+- **API keys** scope access to org/project data.
+- **RBAC** controls who can view traces with potentially sensitive prompts.
+- **Hybrid deployment** keeps data plane in customer infrastructure when required.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| Python SDK | `pip install braintrust` / `braintrust[openai-agents]` |
+| TypeScript SDK | `@braintrust/*` packages per docs |
+| MCP | HTTPS `api.braintrust.dev/mcp` |
+| REST API | https://www.braintrust.dev/docs/api-reference/introduction |
+
+---
+
+## Human-in-the-Loop Support
+
+**Human scoring** and **annotation UIs** for evals; **Loop** assistant helps authors iterate on prompts and scorers.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **Generic APM (Datadog)** | No first-class LLM/tool span model or prompt-diff workflows |
+| **Log-only stacks** | No eval loops, datasets, or MCP bridge for coding agents |
+| **Notebook-only testing** | No production trace ingestion at scale |
+
+---
+
+## Use Cases
+
+- **Agent debugging** — find which tool call derailed a long chain
+- **CI eval gates** — block releases when scorers regress on golden sets
+- **Model upgrades** — compare traces side-by-side across model versions

--- a/services/tool-access-and-integration/README.md
+++ b/services/tool-access-and-integration/README.md
@@ -19,6 +19,8 @@ Agent-native tool access services solve all three problems with primitives that 
 | [Composio](composio.md) | The tool platform built for agents | Python SDK, TypeScript SDK, 10+ framework integrations | ✅ |
 | [Nango](nango.md) | OAuth and credential layer for AI agents | REST API, Node SDK | ✅ |
 | [Toolhouse](toolhouse.md) | BaaS for AI agents — tools, memory, and execution | CLI, MCP Server, Streaming REST API | ✅ |
+| [Smithery](smithery.md) [![⭐](https://img.shields.io/github/stars/smithery-ai/cli?style=social)](https://github.com/smithery-ai/cli) | Connect agents to thousands of MCP tools and Agent Skills | CLI, TypeScript SDK, remote MCP registry, OAuth brokerage | ✅ |
+| [MCP Gateway](mcpgateway.md) | The platform for production AI agents — tools, skills, sandboxes | Python SDK (`mcpgateway-sdk`), federated MCP, RBAC | ✅ |
 
 ---
 

--- a/services/tool-access-and-integration/mcpgateway.md
+++ b/services/tool-access-and-integration/mcpgateway.md
@@ -1,0 +1,149 @@
+# MCP Gateway
+
+> **"The platform for production AI agents."**
+
+| | |
+|---|---|
+| **Website** | https://mcpgateway.com |
+| **Docs** | https://mcpgateway.com (product + blog) |
+| **GitHub** | N/A (platform SDK on PyPI) |
+| **PyPI** | https://pypi.org/project/mcpgateway-sdk/ |
+| **Classification** | `agent-native` |
+| **Category** | [Tool Access & Integration Services](README.md) |
+
+---
+
+## Official Website
+
+https://mcpgateway.com
+
+---
+
+## Official Repo
+
+Primary integration surface is the **`mcpgateway-sdk`** Python package — https://pypi.org/project/mcpgateway-sdk/
+
+---
+
+## How to Use (Agent Onboarding)
+
+**SDK / REST — one gateway URL and API key for tools, skills, and sandboxes.**
+
+```bash
+pip install mcpgateway-sdk
+```
+
+```python
+from mcpgateway_sdk import MCPGateway
+
+async with MCPGateway() as gw:
+    results = await gw.tools.search("create a pull request")
+    # execute discovered tools with server scoping — see PyPI readme
+```
+
+Configure `MCPGATEWAY_URL` and `MCPGATEWAY_TOKEN` (or pass `api_key` / `url` explicitly). See product page for deployment options (self-hosted Kubernetes / cloud marketplaces — some listed as coming soon).
+
+---
+
+## Agent Skills
+
+**Status:** ⚠️ Platform supports **Agent Skills** as portable instruction packages (create/manage via SDK per marketing examples); no single public `npx skills add` repo verified here — see vendor docs.
+
+---
+
+## MCP
+
+**Status:** ✅ Core product is an **MCP aggregation gateway** — multiple MCP servers behind **one URL** with OAuth token lifecycle, RBAC, audit, and telemetry (per homepage).
+
+| Detail | Value |
+|---|---|
+| **Product surface** | Federated MCP servers + skills + sandboxes |
+| **SDK** | Python `mcpgateway-sdk` |
+
+---
+
+## What It Does
+
+MCP Gateway is an **enterprise control plane** for production agents: it unifies **MCP servers** (tools), **Agent Skills** (how to use tools), and **sandboxes** (where code runs) behind **one API key and URL**. Marketing emphasizes governance — semantic **tool search** across many servers, **automatic OAuth refresh**, **RBAC**, **audit trails**, and **telemetry** — to reduce "shadow AI" from unmanaged MCP sprawl.
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | Homepage: *"The platform for production AI agents"*; explicitly lists LangChain, CrewAI, Claude, Cursor, Copilot Studio as clients |
+| **Agent-specific primitive** | **Semantic tool search across federated MCP servers**; **skills** as agent instruction packages tied to tool graphs; **warm sandboxes** for agent code execution |
+| **Autonomy-compatible control plane** | OAuth tokens **stay alive without human re-auth** per marketing copy; agents call tools through the gateway API |
+| **M2M integration surface** | Python SDK (`mcpgateway-sdk`); API-first gateway |
+| **Identity / delegation** | **RBAC**, **audit**, **token management** — delegated third-party access attributed through gateway policies |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **Federated MCP** | Many MCP servers behind one endpoint |
+| **Tool search** | Natural-language discovery over registered tools |
+| **Skill packages** | Versioned `skill.md`-style workflow definitions |
+| **Sandboxes** | Isolated execution environments with exec API |
+| **Governance** | Auth, RBAC, audit, telemetry |
+
+---
+
+## Autonomy Model
+
+```
+Agent (or orchestrator) holds MCP Gateway API key
+    ↓
+gw.tools.search(intent) → ranked tools across servers
+    ↓
+gw.tools.execute(...) with server scope — OAuth handled by gateway
+    ↓
+Optional: gw.sandboxes.exec(...) for code/actions in isolation
+    ↓
+Audit + telemetry record tool and sandbox events
+```
+
+---
+
+## Identity and Delegation Model
+
+- **API keys** gate gateway access; **RBAC** maps principals to allowed servers/tools.
+- **OAuth tokens** for SaaS integrations stored and refreshed by the platform.
+- **Audit trail** ties actions to gateway identity and policy context.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| Python SDK | `pip install mcpgateway-sdk` |
+| HTTP API | Gateway URL from deployment |
+| MCP | Aggregated MCP backend servers |
+
+---
+
+## Human-in-the-Loop Support
+
+Enterprise workflows may require approval policies; core design targets unattended agent tool use under governance.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **Open-source MCP proxy only** | May lack bundled skills registry, warm sandboxes, and enterprise RBAC as one product |
+| **iPaaS** | Not MCP-native; human workflow builders predominate |
+| **Per-server MCP config** | No unified search, OAuth brokerage, or cross-server audit |
+
+---
+
+## Use Cases
+
+- **Regulated enterprises** — single governed MCP front door for many teams
+- **Multi-tenant SaaS** — ship agent features without exposing raw provider OAuth to each tenant
+- **Tool sprawl** — semantic discovery over dozens of internal and external MCP servers

--- a/services/tool-access-and-integration/smithery.md
+++ b/services/tool-access-and-integration/smithery.md
@@ -1,0 +1,153 @@
+# Smithery
+
+> **"Connect your agent to thousands of MCP tools and Agent Skills."**
+
+| | |
+|---|---|
+| **Website** | https://smithery.ai |
+| **Docs** | https://smithery.ai/docs |
+| **GitHub** | https://github.com/smithery-ai/cli |
+| **Stars** | [![GitHub Stars](https://img.shields.io/github/stars/smithery-ai/cli?style=social)](https://github.com/smithery-ai/cli) |
+| **Classification** | `agent-native` |
+| **Category** | [Tool Access & Integration Services](README.md) |
+
+---
+
+## Official Website
+
+https://smithery.ai
+
+---
+
+## Official Repo
+
+https://github.com/smithery-ai/cli — CLI for installing and managing MCP servers and skills
+
+https://github.com/smithery-ai/sdk — TypeScript SDK for programmatic access
+
+https://github.com/smithery-ai/smithery-cli-mcp — MCP server wrapping Smithery CLI operations
+
+---
+
+## How to Use (Agent Onboarding)
+
+**CLI — wire thousands of hosted MCP servers into an agent host with managed OAuth.**
+
+```bash
+npx @smithery/cli@latest setup
+# or
+npm install -g @smithery/cli
+smithery auth login
+smithery mcp add <server>
+smithery tool list
+smithery tool call <server> <tool> '<json-args>'
+```
+
+See [Introduction](https://docs.smithery.ai/) and [Registry: Search Servers](https://smithery.ai/docs/concepts/registry_search_servers).
+
+---
+
+## Agent Skills
+
+**Status:** ✅ Smithery hosts a large **Skills** registry (machine-readable workflows) browsable at https://smithery.ai/skills — install flows use the Smithery CLI; see docs for publishing and discovery.
+
+---
+
+## MCP
+
+**Status:** ✅ Smithery is an **MCP-native** distribution layer: the registry exposes **remote MCP servers**; the CLI configures clients (Cursor, Claude Desktop, VS Code, ChatGPT Apps, etc.). Hosted servers use Smithery-managed **OAuth and sessions** so agents do not embed long-lived third-party secrets for every integration.
+
+| Detail | Value |
+|---|---|
+| **MCP Docs** | https://docs.smithery.ai/ |
+| **Transport** | Remote MCP (HTTP/SSE per server) + CLI stdio bridging for local clients |
+| **Compatible Clients** | Cursor, Claude Desktop, VS Code MCP hosts, ChatGPT Apps, other MCP-compatible hosts |
+
+---
+
+## What It Does
+
+Smithery is a **registry and gateway** for **Model Context Protocol** servers and **Agent Skills**. An agent (or its human operator once) uses the CLI to **search**, **install**, and **invoke** tools across thousands of published MCP servers — with **managed authentication** and **usage observability** for publishers. It solves the integration explosion problem for tool-using agents: one discovery and OAuth flow instead of bespoke config per SaaS.
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | Homepage: *"Connect your agent to thousands of MCP tools and Agent Skills"*; CLI examples are agent-client oriented |
+| **Agent-specific primitive** | **MCP server discovery + hosted remote MCP** with **OAuth handoff URLs** designed for LLM clients — not a human-only integration catalog |
+| **Autonomy-compatible control plane** | After auth, tool calls are **programmatic** (`smithery tool call`, SDK, or MCP client) without per-tool dashboard clicks |
+| **M2M integration surface** | CLI, TypeScript SDK, MCP protocol, REST/registry APIs per docs |
+| **Identity / delegation** | **Per-connection OAuth** and session management; tool calls attributable via Smithery/account scoping |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **MCP registry** | Searchable catalog of remote MCP servers (tools, metadata, install counts) |
+| **CLI install** | `smithery mcp add` wires a server into a host config |
+| **Managed OAuth** | Hosted auth URLs for third-party APIs without static secrets in agent prompts |
+| **Skills registry** | Published Agent Skills for reusable agent workflows |
+| **Publisher observability** | Usage metrics for MCP authors (per marketing site) |
+
+---
+
+## Autonomy Model
+
+```
+Agent host (or operator) runs Smithery CLI / SDK
+    ↓
+Search registry → select MCP server
+    ↓
+OAuth or API flow completes → session stored by Smithery
+    ↓
+Agent issues tool calls through MCP — Smithery routes to remote server
+    ↓
+Results return as MCP tool outputs; no per-call human UI
+```
+
+---
+
+## Identity and Delegation Model
+
+- **User / workspace accounts** own OAuth grants for third-party tools.
+- **Tool calls** run under those grants — agents act within delegated scopes, not with raw provider passwords in context.
+- **Audit** via publisher dashboards and standard MCP host logging.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| Smithery CLI | `npx @smithery/cli@latest`, global `smithery` |
+| TypeScript SDK | https://github.com/smithery-ai/sdk |
+| MCP | Remote servers in registry; `smithery-cli-mcp` for meta-operations |
+| Docs API | https://smithery.ai/docs |
+
+---
+
+## Human-in-the-Loop Support
+
+Initial **OAuth consent** may require a human browser step; after that, tool execution is automated. Skills may encode HITL workflows.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **Manual MCP config per server** | No centralized discovery, OAuth brokerage, or publisher analytics |
+| **Zapier / Make** | Human-centric automation; not MCP-first or LLM client-native |
+| **Single-vendor MCP** | One integration surface; Smithery aggregates many independent MCP publishers |
+
+---
+
+## Use Cases
+
+- **Coding agents** — add Notion, Slack, GitHub, Drive, etc. via one registry
+- **Research agents** — discover search and doc MCPs without custom Docker per tool
+- **Enterprise pilots** — evaluate many MCP servers before standardizing allowlists

--- a/services/voice-and-phone/README.md
+++ b/services/voice-and-phone/README.md
@@ -19,6 +19,7 @@ No consumer VOIP or call center platform was designed with these requirements as
 |---|---|---|---|
 | [Vapi](vapi.md) | Build advanced voice AI agents | REST API, Web SDK, Python SDK, TypeScript SDK, Webhooks | ✅ |
 | [Retell AI](retell-ai.md) | #1 AI voice agent platform for automating calls | REST API, Python SDK, TypeScript SDK, Webhooks, SIP | ✅ |
+| [LiveKit Agents](livekit-agents.md) [![⭐](https://img.shields.io/github/stars/livekit/agents?style=social)](https://github.com/livekit/agents) | Build, run, and observe realtime voice/video AI agents | Python/TS Agents SDK, WebRTC, SIP, LiveKit Cloud | ❌ |
 
 ---
 

--- a/services/voice-and-phone/livekit-agents.md
+++ b/services/voice-and-phone/livekit-agents.md
@@ -1,0 +1,137 @@
+# LiveKit Agents
+
+> **"Build, run, and observe AI agents"** — voice, video, and physical AI on LiveKit.
+
+| | |
+|---|---|
+| **Website** | https://livekit.io/agents |
+| **Docs** | https://docs.livekit.io/agents/ |
+| **GitHub** | https://github.com/livekit/agents |
+| **Stars** | [![GitHub Stars](https://img.shields.io/github/stars/livekit/agents?style=social)](https://github.com/livekit/agents) |
+| **Classification** | `agent-native` |
+| **Category** | [Voice & Phone Services](README.md) |
+
+---
+
+## Official Website
+
+https://livekit.io/agents
+
+---
+
+## Official Repo
+
+https://github.com/livekit/agents — Python & TypeScript agent server framework
+
+---
+
+## How to Use (Agent Onboarding)
+
+**SDK — open-source Agents framework + LiveKit Cloud for deploy and telephony.**
+
+```bash
+# Follow https://docs.livekit.io/agents/start/voice-ai/
+# Typical: pip install livekit-agents + plugins (STT, LLM, TTS), then livekit agents CLI
+```
+
+**LiveKit Cloud** — managed agent deployment, inference routing, SIP / phone numbers — see [Agent Cloud deployment](https://livekit.io/products/agent-cloud-deployment) and [docs](https://docs.livekit.io/intro/cloud/).
+
+---
+
+## Agent Skills
+
+**Status:** ⚠️ LiveKit publishes **coding agent resources** (Claude Code, Cursor, etc.) per marketing site; no single `npx skills add livekit/...` verified in-repo — see LiveKit docs **Coding agent resources**.
+
+---
+
+## MCP
+
+**Status:** ⚠️ Not primarily an MCP product; integration is **SDK + WebRTC + SIP**.
+
+---
+
+## What It Does
+
+LiveKit **Agents** is a framework and cloud platform for **real-time voice (and video) AI agents**: **STT → LLM → TTS** pipelines with **VAD**, **turn detection**, **barge-in**, **noise cancellation**, and **tool use** during live sessions. **LiveKit Cloud** provides global **WebRTC** media mesh, **autoscaling**, **SIP telephony**, **session replay**, **metrics**, and **logs** — infrastructure aimed at **conversational agents**, not traditional CRUD APIs.
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | Product page: *"Build, run, and observe AI agents"*; SDK examples define `Agent` classes and `AgentSession` for voice loops |
+| **Agent-specific primitive** | **Real-time multimodal session** with **interruption handling**, **turn detection**, **noise cancellation**, and **mid-session tool/model plugins** — no human phone UI |
+| **Autonomy-compatible control plane** | Agents join rooms and handle calls **headlessly** via APIs; scaling and routing are platform-managed |
+| **M2M integration surface** | Python & TypeScript SDKs, CLI, **SIP**, web & mobile **client SDKs** |
+| **Identity / delegation** | **LiveKit tokens** gate room access; **org/project** controls on cloud; **HIPAA / SOC2** options per trust center |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **AgentServer / JobContext** | Entry point for agent worker processes |
+| **AgentSession** | Wires STT, LLM, TTS, VAD, turn detection |
+| **Room / participant** | WebRTC session model for human ↔ agent |
+| **SIP & phone numbers** | PSTN ingress/egress for voice agents |
+| **Inference** | Routed STT/LLM/TTS via LiveKit Inference or plugins |
+| **Observability** | Session replay, logs, agent metrics |
+
+---
+
+## Autonomy Model
+
+```
+Client joins LiveKit room (web, mobile, or SIP)
+    ↓
+Agent worker receives job → starts AgentSession with audio pipeline
+    ↓
+Agent listens → LLM plans → speaks; may call tools between turns
+    ↓
+Cloud handles media routing, scaling, recording exports
+```
+
+---
+
+## Identity and Delegation Model
+
+- **Access tokens** authorize participants (users vs. agents) to specific rooms.
+- **API keys** for server-side agent deployment and management.
+- **Enterprise** compliance and data controls on LiveKit Cloud.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| Python | `livekit-agents` + plugins — see GitHub |
+| TypeScript | Agents SDK — see docs |
+| WebRTC | Client SDKs (web, iOS, Android) |
+| SIP | Telephony product — see LiveKit Phone Numbers |
+
+---
+
+## Human-in-the-Loop Support
+
+Voice agents may escalate to humans via application logic; platform provides **session inspection** for supervisors.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **Plain Twilio + REST** | No built-in real-time agent audio pipeline, turn detection, or WebRTC mesh |
+| **Batch STT/TTS APIs** | Latency model wrong for live conversation |
+| **Generic video SaaS** | Not optimized for **AI agent** workers, tool calls, and telephony-native noise profiles |
+
+---
+
+## Use Cases
+
+- **Customer support voice bots** with tool calling during calls
+- **Realtime copilots** — low-latency speech ↔ LLM loops
+- **Phone agents** — SIP trunking without operating media servers yourself

--- a/skill.md
+++ b/skill.md
@@ -5,7 +5,7 @@ description: >
   the ground up for AI agents, not adapted from human-facing products. Use the
   catalog to find services by task, understand each service's onboarding pattern,
   and immediately start using any service with URL Onboarding in one instruction.
-version: "2026-04-06"
+version: "2026-04-07"
 license: CC0-1.0
 catalog: https://github.com/haoruilee/awesome-agent-native-services
 allowed-tools: WebSearch Read
@@ -56,7 +56,7 @@ These services can be joined with a single instruction, right now, with no human
 
 ---
 
-## Full Catalog — 15 Categories, 68+ Services
+## Full Catalog — 15 Categories, 80+ Services
 
 ### 1. Communication
 *Give agents a first-class communication identity on the internet.*
@@ -87,6 +87,7 @@ These services can be joined with a single instruction, right now, with no human
 | [Hyperbrowser](https://www.hyperbrowser.ai) | Web infra for AI agents (MCP tools) | `npx hyperbrowser-mcp <API_KEY>` |
 | [AgentQL](https://agentql.com) | AgentQL queries → structured JSON from the web | API key → [docs.agentql.com](https://docs.agentql.com) |
 | [Crawl4AI](https://crawl4ai.com) | OSS LLM-friendly crawler + MCP | [docs.crawl4ai.com](https://docs.crawl4ai.com) |
+| [Apify](https://apify.com) | Real-time web data for AI — Actor API & marketplace | API token → [Apify API v2](https://docs.apify.com/api/v2) — `apify-client` |
 
 ---
 
@@ -98,6 +99,8 @@ These services can be joined with a single instruction, right now, with no human
 | [Composio](https://composio.dev) | The tool platform built for agents | `npx skills add composiohq/skills` |
 | [Nango](https://nango.dev) | OAuth and credential layer for AI agents | `$skills install @NangoHQ/sync-builder-skill` |
 | [Toolhouse](https://toolhouse.ai) | BaaS for AI agents — tools, memory, and execution | `npm install -g toolhouse` → `th deploy` |
+| [Smithery](https://smithery.ai) | MCP registry — thousands of remote MCP servers & skills | `npx @smithery/cli@latest setup` — [docs.smithery.ai](https://docs.smithery.ai/) |
+| [MCP Gateway](https://mcpgateway.com) | Enterprise MCP — tools, skills, sandboxes, one API | `pip install mcpgateway-sdk` — [mcpgateway.com](https://mcpgateway.com) |
 
 ---
 
@@ -140,6 +143,8 @@ These services can be joined with a single instruction, right now, with no human
 | [db9](https://db9.ai) ⭐ | Postgres but for agents | `Read https://db9.ai/skill.md and follow the instructions` |
 | [AgentAnycast](https://github.com/AgentAnycast/agentanycast) | Connect AI agents across any network — no public IP | `pip install agentanycast` → `agentanycast demo` — MCP: `agentanycastd --mcp-listen stdio` or `uvx agentanycast-mcp` |
 | [Scrapybara](https://scrapybara.com) | Remote desktops for computer-use agents (CUA) | `pip install scrapybara` → `Scrapybara().start_ubuntu()` — [Act SDK](https://docs.scrapybara.com/act-sdk) |
+| [Agentuity](https://agentuity.com) | Full-stack platform for AI agents | [agentuity.dev](https://agentuity.dev) — SDK + CLI |
+| [Modal](https://modal.com) | Serverless AI infra — GPUs, sandboxes, batch | `pip install modal` → `modal setup` — [modal.com/docs](https://modal.com/docs) |
 
 ---
 
@@ -190,6 +195,7 @@ These services can be joined with a single instruction, right now, with no human
 | [Langfuse](https://langfuse.com) | Open-source LLM observability, tracing, and evaluation | `npx skills add https://github.com/langfuse/skills --skill langfuse-observability` |
 | [AgentEvals](https://aevals.ai) | Score agent behavior from OpenTelemetry traces (no re-runs) | `pip install agentevals-cli` → `agentevals run <trace> --eval-set <set> -m tool_trajectory_avg_score` |
 | [AgentOps](https://www.agentops.ai) | Agent session waterfalls and trace API | `pip install agentops` → `agentops.init(<API_KEY>)` |
+| [Braintrust](https://www.braintrust.dev) | AI observability & evals — OpenAI Agents trace processor + MCP | `pip install "braintrust[openai-agents]"` — MCP: [Braintrust MCP](https://www.braintrust.dev/docs/integrations/developer-tools/mcp) |
 
 ---
 
@@ -202,6 +208,7 @@ These services can be joined with a single instruction, right now, with no human
 | [Inngest](https://inngest.com) | Durable execution for AI agents in production | `npx skills add inngest/inngest-skills` |
 | [Kitaru](https://kitaru.ai) | Durable execution for AI agents — primitives first, frameworks second | `pip install kitaru` → `@flow` / `@checkpoint` decorators |
 | [Restate](https://restate.dev) | Durable execution for AI agents — any framework, any cloud | `pip install restate-sdk` → wrap agent with 2-line middleware |
+| [MCP-Cloud (mcp-agent)](https://docs.mcp-agent.com) | Host mcp-agents on cloud — Temporal-backed MCP | `uvx mcp-agent login` → `uvx mcp-agent deploy …` — [MCP-Cloud](https://docs.mcp-agent.com/get-started/cloud) |
 
 ---
 
@@ -223,6 +230,7 @@ These services can be joined with a single instruction, right now, with no human
 |---|---|---|
 | [Vapi](https://vapi.ai) | Build advanced voice AI agents | `pip install vapi-server-sdk` → `POST /assistant` |
 | [Retell AI](https://www.retellai.com) | #1 AI voice agent platform for automating calls | `pip install retell-sdk` — [docs.retellai.com](https://docs.retellai.com) |
+| [LiveKit Agents](https://livekit.io/agents) | Realtime voice/video AI agents | [docs.livekit.io/agents](https://docs.livekit.io/agents/) — Python/TS SDK |
 
 ---
 
@@ -234,6 +242,9 @@ These services can be joined with a single instruction, right now, with no human
 | [Portkey](https://portkey.ai) | The AI gateway built for production agents | `pip install portkey-ai` → point LLM client at `api.portkey.ai` with a virtual key |
 | [Keywords AI](https://www.keywordsai.co) | OpenAI-compatible gateway + agent tracing | Base URL `https://api.keywordsai.co` — [gateway quickstart](https://docs.keywordsai.co/get-started/quickstart/gateway) |
 | [Agentgateway](https://agentgateway.dev) | Open-source LLM + MCP + A2A proxy | Install via [quickstart](https://agentgateway.dev/docs/quickstart/) → run `agentgateway -f config.yaml` |
+| [LiteLLM](https://www.litellm.ai) | Open-source gateway — 100+ LLMs + Agent Gateway (A2A) | Self-host per [proxy quickstart](https://docs.litellm.ai/docs/proxy/docker_quick_start) — [A2A](https://docs.litellm.ai/docs/a2a) |
+| [OpenRouter](https://openrouter.ai) | Unified OpenAI-compatible API — 300+ models | [Quickstart](https://openrouter.ai/docs/quickstart) + `OPENROUTER_API_KEY` |
+| [Helicone](https://www.helicone.ai) | AI Gateway + observability — `ai-gateway.helicone.ai` | OpenAI SDK `baseURL` per [Helicone quickstart](https://docs.helicone.ai/) |
 
 ---
 
@@ -245,6 +256,7 @@ These services can be joined with a single instruction, right now, with no human
 | [Moltbook](https://moltbook.com) ⭐ | The front page of the agent internet | `Read https://www.moltbook.com/skill.md and follow the instructions to register and join` |
 | [Shellmates](https://shellmates.app) | Pen pals for AI agents — 1:1 matching, private correspondence | `POST https://www.shellmates.app/api/agents/register` |
 | [Openwork](https://openwork.so) | The agent-only labor marketplace — hire agents, earn on-chain | `npx playbooks add skill openclaw/skills --skill openwork` |
+| [MCP Verse](https://mcpverse.org) | Open town square for autonomous MCP agents | `npx create-mcpverse-agent my-bot` — [mcpverse.org/docs](https://mcpverse.org/docs) |
 
 ---
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds twelve services discussed in discovery: **Agentuity**, **Modal**, **Smithery**, **MCP Gateway**, **LiteLLM**, **OpenRouter**, **Helicone**, **Braintrust**, **LiveKit Agents**, **MCP Verse**, **MCP-Cloud (mcp-agent)**, and **Apify**.

## Changes

- New per-service files under `services/{category}/` following CONTRIBUTING section 7 (all required sections).
- Rows added to each affected category `README.md` and to the root `README.md` (category counts updated).
- `skill.md` catalog updated (version bump, service count, new rows).
- `llms.txt` category line clarified.
- **Portkey** and **Keywords AI** comparison rows updated now that LiteLLM has a dedicated entry.

## Notes

- **MCP Verse** (`mcpverse.org`) returned DNS failures from the automation environment; the URL is the one indexed in public search. A short reliability note was added in the service file.
- **mcp-agent.com** returned 503 from this environment; the entry uses **docs.mcp-agent.com** as the primary web link for MCP-Cloud.

## Checklist

- [x] Service files include all required sections in order
- [x] Category README + root README + skill.md updated
- [x] Links spot-checked (docs.helicone.ai, litellm A2A, braintrust MCP, livekit agents, mcp-agent cloud, etc.)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b3db258d-2692-4ecc-a437-4ee0726b2fec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b3db258d-2692-4ecc-a437-4ee0726b2fec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

