### PR TITLE
[New Service] Add Agents Mail and Agent Sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Source files are in `.skills/` in this repo. ClawHub CLI options (including the 
 
 | # | Category | Services | Description |
 |---|---|---|---|
-| 1 | [Communication](#1-communication-services) | 5 | Give agents a communication identity on the internet |
+| 1 | [Communication](#1-communication-services) | 6 | Give agents a communication identity on the internet |
 | 2 | [Browser & Web Execution](#2-browser--web-execution-services) | 17 | Remote browser and web data extraction for agents |
 | 3 | [Tool Access & Integration](#3-tool-access--integration-services) | 9 | Runtime tool discovery, auth, and execution |
 | 4 | [Oversight & Approval](#4-oversight--approval-services) | 1 | Human-in-the-loop approval and escalation |
@@ -66,7 +66,7 @@ Source files are in `.skills/` in this repo. ClawHub CLI options (including the 
 | 6 | [Agent Runtime & Infrastructure](#6-agent-runtime--infrastructure-services) | 17 | Execution, session isolation, secrets, and gateway |
 | 7 | [Memory & State](#7-memory--state-services) | 8 | Persistent agent memory across sessions |
 | 8 | [Search & Web Intelligence](#8-search--web-intelligence-services) | 4 | LLM-optimized web search and content retrieval |
-| 9 | [Code Execution](#9-code-execution-services) | 5 | Secure sandboxes for AI-generated code |
+| 9 | [Code Execution](#9-code-execution-services) | 6 | Secure sandboxes for AI-generated code |
 | 10 | [Observability & Tracing](#10-observability--tracing-services) | 4 | Agent trajectory tracing and evaluation |
 | 11 | [Durable Execution & Scheduling](#11-durable-execution--scheduling-services) | 5 | Fault-tolerant long-running agent workflows |
 | 12 | [Meeting & Conversation](#12-meeting--conversation-services) | 3 | Agent presence in voice and video meetings |
@@ -91,6 +91,7 @@ Source files are in `.skills/` in this repo. ClawHub CLI options (including the 
 | [mails.dev](services/communication/mails-dev.md) | Email for AI Agents | @mails.dev mailbox · Send/inbox · wait-for-code · Full-text search | ⚠️ | Read https://mails.dev/skill.md and follow the instructions |
 | [OpenMail](services/communication/openmail.md) | Email API for AI agents | One inbox per agent · Webhook/WebSocket inbound · RAG-ready attachment parsing | ⚠️ | `npm install -g @openmail/cli` → `openmail setup` — [docs.openmail.sh](https://docs.openmail.sh/quickstart) |
 | [MailboxKit](services/communication/mailboxkit.md) | Email infrastructure for AI agents | Per-agent address · REST v1 · Inbound webhooks · URL Onboarding | ⚠️ | Read https://mailboxkit.com/skill.md and follow the instructions |
+| [Agents Mail](services/communication/agents-mail.md) | Email for AI Agents | Agent registration · Inbox lifecycle · Send/reply API · URL Onboarding | ⚠️ | Read https://agentsmail.org/skill.md and follow the instructions |
 
 ---
 
@@ -252,6 +253,7 @@ Source files are in `.skills/` in this repo. ClawHub CLI options (including the 
 | [Runloop](services/code-execution/runloop.md) [![⭐](https://img.shields.io/github/stars/runloopai/api-client-python?style=social)](https://github.com/runloopai/api-client-python) | Your AI agent accelerator | Devbox micro-VM · Snapshot/branch disk state · Benchmark jobs · Suspend/resume | ✅ | `export RUNLOOP_API_KEY=...` → `npm install -g @runloop/rl-cli` → `rli mcp install` — [CLI docs](https://docs.runloop.ai/docs/tools/rl-cli) |
 | [Vercel Sandbox](services/code-execution/vercel-sandbox.md) [![⭐](https://img.shields.io/github/stars/vercel/sandbox?style=social)](https://github.com/vercel/sandbox) | Firecracker microVMs for AI-generated code | Node/Python runtimes · Snapshots · REST + `@vercel/sandbox` SDK | ❌ | `npm install @vercel/sandbox` — [vercel.com/docs/vercel-sandbox](https://vercel.com/docs/vercel-sandbox) |
 | [AIO Sandbox](services/code-execution/agent-infra-sandbox.md) [![⭐](https://img.shields.io/github/stars/agent-infra/sandbox?style=social)](https://github.com/agent-infra/sandbox) | All-in-one Docker sandbox for AI agents | Browser + shell + files + VS Code + Jupyter + MCP · Shared filesystem | ✅ | `docker run -p 8080:8080 ghcr.io/agent-infra/sandbox:latest` — MCP `http://localhost:8080/mcp` |
+| [Agent Sandbox](services/code-execution/agent-sandbox.md) | The trusted runtime for untrusted code | Hosted code sessions · Dependency install · Files/artifacts API · URL onboarding | ⚠️ | Read https://agentsandbox.co/skill.md and follow the instructions |
 
 ---
 

--- a/services/code-execution/README.md
+++ b/services/code-execution/README.md
@@ -25,6 +25,7 @@ Agent-native code execution services solve this with:
 | [Runloop](runloop.md) | Your AI agent accelerator — Devboxes and agent benchmarks | Python/TS SDK, REST, Runloop CLI (`rli`) + MCP | ✅ |
 | [Vercel Sandbox](vercel-sandbox.md) [![⭐](https://img.shields.io/github/stars/vercel/sandbox?style=social)](https://github.com/vercel/sandbox) | Firecracker microVMs for AI-generated and untrusted code | `@vercel/sandbox` SDK, REST API, Sandbox CLI | ❌ |
 | [AIO Sandbox](agent-infra-sandbox.md) [![⭐](https://img.shields.io/github/stars/agent-infra/sandbox?style=social)](https://github.com/agent-infra/sandbox) | All-in-one Docker sandbox — browser, shell, VS Code, Jupyter, MCP | Docker image, OpenAPI, Python/JS/Go SDKs, MCP HTTP | ✅ |
+| [Agent Sandbox](agent-sandbox.md) | The trusted runtime for untrusted code | REST API, Python SDK, URL onboarding (`skill.md`) | ⚠️ |
 
 ---
 

--- a/services/code-execution/agent-sandbox.md
+++ b/services/code-execution/agent-sandbox.md
@@ -1,0 +1,144 @@
+# Agent Sandbox
+
+> **"The trusted runtime for untrusted code."**
+
+| | |
+|---|---|
+| **Website** | https://agentsandbox.co |
+| **Docs** | https://agentsandbox.co/docs |
+| **Classification** | `agent-native` |
+| **Category** | [Code Execution Services](README.md) |
+
+---
+
+## Official Website
+
+https://agentsandbox.co
+
+---
+
+## Official Repo
+
+Not publicly listed. Official entry points are the hosted API, docs, and `skill.md` onboarding URL.
+
+---
+
+## ⭐ How to Use (Agent Onboarding)
+
+Read:
+
+```text
+https://agentsandbox.co/skill.md
+```
+
+Then follow the skill instructions to start a sandbox session and run code.
+
+SDK path:
+
+```bash
+pip install agentsandbox-sdk
+```
+
+---
+
+## Agent Skills
+
+**Status:** ✅ Available (URL onboarding at `https://agentsandbox.co/skill.md`)
+
+| Skill | What It Teaches the Agent |
+|---|---|
+| `agentsandbox` (`skill.md`) | How to authenticate, create sessions, run code, and handle files/artifacts |
+
+---
+
+## MCP
+
+**Status:** ⚠️ Not yet published as a dedicated official MCP server (as of April 15, 2026).
+
+| Detail | Value |
+|---|---|
+| **Primary interface** | REST API + Python SDK |
+| **URL onboarding** | `https://agentsandbox.co/skill.md` |
+| **Compatible clients** | Any agent runtime that can call HTTPS APIs |
+
+---
+
+## What It Does
+
+Agent Sandbox provides a managed, isolated runtime where AI agents can execute Python and shell commands, install dependencies, and exchange files through a single API. The product is positioned around giving each agent a personal remote computer and drive, with explicit support for sessioned execution and artifact pipelines.
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | Homepage headline and copy: “SHIP AGENTS THAT EXECUTE CODE”, “Your agents need a computer and a drive. Here’s the API.” and “The trusted runtime for untrusted code.” — https://agentsandbox.co/ |
+| **Agent-specific primitive** | Agent-oriented secure execution session, dependency manifest install, and file artifact pipeline (“Upload. Execute. Retrieve. One API for code, sessions, and artifacts.”) |
+| **Autonomy-compatible control plane** | API-key + API-driven workflow for code execution; agents can run full loops without per-action human confirmation |
+| **M2M integration surface** | REST docs + Python SDK install command (`pip install agentsandbox-sdk`) + URL onboarding |
+| **Identity / delegation** | API key model and per-session execution context allow attributable, bounded agent operations |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **Sandbox session** | Isolated runtime where an agent executes Python/shell commands |
+| **Dependency manifest** | Per-run dependency installation for reproducible execution |
+| **Artifacts pipeline** | Upload input files, process in sandbox, retrieve output files |
+| **Skill onboarding URL** | Machine-readable bootstrap path for autonomous agent setup |
+
+---
+
+## Autonomy Model
+
+1. Agent reads `https://agentsandbox.co/skill.md`.
+2. Agent authenticates with API key and creates/uses a sandbox session.
+3. Agent uploads input data and executes code inside isolated runtime.
+4. Agent downloads generated artifacts and continues downstream tasks.
+5. Human oversight is optional (dashboard), not required for every action.
+
+---
+
+## Identity and Delegation Model
+
+- **Agent identity:** API key-backed service identity.
+- **Delegation:** Operator decides which agent gets key access and budget.
+- **Auditability:** Session/artifact operations are attributable to the authenticated key.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| REST API | https://agentsandbox.co/docs |
+| Python SDK | `pip install agentsandbox-sdk` |
+| URL Onboarding | `https://agentsandbox.co/skill.md` |
+
+---
+
+## Human-in-the-Loop Support
+
+Optional dashboard-level monitoring and controls are available, but runtime execution is API-first and autonomous.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **Raw VPS / shell hosting** | Not agent-first; lacks built-in autonomous onboarding and agent-oriented execution primitives |
+| **Generic CI runners** | Optimized for build jobs, not persistent agent interaction loops with tool-call style runtime semantics |
+| **Local Docker only** | Requires human-operated infra and does not provide hosted agent identity/control plane out of the box |
+
+---
+
+## Use Cases
+
+- **Code interpreter tools** — secure execution for generated code.
+- **Artifact generation** — transform data into reports/charts/files.
+- **Agentic workflows** — run shell/Python steps inside a bounded environment.
+- **Evaluation harnesses** — execute and verify generated code in isolation.

--- a/services/communication/README.md
+++ b/services/communication/README.md
@@ -15,6 +15,7 @@ Human communication infrastructure (Gmail, Outlook, Slack) was built around the 
 | [mails.dev](mails-dev.md) | Email for AI Agents | CLI, REST API, TypeScript SDK | ⚠️ |
 | [OpenMail](openmail.md) | Email API for AI agents | REST API, WebSocket, Webhooks, CLI (`@openmail/cli`) | ⚠️ |
 | [MailboxKit](mailboxkit.md) | Email infrastructure for AI agents | REST API v1, Webhooks, URL Onboarding (`skill.md`) | ⚠️ |
+| [Agents Mail](agents-mail.md) | Email for AI Agents | REST API, URL Onboarding (`skill.md`), `.well-known/agent.json` discovery | ⚠️ |
 
 ---
 

--- a/services/communication/agents-mail.md
+++ b/services/communication/agents-mail.md
@@ -1,0 +1,139 @@
+# Agents Mail
+
+> **"Email for AI Agents."**
+
+| | |
+|---|---|
+| **Website** | https://agentsmail.org |
+| **Docs** | https://agentsmail.org/docs |
+| **Classification** | `agent-native` |
+| **Category** | [Communication Services](README.md) |
+
+---
+
+## Official Website
+
+https://agentsmail.org
+
+---
+
+## Official Repo
+
+Not publicly listed. Official onboarding is hosted at `skill.md` and `.well-known/agent.json`.
+
+---
+
+## ⭐ How to Use (Agent Onboarding)
+
+Read:
+
+```text
+https://agentsmail.org/skill.md
+```
+
+Then follow the registration and API instructions to provision inboxes and send/receive mail.
+
+---
+
+## Agent Skills
+
+**Status:** ✅ Available (URL onboarding)
+
+| Skill | What It Teaches the Agent |
+|---|---|
+| `agentsmail` (`skill.md`) | Register an agent, create inboxes, send/reply messages, and monitor inbound mail |
+
+---
+
+## MCP
+
+**Status:** ⚠️ Not yet published as an official dedicated MCP server (as of April 15, 2026).
+
+| Detail | Value |
+|---|---|
+| **Primary interface** | REST API |
+| **Onboarding** | `https://agentsmail.org/skill.md` |
+| **Discovery metadata** | `https://agentsmail.org/.well-known/agent.json` |
+
+---
+
+## What It Does
+
+Agents Mail provides mailbox infrastructure specifically for AI agents: programmatic inbox creation, sending/replying to email, message retrieval, and machine-readable onboarding/discovery metadata. The service is explicitly framed as communication infrastructure for autonomous agents rather than as a human mailbox product with add-on APIs.
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | Homepage and docs position the service as “Email for AI Agents” and expose an agent bootstrap URL (`/skill.md`) |
+| **Agent-specific primitive** | Agent registration + inbox lifecycle + message send/reply API designed for autonomous tool loops |
+| **Autonomy-compatible control plane** | Agent can provision inboxes and process mail headlessly via API without interactive UI steps |
+| **M2M integration surface** | REST endpoints plus machine-readable onboarding/discovery URLs (`skill.md`, `.well-known/agent.json`) |
+| **Identity / delegation** | Per-agent registration and mailbox scope provide explicit identity boundaries for outbound/inbound actions |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **Agent registration** | Bootstrap an autonomous agent identity for mail operations |
+| **Inbox provisioning** | Create/manage agent-owned mailboxes programmatically |
+| **Message send/reply** | API actions for outbound and threaded communication |
+| **Message retrieval** | Programmatic inbox access for autonomous processing |
+| **Discovery metadata** | `.well-known/agent.json` for machine-readable capability discovery |
+
+---
+
+## Autonomy Model
+
+1. Agent reads `https://agentsmail.org/skill.md`.
+2. Agent registers and stores its API credentials.
+3. Agent provisions an inbox via API.
+4. Agent sends/replies to messages and polls or receives inbound updates.
+5. Agent logs actions per mailbox scope for traceable communication.
+
+---
+
+## Identity and Delegation Model
+
+- **Agent identity:** Explicit registration flow for agent credentials.
+- **Delegation:** Mailbox-level permissions can be scoped to agent-owned identities.
+- **Audit trail:** API-driven send/reply/read actions are attributable to registered credentials.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| REST API | https://agentsmail.org/docs |
+| URL onboarding | `https://agentsmail.org/skill.md` |
+| Agent metadata | `https://agentsmail.org/.well-known/agent.json` |
+
+---
+
+## Human-in-the-Loop Support
+
+Optional. Core communication operations are autonomous and API-driven.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **Human email APIs (Gmail/Outlook wrappers)** | Typically centered on delegated human inbox access rather than native agent-owned communication identities |
+| **General notification APIs** | May send messages but lack agent registration + autonomous mailbox lifecycle primitives |
+| **SMTP-only providers** | Transport-level only; no agent-native onboarding and identity/delegation semantics |
+
+---
+
+## Use Cases
+
+- **Agent-to-human updates** — send progress, reports, and follow-ups.
+- **Agent inbox operations** — receive and parse customer/vendor responses.
+- **Multi-agent communication** — allocate one mailbox per agent role.
+- **Async workflows** — trigger downstream automations from inbound email events.


### PR DESCRIPTION
### Motivation

- Expand the catalog with two recently discovered agent-native services that provide URL onboarding and agent-oriented primitives for communication and code execution.

### Description

- Added `services/communication/agents-mail.md` containing full per-service documentation, URL onboarding, primitives, autonomy model, identity/delegation model, and qualification rationale.
- Added `services/code-execution/agent-sandbox.md` containing full per-service documentation, URL onboarding, primitives, autonomy model, identity/delegation model, and qualification rationale.
- Updated `services/communication/README.md` and `services/code-execution/README.md` to include the new entries in the category tables.
- Updated top-level `README.md` to increment service counts and add both services to their respective section tables.

### Testing

- Verified required service sections are present in both new files using the `rg` heading check patterned from `CONTRIBUTING.md`, and the check succeeded.
- Performed a repository integrity check to confirm the working tree reflected only the intended changes, and the check succeeded.
- Generated PR metadata via the repository helper (`make_pr`) to prepare the pull request body, and the helper completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfbf1daacc832eb2959e379e6d56dc)