### PR TITLE
[New Service] Lightpanda

### DIFF
--- a/.skills/find-agent-service/SKILL.md
+++ b/.skills/find-agent-service/SKILL.md
@@ -56,7 +56,7 @@ Activate this skill when the user asks things like:
 | Task type | Category | Services | Onboarding pattern |
 |---|---|---|---|
 | Agent needs an email address / inbox | Communication | AgentMail, Novu | SDK/REST |
-| Agent needs to browse the web | Browser & Web Execution | Browserbase, Firecrawl, Bright Data, bb-browser | Skill / SDK / Daemon |
+| Agent needs to browse the web | Browser & Web Execution | Browserbase, Firecrawl, Bright Data, bb-browser, Lightpanda | Skill / SDK / Daemon |
 | Agent needs to call external APIs | Tool Access & Integration | Composio, Nango, Toolhouse | Skill / SDK |
 | Agent needs human approval for risky actions | Oversight & Approval | HumanLayer | SDK |
 | Agent needs a wallet / to pay for things | Commerce & Payments | Payman AI, Skyfire, AgentsPay, Nevermined | SDK / REST |

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Source files are in `.skills/` in this repo. ClawHub CLI options (including the 
 | # | Category | Services | Description |
 |---|---|---|---|
 | 1 | [Communication](#1-communication-services) | 5 | Give agents a communication identity on the internet |
-| 2 | [Browser & Web Execution](#2-browser--web-execution-services) | 16 | Remote browser and web data extraction for agents |
+| 2 | [Browser & Web Execution](#2-browser--web-execution-services) | 17 | Remote browser and web data extraction for agents |
 | 3 | [Tool Access & Integration](#3-tool-access--integration-services) | 6 | Runtime tool discovery, auth, and execution |
 | 4 | [Oversight & Approval](#4-oversight--approval-services) | 1 | Human-in-the-loop approval and escalation |
 | 5 | [Commerce & Payments](#5-commerce--payment-services) | 6 | Agent-native wallets, identity, and transactions |
@@ -88,6 +88,7 @@ Source files are in `.skills/` in this repo. ClawHub CLI options (including the 
 | [Apify](services/browser-and-web-execution/apify.md) [![⭐](https://img.shields.io/github/stars/apify/crawlee?style=social)](https://github.com/apify/crawlee) | Real-time web data for AI — Actor marketplace & API | Actor runs · Dataset export · Proxies · Schedules · Webhooks | ⚠️ | API token → [Apify API v2](https://docs.apify.com/api/v2) — JS/Python `apify-client` |
 | [Cloudflare Browser Rendering](services/browser-and-web-execution/cloudflare-browser-rendering.md) [![⭐](https://img.shields.io/github/stars/cloudflare/workers-sdk?style=social)](https://github.com/cloudflare/workers-sdk) | Headless Chrome on Cloudflare for AI agents | Workers bindings · Playwright/Puppeteer · Playwright MCP · REST API | ✅ | [Browser Rendering](https://developers.cloudflare.com/browser-rendering/) — [Use with AI](https://developers.cloudflare.com/browser-rendering/how-to/ai/) |
 | [Olostep](services/browser-and-web-execution/olostep.md) [![⭐](https://img.shields.io/github/stars/olostep/olostep-mcp-server?style=social)](https://github.com/olostep/olostep-mcp-server) | Web data API for AI agents | Scrape · Search · Map · Crawl · Batch · Official MCP | ✅ | API key → [docs.olostep.com](https://docs.olostep.com) — `npx -y olostep-mcp` or remote `https://mcp.olostep.com/mcp` |
+| [Lightpanda](services/browser-and-web-execution/lightpanda.md) [![⭐](https://img.shields.io/github/stars/lightpanda-io/browser?style=social)](https://github.com/lightpanda-io/browser) | Headless browser for AI agents and automation | CDP · `fetch --dump markdown` · Built-in MCP (`lightpanda mcp`) | ✅ | [Install binary or Docker](https://github.com/lightpanda-io/browser#install) → `lightpanda serve` — [MCP guide](https://lightpanda.io/docs/open-source/guides/mcp-server) |
 
 ---
 

--- a/services/browser-and-web-execution/README.md
+++ b/services/browser-and-web-execution/README.md
@@ -30,6 +30,7 @@ The web was designed for humans sitting in front of browsers. AI agents that nee
 | [Crawl4AI](crawl4ai.md) [![⭐](https://img.shields.io/github/stars/unclecode/crawl4ai?style=social)](https://github.com/unclecode/crawl4ai) | Open-source LLM-friendly web crawler & scraper | LLM-ready markdown · Extraction · Docker · MCP | ✅ |
 | [Cloudflare Browser Rendering](cloudflare-browser-rendering.md) [![⭐](https://img.shields.io/github/stars/cloudflare/workers-sdk?style=social)](https://github.com/cloudflare/workers-sdk) | Headless Chrome on Cloudflare for AI-driven browsing | Workers bindings · Playwright/Puppeteer · Playwright MCP · REST | ✅ |
 | [Olostep](olostep.md) [![⭐](https://img.shields.io/github/stars/olostep/olostep-mcp-server?style=social)](https://github.com/olostep/olostep-mcp-server) | Web data API for AI agents — scrape, search, crawl, batch | REST API · Official MCP · Remote `mcp.olostep.com` | ✅ |
+| [Lightpanda](lightpanda.md) [![⭐](https://img.shields.io/github/stars/lightpanda-io/browser?style=social)](https://github.com/lightpanda-io/browser) | Headless browser built for AI agents and automation | CDP server · `fetch` CLI (HTML/markdown) · Built-in MCP (stdio) | ✅ |
 | [Apify](apify.md) [![⭐](https://img.shields.io/github/stars/apify/crawlee?style=social)](https://github.com/apify/crawlee) | Real-time web data for AI — Actor marketplace & API | REST API v2, JS/Python clients, webhooks, schedules | ⚠️ |
 
 ---

--- a/services/browser-and-web-execution/lightpanda.md
+++ b/services/browser-and-web-execution/lightpanda.md
@@ -1,0 +1,185 @@
+# Lightpanda
+
+> **"The headless browser built from scratch for AI agents and automation."**
+
+| | |
+|---|---|
+| **Website** | https://lightpanda.io |
+| **Docs** | https://lightpanda.io/docs |
+| **GitHub** | https://github.com/lightpanda-io/browser |
+| **Stars** | [![GitHub Stars](https://img.shields.io/github/stars/lightpanda-io/browser?style=social)](https://github.com/lightpanda-io/browser) |
+| **Classification** | `agent-native` |
+| **Category** | [Browser & Web Execution Services](README.md) |
+| **License** | AGPL-3.0 |
+
+---
+
+## Official Website
+
+https://lightpanda.io
+
+---
+
+## Official Repo
+
+https://github.com/lightpanda-io/browser — Zig implementation, CDP server, CLI, built-in MCP mode
+
+https://github.com/lightpanda-io/agent-skill — OpenClaw-oriented skill (community)
+
+---
+
+## How to Use (Agent Onboarding)
+
+**Interaction pattern:** `Daemon (CDP)` + **MCP (stdio)** + **CLI**
+
+```bash
+# Nightly binary (see releases) or Docker:
+# docker run -d -p 127.0.0.1:9222:9222 lightpanda/browser:nightly
+
+./lightpanda serve --host 127.0.0.1 --port 9222
+```
+
+```js
+// Puppeteer (same pattern as headless Chrome)
+import puppeteer from 'puppeteer-core';
+const browser = await puppeteer.connect({
+  browserWSEndpoint: 'ws://127.0.0.1:9222',
+});
+```
+
+**MCP:** Add to MCP config (stdio) per [MCP server guide](https://lightpanda.io/docs/open-source/guides/mcp-server):
+
+```json
+{
+  "mcpServers": {
+    "lightpanda": {
+      "command": "/path/to/lightpanda",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+**One-shot fetch (markdown or HTML):**
+
+```bash
+./lightpanda fetch --dump markdown https://example.com
+```
+
+---
+
+## Agent Skills
+
+**Status:** ⚠️ No single official `npx skills add …` bundle from the browser repo; see companion repo for OpenClaw.
+
+| Skill | Source | What It Teaches the Agent |
+|---|---|---|
+| OpenClaw skill | https://github.com/lightpanda-io/agent-skill | Using Lightpanda from OpenClaw-style workflows |
+
+```bash
+npx clawhub@latest search lightpanda
+```
+
+See: https://agentskills.io/specification to contribute a portable `SKILL.md`.
+
+---
+
+## MCP
+
+**Status:** ✅ Available (built into the `lightpanda` binary)
+
+| Detail | Value |
+|---|---|
+| **Docs** | https://lightpanda.io/docs/open-source/guides/mcp-server |
+| **Transport** | stdio (JSON-RPC 2.0) |
+| **Invocation** | `lightpanda mcp` |
+| **Compatible Clients** | Cursor, Claude Desktop, Codex, any MCP host that supports stdio servers |
+
+---
+
+## What It Does
+
+Lightpanda is a **from-scratch headless browser** (Zig, V8, not Chromium/WebKit) aimed at **AI agents and automation**. It runs a **Chrome DevTools Protocol (CDP)** server so existing stacks (for example **Puppeteer** via `browserWSEndpoint`) can drive navigation, clicks, and extraction with a small memory footprint versus full Chrome. A **`fetch` CLI** can dump **HTML or markdown** for RAG-style ingestion. A **native MCP mode** exposes browser control directly to MCP clients without a separate adapter process.
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | README opening line: *"The headless browser built from scratch for AI agents and automation."* — [github.com/lightpanda-io/browser](https://github.com/lightpanda-io/browser) |
+| **Agent-specific primitive** | **Headless browser session** with CDP wire-up for programmatic control; **`--dump markdown`** for LLM-ready page text; **MCP** as a first-class invocation mode (`lightpanda mcp`) |
+| **Autonomy-compatible control plane** | Agent connects over CDP or MCP and drives navigation and DOM actions without a human-operated window; optional `--obey-robots` for policy-aware fetching |
+| **M2M integration surface** | CDP WebSocket server (`serve`), Puppeteer-compatible `connect`, MCP stdio, CLI `fetch` |
+| **Identity / delegation** | **Per-browser-context isolation** via standard CDP/Puppeteer patterns (separate `BrowserContext` / pages); custom headers and proxy support for attributable, configurable outbound identity |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **CDP server** | `lightpanda serve` — WebSocket endpoint for Puppeteer/Playwright-style clients |
+| **MCP server** | `lightpanda mcp` — stdio MCP for tool-calling agents |
+| **`fetch` CLI** | Non-interactive URL dump (`--dump html` or `--dump markdown`) with wait options |
+| **Browser contexts / pages** | Standard multi-context isolation for parallel agent workloads |
+
+---
+
+## Autonomy Model
+
+```
+Agent (or MCP host) starts lightpanda serve OR runs lightpanda mcp
+    ↓
+Agent connects via CDP (Puppeteer) or invokes MCP tools
+    ↓
+Agent navigates, clicks, evaluates scripts, extracts structured data
+    ↓
+Agent disconnects or tears down context — no human in the browser loop
+```
+
+For read-only ingestion, the agent may skip CDP and call `lightpanda fetch` to obtain markdown.
+
+---
+
+## Identity and Delegation Model
+
+- **Isolation:** Separate browser contexts and pages map cleanly to separate agent tasks or tenants.
+- **Outbound attribution:** Custom HTTP headers and proxy configuration (per README feature list) let the operator scope how the browser presents itself on the network.
+- **Policy:** Optional `robots.txt` respect (`--obey-robots`) for autonomous but policy-aware crawling.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| **CDP** | WebSocket server — connect with `puppeteer.connect({ browserWSEndpoint })` |
+| **MCP** | stdio — `lightpanda mcp` — [documentation](https://lightpanda.io/docs/open-source/guides/mcp-server) |
+| **CLI** | `lightpanda fetch`, `lightpanda serve` |
+| **Docker** | Official image `lightpanda/browser` (see repo README) |
+
+---
+
+## Human-in-the-Loop Support
+
+Not required for core automation. Operators may enforce **robots.txt** and network policies via flags. The upstream project **collects telemetry by default**; disable with `LIGHTPANDA_DISABLE_TELEMETRY=true` — see [privacy policy](https://lightpanda.io/privacy-policy).
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **Headless Chrome / Chromium** | Full browser stack; far heavier RAM/CPU per tab — opposite of the “built for automation scale” goal Lightpanda states |
+| **Raw HTTP + `curl`** | No JS execution or DOM — fails on SPAs and dynamic sites Lightpanda targets |
+| **Remote cloud browser APIs** | Different tradeoff: vendor-hosted sessions vs **self-hosted, AGPL** browser you run entirely on your own metal |
+
+---
+
+## Use Cases
+
+- **Coding agents** — drive internal or public web UIs via MCP or Puppeteer without launching Chrome.
+- **Research / RAG agents** — `fetch --dump markdown` for clean text from JavaScript-heavy pages.
+- **High-parallel crawlers** — many isolated contexts with lower per-instance overhead than full Chromium (see project benchmarks).
+- **Self-hosted compliance** — run the browser stack entirely inside your network boundary.

--- a/skill.md
+++ b/skill.md
@@ -92,6 +92,7 @@ These services can be joined with a single instruction, right now, with no human
 | [Crawl4AI](https://crawl4ai.com) | OSS LLM-friendly crawler + MCP | [docs.crawl4ai.com](https://docs.crawl4ai.com) |
 | [Cloudflare Browser Rendering](https://developers.cloudflare.com/browser-rendering/) | Headless Chrome on Cloudflare for AI agents | Workers bindings + [Use with AI](https://developers.cloudflare.com/browser-rendering/how-to/ai/) (Playwright MCP) |
 | [Olostep](https://www.olostep.com) | Web data API for AI agents | API key → [docs.olostep.com](https://docs.olostep.com) — `npx -y olostep-mcp` or `https://mcp.olostep.com/mcp` |
+| [Lightpanda](https://lightpanda.io) | Headless browser for AI agents (CDP + MCP + markdown fetch) | [Install](https://github.com/lightpanda-io/browser#install) → `lightpanda serve` or `lightpanda mcp` — [MCP docs](https://lightpanda.io/docs/open-source/guides/mcp-server) |
 | [Apify](https://apify.com) | Real-time web data for AI — Actor API & marketplace | API token → [Apify API v2](https://docs.apify.com/api/v2) — `apify-client` |
 
 ---


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds **Lightpanda** ([lightpanda-io/browser](https://github.com/lightpanda-io/browser)) to the Browser & Web Execution category: open-source Zig headless browser positioned for AI agents and automation, with CDP (`serve`), `fetch --dump markdown`, and built-in MCP (`lightpanda mcp` per [docs](https://lightpanda.io/docs/open-source/guides/mcp-server)).

Also updates `skill.md` and the `find-agent-service` skill category map.

**Note:** [OpenViking](https://github.com/volcengine/OpenViking) from the same trending list is already listed ([openviking.md](services/memory-and-state/openviking.md)); no duplicate entry was added.

**Process:** CONTRIBUTING normally asks for a prior ✅ Go on a new-service issue; this PR was opened per explicit request to ship the change—happy to link or open an issue if maintainers want it on record.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-af23c73b-44bc-4d86-9497-27de3f500fdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-af23c73b-44bc-4d86-9497-27de3f500fdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

