### PR TITLE
Generate category pages, update docs SEO/metadata, and add CI validation for generated docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -92,4 +92,5 @@ Closes #<!-- issue number -->
 - [ ] All links in the changed files are live (I have clicked them).
 - [ ] I have no undisclosed financial interest in the service(s) mentioned.
 - [ ] Spell-check passed.
+- [ ] If I changed `README.md` or `services/**`, I regenerated docs with `bash scripts/build-github-pages.sh` and committed updated `docs/index.md` / `docs/categories/*`.
 - [ ] The PR title follows the format: `[New Service] ServiceName`, `[Update] ServiceName — what changed`, `[Fix] description`, or `[New Category] CategoryName`.

--- a/.github/workflows/validate-generated-docs.yml
+++ b/.github/workflows/validate-generated-docs.yml
@@ -1,0 +1,23 @@
+name: Validate generated docs
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  check-generated-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Regenerate docs artifacts
+        run: bash scripts/build-github-pages.sh
+
+      - name: Ensure generated docs are committed
+        run: |
+          if ! git diff --quiet -- docs/index.md docs/categories; then
+            echo "Generated docs are out of date. Please run: bash scripts/build-github-pages.sh"
+            git --no-pager diff -- docs/index.md docs/categories
+            exit 1
+          fi

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,10 +1,10 @@
 # GitHub Pages / Jekyll — https://pages.github.com/
 # Built from README via scripts/build-github-pages.sh (CI + optional local runs)
 
-title: "Awesome Agent-Native Services | Curated List for AI Agents"
+title: "Awesome Agent-Native Services (2026) | MCP & Agent Infrastructure"
 # Used only in <title> (short for SEO). On-page <h1> still uses page title from index.md.
-seo_html_title: "Agent-native services catalog | GitHub"
-description: "Curated agent-native services and MCP tools for autonomous AI: communication, memory, browsers, sandboxes, and LLM gateways - full list on GitHub."
+seo_html_title: "Best Agent-Native Services 2026 | MCP, Memory, Browser, Runtime"
+description: "Best agent-native services in 2026: MCP tools, browser automation, memory, code sandboxes, observability, and agent infrastructure."
 url: "https://haoruilee.github.io"
 baseurl: "/awesome-agent-native-services"
 lang: en-US

--- a/docs/_includes/head-custom.html
+++ b/docs/_includes/head-custom.html
@@ -1,2 +1,28 @@
 <meta name="robots" content="index, follow">
-<meta name="keywords" content="AI Agents, Agent-Native, MCP Protocol, LLM Tools, Model Context Protocol, MCP servers, autonomous agents, agent infrastructure">
+<meta name="keywords" content="AI agents, agent-native services, MCP servers, model context protocol, agent infrastructure, ai agent tools, autonomous agents">
+{% if page.url == "/" or page.url == "/awesome-agent-native-services/" %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "ItemList",
+  "name": "Awesome Agent-Native Services Categories",
+  "itemListElement": [
+    { "@type": "ListItem", "position": 1, "url": "{{ '/categories/communication/' | absolute_url }}" },
+    { "@type": "ListItem", "position": 2, "url": "{{ '/categories/browser-and-web-execution/' | absolute_url }}" },
+    { "@type": "ListItem", "position": 3, "url": "{{ '/categories/tool-access-and-integration/' | absolute_url }}" },
+    { "@type": "ListItem", "position": 4, "url": "{{ '/categories/oversight-and-approval/' | absolute_url }}" },
+    { "@type": "ListItem", "position": 5, "url": "{{ '/categories/commerce-and-payments/' | absolute_url }}" },
+    { "@type": "ListItem", "position": 6, "url": "{{ '/categories/agent-runtime-and-infrastructure/' | absolute_url }}" },
+    { "@type": "ListItem", "position": 7, "url": "{{ '/categories/memory-and-state/' | absolute_url }}" },
+    { "@type": "ListItem", "position": 8, "url": "{{ '/categories/search-and-web-intelligence/' | absolute_url }}" },
+    { "@type": "ListItem", "position": 9, "url": "{{ '/categories/code-execution/' | absolute_url }}" },
+    { "@type": "ListItem", "position": 10, "url": "{{ '/categories/observability-and-tracing/' | absolute_url }}" },
+    { "@type": "ListItem", "position": 11, "url": "{{ '/categories/durable-execution-and-scheduling/' | absolute_url }}" },
+    { "@type": "ListItem", "position": 12, "url": "{{ '/categories/meeting-and-conversation/' | absolute_url }}" },
+    { "@type": "ListItem", "position": 13, "url": "{{ '/categories/voice-and-phone/' | absolute_url }}" },
+    { "@type": "ListItem", "position": 14, "url": "{{ '/categories/llm-gateway-and-routing/' | absolute_url }}" },
+    { "@type": "ListItem", "position": 15, "url": "{{ '/categories/agent-social-network/' | absolute_url }}" }
+  ]
+}
+</script>
+{% endif %}

--- a/docs/categories/agent-runtime-and-infrastructure.md
+++ b/docs/categories/agent-runtime-and-infrastructure.md
@@ -1,0 +1,30 @@
+---
+title: "Agent Runtime And Infrastructure | Agent-Native Services"
+description: "Agent-native agent runtime and infrastructure services with onboarding links, MCP status, and official references."
+permalink: /categories/agent-runtime-and-infrastructure/
+---
+
+> Category source: [services/agent-runtime-and-infrastructure/README.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/README.md)
+
+## Services in this category
+
+| Service | Catalog Entry |
+|---|---|
+| acpx | [services/agent-runtime-and-infrastructure/acpx.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/acpx.md) |
+| Aembit | [services/agent-runtime-and-infrastructure/aembit.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/aembit.md) |
+| AgentAnycast | [services/agent-runtime-and-infrastructure/agentanycast.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/agentanycast.md) |
+| Agentuity | [services/agent-runtime-and-infrastructure/agentuity.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/agentuity.md) |
+| Amazon Bedrock AgentCore | [services/agent-runtime-and-infrastructure/amazon-bedrock-agentcore.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/amazon-bedrock-agentcore.md) |
+| Chrome DevTools MCP | [services/agent-runtime-and-infrastructure/chrome-devtools-mcp.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/chrome-devtools-mcp.md) |
+| Claude Managed Agents | [services/agent-runtime-and-infrastructure/claude-managed-agents.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/claude-managed-agents.md) |
+| Claude Peers (claude-peers-mcp) | [services/agent-runtime-and-infrastructure/claude-peers.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/claude-peers.md) |
+| Codex plugin for Claude Code (codex-plugin-cc) | [services/agent-runtime-and-infrastructure/codex-plugin-cc.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/codex-plugin-cc.md) |
+| cx | [services/agent-runtime-and-infrastructure/cx.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/cx.md) |
+| db9 | [services/agent-runtime-and-infrastructure/db9.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/db9.md) |
+| Infisical Agent Sentinel | [services/agent-runtime-and-infrastructure/infisical-agent-sentinel.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/infisical-agent-sentinel.md) |
+| Letta | [services/agent-runtime-and-infrastructure/letta.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/letta.md) |
+| Modal | [services/agent-runtime-and-infrastructure/modal.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/modal.md) |
+| Multica | [services/agent-runtime-and-infrastructure/multica.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/multica.md) |
+| Scrapybara | [services/agent-runtime-and-infrastructure/scrapybara.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/scrapybara.md) |
+| Serena | [services/agent-runtime-and-infrastructure/serena.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/serena.md) |
+| Vertex AI Agent Engine | [services/agent-runtime-and-infrastructure/vertex-ai-agent-engine.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/vertex-ai-agent-engine.md) |

--- a/docs/categories/agent-social-network.md
+++ b/docs/categories/agent-social-network.md
@@ -1,0 +1,16 @@
+---
+title: "Agent Social Network | Agent-Native Services"
+description: "Agent-native agent social network services with onboarding links, MCP status, and official references."
+permalink: /categories/agent-social-network/
+---
+
+> Category source: [services/agent-social-network/README.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-social-network/README.md)
+
+## Services in this category
+
+| Service | Catalog Entry |
+|---|---|
+| MCP Verse | [services/agent-social-network/mcpverse.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-social-network/mcpverse.md) |
+| Moltbook | [services/agent-social-network/moltbook.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-social-network/moltbook.md) |
+| Openwork | [services/agent-social-network/openwork.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-social-network/openwork.md) |
+| Shellmates | [services/agent-social-network/shellmates.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-social-network/shellmates.md) |

--- a/docs/categories/browser-and-web-execution.md
+++ b/docs/categories/browser-and-web-execution.md
@@ -1,0 +1,29 @@
+---
+title: "Browser And Web Execution | Agent-Native Services"
+description: "Agent-native browser and web execution services with onboarding links, MCP status, and official references."
+permalink: /categories/browser-and-web-execution/
+---
+
+> Category source: [services/browser-and-web-execution/README.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/browser-and-web-execution/README.md)
+
+## Services in this category
+
+| Service | Catalog Entry |
+|---|---|
+| AgentQL | [services/browser-and-web-execution/agentql.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/browser-and-web-execution/agentql.md) |
+| Anchor Browser | [services/browser-and-web-execution/anchor-browser.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/browser-and-web-execution/anchor-browser.md) |
+| Apify | [services/browser-and-web-execution/apify.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/browser-and-web-execution/apify.md) |
+| bb-browser | [services/browser-and-web-execution/bb-browser.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/browser-and-web-execution/bb-browser.md) |
+| Bright Data Agent Browser | [services/browser-and-web-execution/bright-data-agent-browser.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/browser-and-web-execution/bright-data-agent-browser.md) |
+| Browser Use Cloud | [services/browser-and-web-execution/browser-use-cloud.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/browser-and-web-execution/browser-use-cloud.md) |
+| Browserbase | [services/browser-and-web-execution/browserbase.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/browser-and-web-execution/browserbase.md) |
+| Cloudflare Browser Rendering | [services/browser-and-web-execution/cloudflare-browser-rendering.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/browser-and-web-execution/cloudflare-browser-rendering.md) |
+| Crawl4AI | [services/browser-and-web-execution/crawl4ai.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/browser-and-web-execution/crawl4ai.md) |
+| Firecrawl | [services/browser-and-web-execution/firecrawl.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/browser-and-web-execution/firecrawl.md) |
+| Hyperbrowser | [services/browser-and-web-execution/hyperbrowser.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/browser-and-web-execution/hyperbrowser.md) |
+| Lightpanda | [services/browser-and-web-execution/lightpanda.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/browser-and-web-execution/lightpanda.md) |
+| Notte | [services/browser-and-web-execution/notte.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/browser-and-web-execution/notte.md) |
+| Olostep | [services/browser-and-web-execution/olostep.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/browser-and-web-execution/olostep.md) |
+| OpenCLI | [services/browser-and-web-execution/opencli.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/browser-and-web-execution/opencli.md) |
+| Skyvern | [services/browser-and-web-execution/skyvern.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/browser-and-web-execution/skyvern.md) |
+| Steel | [services/browser-and-web-execution/steel.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/browser-and-web-execution/steel.md) |

--- a/docs/categories/code-execution.md
+++ b/docs/categories/code-execution.md
@@ -1,0 +1,18 @@
+---
+title: "Code Execution | Agent-Native Services"
+description: "Agent-native code execution services with onboarding links, MCP status, and official references."
+permalink: /categories/code-execution/
+---
+
+> Category source: [services/code-execution/README.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/README.md)
+
+## Services in this category
+
+| Service | Catalog Entry |
+|---|---|
+| AIO Sandbox (agent-infra) | [services/code-execution/agent-infra-sandbox.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/agent-infra-sandbox.md) |
+| Agent Sandbox | [services/code-execution/agent-sandbox.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/agent-sandbox.md) |
+| Daytona | [services/code-execution/daytona.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/daytona.md) |
+| E2B | [services/code-execution/e2b.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/e2b.md) |
+| Runloop | [services/code-execution/runloop.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/runloop.md) |
+| Vercel Sandbox | [services/code-execution/vercel-sandbox.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/vercel-sandbox.md) |

--- a/docs/categories/commerce-and-payments.md
+++ b/docs/categories/commerce-and-payments.md
@@ -1,0 +1,17 @@
+---
+title: "Commerce And Payments | Agent-Native Services"
+description: "Agent-native commerce and payments services with onboarding links, MCP status, and official references."
+permalink: /categories/commerce-and-payments/
+---
+
+> Category source: [services/commerce-and-payments/README.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/commerce-and-payments/README.md)
+
+## Services in this category
+
+| Service | Catalog Entry |
+|---|---|
+| AgentsPay | [services/commerce-and-payments/agentspay.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/commerce-and-payments/agentspay.md) |
+| Coinbase Developer Platform (x402) | [services/commerce-and-payments/coinbase-x402.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/commerce-and-payments/coinbase-x402.md) |
+| Nevermined | [services/commerce-and-payments/nevermined.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/commerce-and-payments/nevermined.md) |
+| Payman AI | [services/commerce-and-payments/payman-ai.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/commerce-and-payments/payman-ai.md) |
+| Skyfire | [services/commerce-and-payments/skyfire.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/commerce-and-payments/skyfire.md) |

--- a/docs/categories/communication.md
+++ b/docs/categories/communication.md
@@ -1,0 +1,18 @@
+---
+title: "Communication | Agent-Native Services"
+description: "Agent-native communication services with onboarding links, MCP status, and official references."
+permalink: /categories/communication/
+---
+
+> Category source: [services/communication/README.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/communication/README.md)
+
+## Services in this category
+
+| Service | Catalog Entry |
+|---|---|
+| AgentMail | [services/communication/agentmail.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/communication/agentmail.md) |
+| Agents Mail | [services/communication/agents-mail.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/communication/agents-mail.md) |
+| MailboxKit | [services/communication/mailboxkit.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/communication/mailboxkit.md) |
+| mails.dev | [services/communication/mails-dev.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/communication/mails-dev.md) |
+| Novu | [services/communication/novu.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/communication/novu.md) |
+| OpenMail | [services/communication/openmail.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/communication/openmail.md) |

--- a/docs/categories/durable-execution-and-scheduling.md
+++ b/docs/categories/durable-execution-and-scheduling.md
@@ -1,0 +1,17 @@
+---
+title: "Durable Execution And Scheduling | Agent-Native Services"
+description: "Agent-native durable execution and scheduling services with onboarding links, MCP status, and official references."
+permalink: /categories/durable-execution-and-scheduling/
+---
+
+> Category source: [services/durable-execution-and-scheduling/README.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/durable-execution-and-scheduling/README.md)
+
+## Services in this category
+
+| Service | Catalog Entry |
+|---|---|
+| Inngest | [services/durable-execution-and-scheduling/inngest.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/durable-execution-and-scheduling/inngest.md) |
+| Kitaru | [services/durable-execution-and-scheduling/kitaru.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/durable-execution-and-scheduling/kitaru.md) |
+| MCP-Cloud (mcp-agent) | [services/durable-execution-and-scheduling/mcp-cloud-mcp-agent.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/durable-execution-and-scheduling/mcp-cloud-mcp-agent.md) |
+| Restate | [services/durable-execution-and-scheduling/restate.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/durable-execution-and-scheduling/restate.md) |
+| Trigger.dev | [services/durable-execution-and-scheduling/trigger-dev.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/durable-execution-and-scheduling/trigger-dev.md) |

--- a/docs/categories/index.md
+++ b/docs/categories/index.md
@@ -1,0 +1,23 @@
+---
+title: "Agent-Native Service Categories"
+description: "Browse agent-native services by category: communication, browser automation, MCP tools, memory, runtimes, and more."
+permalink: /categories/
+---
+
+This page helps search engines and humans discover the catalog through focused category landing pages.
+
+- [Agent Runtime And Infrastructure]({{ '/categories/agent-runtime-and-infrastructure/' | relative_url }})
+- [Agent Social Network]({{ '/categories/agent-social-network/' | relative_url }})
+- [Browser And Web Execution]({{ '/categories/browser-and-web-execution/' | relative_url }})
+- [Code Execution]({{ '/categories/code-execution/' | relative_url }})
+- [Commerce And Payments]({{ '/categories/commerce-and-payments/' | relative_url }})
+- [Communication]({{ '/categories/communication/' | relative_url }})
+- [Durable Execution And Scheduling]({{ '/categories/durable-execution-and-scheduling/' | relative_url }})
+- [Llm Gateway And Routing]({{ '/categories/llm-gateway-and-routing/' | relative_url }})
+- [Meeting And Conversation]({{ '/categories/meeting-and-conversation/' | relative_url }})
+- [Memory And State]({{ '/categories/memory-and-state/' | relative_url }})
+- [Observability And Tracing]({{ '/categories/observability-and-tracing/' | relative_url }})
+- [Oversight And Approval]({{ '/categories/oversight-and-approval/' | relative_url }})
+- [Search And Web Intelligence]({{ '/categories/search-and-web-intelligence/' | relative_url }})
+- [Tool Access And Integration]({{ '/categories/tool-access-and-integration/' | relative_url }})
+- [Voice And Phone]({{ '/categories/voice-and-phone/' | relative_url }})

--- a/docs/categories/llm-gateway-and-routing.md
+++ b/docs/categories/llm-gateway-and-routing.md
@@ -1,0 +1,18 @@
+---
+title: "Llm Gateway And Routing | Agent-Native Services"
+description: "Agent-native llm gateway and routing services with onboarding links, MCP status, and official references."
+permalink: /categories/llm-gateway-and-routing/
+---
+
+> Category source: [services/llm-gateway-and-routing/README.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/llm-gateway-and-routing/README.md)
+
+## Services in this category
+
+| Service | Catalog Entry |
+|---|---|
+| Agentgateway | [services/llm-gateway-and-routing/agentgateway.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/llm-gateway-and-routing/agentgateway.md) |
+| Helicone | [services/llm-gateway-and-routing/helicone.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/llm-gateway-and-routing/helicone.md) |
+| Keywords AI | [services/llm-gateway-and-routing/keywords-ai.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/llm-gateway-and-routing/keywords-ai.md) |
+| LiteLLM | [services/llm-gateway-and-routing/litellm.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/llm-gateway-and-routing/litellm.md) |
+| OpenRouter | [services/llm-gateway-and-routing/openrouter.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/llm-gateway-and-routing/openrouter.md) |
+| Portkey | [services/llm-gateway-and-routing/portkey.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/llm-gateway-and-routing/portkey.md) |

--- a/docs/categories/meeting-and-conversation.md
+++ b/docs/categories/meeting-and-conversation.md
@@ -1,0 +1,15 @@
+---
+title: "Meeting And Conversation | Agent-Native Services"
+description: "Agent-native meeting and conversation services with onboarding links, MCP status, and official references."
+permalink: /categories/meeting-and-conversation/
+---
+
+> Category source: [services/meeting-and-conversation/README.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/meeting-and-conversation/README.md)
+
+## Services in this category
+
+| Service | Catalog Entry |
+|---|---|
+| Meeting BaaS | [services/meeting-and-conversation/meeting-baas.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/meeting-and-conversation/meeting-baas.md) |
+| MeetStream | [services/meeting-and-conversation/meetstream.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/meeting-and-conversation/meetstream.md) |
+| Recall.ai | [services/meeting-and-conversation/recall-ai.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/meeting-and-conversation/recall-ai.md) |

--- a/docs/categories/memory-and-state.md
+++ b/docs/categories/memory-and-state.md
@@ -1,0 +1,20 @@
+---
+title: "Memory And State | Agent-Native Services"
+description: "Agent-native memory and state services with onboarding links, MCP status, and official references."
+permalink: /categories/memory-and-state/
+---
+
+> Category source: [services/memory-and-state/README.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/README.md)
+
+## Services in this category
+
+| Service | Catalog Entry |
+|---|---|
+| Ensue | [services/memory-and-state/ensue.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/ensue.md) |
+| LycheeMem | [services/memory-and-state/lycheemem.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/lycheemem.md) |
+| Mem0 | [services/memory-and-state/mem0.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/mem0.md) |
+| mem9 | [services/memory-and-state/mem9.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/mem9.md) |
+| MemOS | [services/memory-and-state/memos.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/memos.md) |
+| memU | [services/memory-and-state/memu.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/memu.md) |
+| OpenViking | [services/memory-and-state/openviking.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/openviking.md) |
+| Zep | [services/memory-and-state/zep.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/zep.md) |

--- a/docs/categories/observability-and-tracing.md
+++ b/docs/categories/observability-and-tracing.md
@@ -1,0 +1,16 @@
+---
+title: "Observability And Tracing | Agent-Native Services"
+description: "Agent-native observability and tracing services with onboarding links, MCP status, and official references."
+permalink: /categories/observability-and-tracing/
+---
+
+> Category source: [services/observability-and-tracing/README.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/observability-and-tracing/README.md)
+
+## Services in this category
+
+| Service | Catalog Entry |
+|---|---|
+| AgentEvals | [services/observability-and-tracing/agentevals.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/observability-and-tracing/agentevals.md) |
+| AgentOps | [services/observability-and-tracing/agentops.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/observability-and-tracing/agentops.md) |
+| Braintrust | [services/observability-and-tracing/braintrust.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/observability-and-tracing/braintrust.md) |
+| Langfuse | [services/observability-and-tracing/langfuse.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/observability-and-tracing/langfuse.md) |

--- a/docs/categories/oversight-and-approval.md
+++ b/docs/categories/oversight-and-approval.md
@@ -1,0 +1,13 @@
+---
+title: "Oversight And Approval | Agent-Native Services"
+description: "Agent-native oversight and approval services with onboarding links, MCP status, and official references."
+permalink: /categories/oversight-and-approval/
+---
+
+> Category source: [services/oversight-and-approval/README.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/oversight-and-approval/README.md)
+
+## Services in this category
+
+| Service | Catalog Entry |
+|---|---|
+| HumanLayer | [services/oversight-and-approval/humanlayer.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/oversight-and-approval/humanlayer.md) |

--- a/docs/categories/search-and-web-intelligence.md
+++ b/docs/categories/search-and-web-intelligence.md
@@ -1,0 +1,16 @@
+---
+title: "Search And Web Intelligence | Agent-Native Services"
+description: "Agent-native search and web intelligence services with onboarding links, MCP status, and official references."
+permalink: /categories/search-and-web-intelligence/
+---
+
+> Category source: [services/search-and-web-intelligence/README.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/search-and-web-intelligence/README.md)
+
+## Services in this category
+
+| Service | Catalog Entry |
+|---|---|
+| Exa | [services/search-and-web-intelligence/exa.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/search-and-web-intelligence/exa.md) |
+| Jina Reader | [services/search-and-web-intelligence/jina-reader.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/search-and-web-intelligence/jina-reader.md) |
+| Parallel | [services/search-and-web-intelligence/parallel.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/search-and-web-intelligence/parallel.md) |
+| Tavily | [services/search-and-web-intelligence/tavily.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/search-and-web-intelligence/tavily.md) |

--- a/docs/categories/tool-access-and-integration.md
+++ b/docs/categories/tool-access-and-integration.md
@@ -1,0 +1,22 @@
+---
+title: "Tool Access And Integration | Agent-Native Services"
+description: "Agent-native tool access and integration services with onboarding links, MCP status, and official references."
+permalink: /categories/tool-access-and-integration/
+---
+
+> Category source: [services/tool-access-and-integration/README.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/README.md)
+
+## Services in this category
+
+| Service | Catalog Entry |
+|---|---|
+| Arcade | [services/tool-access-and-integration/arcade.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/arcade.md) |
+| ClawHub | [services/tool-access-and-integration/clawhub.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/clawhub.md) |
+| Composio | [services/tool-access-and-integration/composio.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/composio.md) |
+| Framelink MCP for Figma | [services/tool-access-and-integration/framelink-figma-mcp.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/framelink-figma-mcp.md) |
+| GitHub MCP Server | [services/tool-access-and-integration/github-mcp-server.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/github-mcp-server.md) |
+| MCP Toolbox for Databases | [services/tool-access-and-integration/google-mcp-toolbox.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/google-mcp-toolbox.md) |
+| MCP Gateway | [services/tool-access-and-integration/mcpgateway.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/mcpgateway.md) |
+| Nango | [services/tool-access-and-integration/nango.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/nango.md) |
+| Smithery | [services/tool-access-and-integration/smithery.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/smithery.md) |
+| Toolhouse | [services/tool-access-and-integration/toolhouse.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/toolhouse.md) |

--- a/docs/categories/voice-and-phone.md
+++ b/docs/categories/voice-and-phone.md
@@ -1,0 +1,15 @@
+---
+title: "Voice And Phone | Agent-Native Services"
+description: "Agent-native voice and phone services with onboarding links, MCP status, and official references."
+permalink: /categories/voice-and-phone/
+---
+
+> Category source: [services/voice-and-phone/README.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/voice-and-phone/README.md)
+
+## Services in this category
+
+| Service | Catalog Entry |
+|---|---|
+| LiveKit Agents | [services/voice-and-phone/livekit-agents.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/voice-and-phone/livekit-agents.md) |
+| Retell AI | [services/voice-and-phone/retell-ai.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/voice-and-phone/retell-ai.md) |
+| Vapi | [services/voice-and-phone/vapi.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/voice-and-phone/vapi.md) |

--- a/docs/index.md
+++ b/docs/index.md
@@ -464,4 +464,4 @@ Navigate by category to compare services faster:
 - [Tool Access And Integration]({{ '/categories/tool-access-and-integration/' | relative_url }})
 - [Voice And Phone]({{ '/categories/voice-and-phone/' | relative_url }})
 
-_Last content update (git commit time): 2026-04-16T00:53:31+08:00_
+_Last site build time: {{ site.time | date: '%Y-%m-%d %H:%M UTC' }}_

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ---
-title: "Awesome Agent-Native Services | Curated List for AI Agents"
-description: "Curated agent-native services and MCP tools for autonomous AI: communication, memory, browsers, sandboxes, and LLM gateways - full list on GitHub."
+title: "Awesome Agent-Native Services (2026) | MCP & Agent Infrastructure"
+description: "Best agent-native services in 2026: MCP tools, browser automation, memory, code sandboxes, observability, and agent infrastructure."
 image: /assets/images/social-preview.png
 ---
 
@@ -63,7 +63,7 @@ Source files are in `.skills/` in this repo. ClawHub CLI options (including the 
 
 | # | Category | Services | Description |
 |---|---|---|---|
-| 1 | [Communication](#1-communication-services) | 5 | Give agents a communication identity on the internet |
+| 1 | [Communication](#1-communication-services) | 6 | Give agents a communication identity on the internet |
 | 2 | [Browser & Web Execution](#2-browser--web-execution-services) | 17 | Remote browser and web data extraction for agents |
 | 3 | [Tool Access & Integration](#3-tool-access--integration-services) | 9 | Runtime tool discovery, auth, and execution |
 | 4 | [Oversight & Approval](#4-oversight--approval-services) | 1 | Human-in-the-loop approval and escalation |
@@ -71,7 +71,7 @@ Source files are in `.skills/` in this repo. ClawHub CLI options (including the 
 | 6 | [Agent Runtime & Infrastructure](#6-agent-runtime--infrastructure-services) | 17 | Execution, session isolation, secrets, and gateway |
 | 7 | [Memory & State](#7-memory--state-services) | 8 | Persistent agent memory across sessions |
 | 8 | [Search & Web Intelligence](#8-search--web-intelligence-services) | 4 | LLM-optimized web search and content retrieval |
-| 9 | [Code Execution](#9-code-execution-services) | 5 | Secure sandboxes for AI-generated code |
+| 9 | [Code Execution](#9-code-execution-services) | 6 | Secure sandboxes for AI-generated code |
 | 10 | [Observability & Tracing](#10-observability--tracing-services) | 4 | Agent trajectory tracing and evaluation |
 | 11 | [Durable Execution & Scheduling](#11-durable-execution--scheduling-services) | 5 | Fault-tolerant long-running agent workflows |
 | 12 | [Meeting & Conversation](#12-meeting--conversation-services) | 3 | Agent presence in voice and video meetings |
@@ -96,6 +96,7 @@ Source files are in `.skills/` in this repo. ClawHub CLI options (including the 
 | [mails.dev](services/communication/mails-dev.md) | Email for AI Agents | @mails.dev mailbox · Send/inbox · wait-for-code · Full-text search | ⚠️ | Read https://mails.dev/skill.md and follow the instructions |
 | [OpenMail](services/communication/openmail.md) | Email API for AI agents | One inbox per agent · Webhook/WebSocket inbound · RAG-ready attachment parsing | ⚠️ | `npm install -g @openmail/cli` → `openmail setup` — [docs.openmail.sh](https://docs.openmail.sh/quickstart) |
 | [MailboxKit](services/communication/mailboxkit.md) | Email infrastructure for AI agents | Per-agent address · REST v1 · Inbound webhooks · URL Onboarding | ⚠️ | Read https://mailboxkit.com/skill.md and follow the instructions |
+| [Agents Mail](services/communication/agents-mail.md) | Email for AI Agents | Agent registration · Inbox lifecycle · Send/reply API · URL Onboarding | ⚠️ | Read https://agentsmail.org/skill.md and follow the instructions |
 
 ---
 
@@ -257,6 +258,7 @@ Source files are in `.skills/` in this repo. ClawHub CLI options (including the 
 | [Runloop](services/code-execution/runloop.md) [![⭐](https://img.shields.io/github/stars/runloopai/api-client-python?style=social)](https://github.com/runloopai/api-client-python) | Your AI agent accelerator | Devbox micro-VM · Snapshot/branch disk state · Benchmark jobs · Suspend/resume | ✅ | `export RUNLOOP_API_KEY=...` → `npm install -g @runloop/rl-cli` → `rli mcp install` — [CLI docs](https://docs.runloop.ai/docs/tools/rl-cli) |
 | [Vercel Sandbox](services/code-execution/vercel-sandbox.md) [![⭐](https://img.shields.io/github/stars/vercel/sandbox?style=social)](https://github.com/vercel/sandbox) | Firecracker microVMs for AI-generated code | Node/Python runtimes · Snapshots · REST + `@vercel/sandbox` SDK | ❌ | `npm install @vercel/sandbox` — [vercel.com/docs/vercel-sandbox](https://vercel.com/docs/vercel-sandbox) |
 | [AIO Sandbox](services/code-execution/agent-infra-sandbox.md) [![⭐](https://img.shields.io/github/stars/agent-infra/sandbox?style=social)](https://github.com/agent-infra/sandbox) | All-in-one Docker sandbox for AI agents | Browser + shell + files + VS Code + Jupyter + MCP · Shared filesystem | ✅ | `docker run -p 8080:8080 ghcr.io/agent-infra/sandbox:latest` — MCP `http://localhost:8080/mcp` |
+| [Agent Sandbox](services/code-execution/agent-sandbox.md) | The trusted runtime for untrusted code | Hosted code sessions · Dependency install · Files/artifacts API · URL onboarding | ⚠️ | Read https://agentsandbox.co/skill.md and follow the instructions |
 
 ---
 
@@ -439,3 +441,27 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full submission guide, criteria c
 [![CC0](https://mirrors.creativecommons.org/presskit/buttons/88x31/svg/cc-zero.svg)](https://creativecommons.org/publicdomain/zero/1.0)
 
 To the extent possible under law, the contributors have waived all copyright and related rights to this work.
+
+---
+
+## Explore by category pages (SEO hub)
+
+Navigate by category to compare services faster:
+
+- [Agent Runtime And Infrastructure]({{ '/categories/agent-runtime-and-infrastructure/' | relative_url }})
+- [Agent Social Network]({{ '/categories/agent-social-network/' | relative_url }})
+- [Browser And Web Execution]({{ '/categories/browser-and-web-execution/' | relative_url }})
+- [Code Execution]({{ '/categories/code-execution/' | relative_url }})
+- [Commerce And Payments]({{ '/categories/commerce-and-payments/' | relative_url }})
+- [Communication]({{ '/categories/communication/' | relative_url }})
+- [Durable Execution And Scheduling]({{ '/categories/durable-execution-and-scheduling/' | relative_url }})
+- [Llm Gateway And Routing]({{ '/categories/llm-gateway-and-routing/' | relative_url }})
+- [Meeting And Conversation]({{ '/categories/meeting-and-conversation/' | relative_url }})
+- [Memory And State]({{ '/categories/memory-and-state/' | relative_url }})
+- [Observability And Tracing]({{ '/categories/observability-and-tracing/' | relative_url }})
+- [Oversight And Approval]({{ '/categories/oversight-and-approval/' | relative_url }})
+- [Search And Web Intelligence]({{ '/categories/search-and-web-intelligence/' | relative_url }})
+- [Tool Access And Integration]({{ '/categories/tool-access-and-integration/' | relative_url }})
+- [Voice And Phone]({{ '/categories/voice-and-phone/' | relative_url }})
+
+_Last content update (git commit time): 2026-04-16T00:53:31+08:00_

--- a/scripts/build-github-pages.sh
+++ b/scripts/build-github-pages.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
-# Generate docs/index.md from README.md and refresh the social preview image.
+# Generate docs/index.md from README.md, plus category landing pages for SEO/internal links.
 set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 DOCS="$ROOT/docs"
 README="$ROOT/README.md"
 INDEX="$DOCS/index.md"
+CAT_ROOT="$DOCS/categories"
 FONT="/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf"
 IMG_DIR="$DOCS/assets/images"
 IMG="$IMG_DIR/social-preview.png"
@@ -19,14 +20,84 @@ fi
 # Front matter for Jekyll SEO (meta description ~140–160 chars for search snippets)
 cat >"$INDEX" <<'YAML'
 ---
-title: "Awesome Agent-Native Services | Curated List for AI Agents"
-description: "Curated agent-native services and MCP tools for autonomous AI: communication, memory, browsers, sandboxes, and LLM gateways - full list on GitHub."
+title: "Awesome Agent-Native Services (2026) | MCP & Agent Infrastructure"
+description: "Best agent-native services in 2026: MCP tools, browser automation, memory, code sandboxes, observability, and agent infrastructure."
 image: /assets/images/social-preview.png
 ---
 
 YAML
 # Omit README line 1 — Jekyll theme already renders page.title as the on-page <h1>
 tail -n +2 "$README" >>"$INDEX"
+
+{
+  echo ""
+  echo "---"
+  echo ""
+  echo "## Explore by category pages (SEO hub)"
+  echo ""
+  echo "Navigate by category to compare services faster:"
+  echo ""
+  for dir in "$ROOT"/services/*; do
+    [[ -d "$dir" ]] || continue
+    slug="$(basename "$dir")"
+    pretty="$(echo "$slug" | tr '-' ' ')"
+    pretty="$(echo "$pretty" | sed -E 's/\b([a-z])/\U\1/g')"
+    echo "- [${pretty}]({{ '/categories/${slug}/' | relative_url }})"
+  done
+  echo ""
+  echo "_Last content update (git commit time): $(git -C "$ROOT" log -1 --format=%cI)_"
+} >>"$INDEX"
+
+# Generate category landing pages (spokes)
+rm -rf "$CAT_ROOT"
+mkdir -p "$CAT_ROOT"
+cat >"$CAT_ROOT/index.md" <<'YAML'
+---
+title: "Agent-Native Service Categories"
+description: "Browse agent-native services by category: communication, browser automation, MCP tools, memory, runtimes, and more."
+permalink: /categories/
+---
+
+This page helps search engines and humans discover the catalog through focused category landing pages.
+
+YAML
+
+for dir in "$ROOT"/services/*; do
+  [[ -d "$dir" ]] || continue
+  slug="$(basename "$dir")"
+  pretty="$(echo "$slug" | tr '-' ' ')"
+  pretty="$(echo "$pretty" | sed -E 's/\b([a-z])/\U\1/g')"
+  out="$CAT_ROOT/$slug.md"
+
+  {
+    cat <<YAML
+---
+title: "${pretty} | Agent-Native Services"
+description: "Agent-native ${pretty,,} services with onboarding links, MCP status, and official references."
+permalink: /categories/${slug}/
+---
+
+> Category source: [services/${slug}/README.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/${slug}/README.md)
+
+## Services in this category
+
+| Service | Catalog Entry |
+|---|---|
+YAML
+
+    for file in "$dir"/*.md; do
+      [[ -f "$file" ]] || continue
+      base="$(basename "$file")"
+      [[ "$base" == "README.md" ]] && continue
+      service_slug="${base%.md}"
+      service_title="$(sed -n '1{s/^# //;p;q;}' "$file")"
+      [[ -n "$service_title" ]] || service_title="$service_slug"
+      echo "| ${service_title} | [services/${slug}/${base}](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/${slug}/${base}) |"
+    done
+  } >"$out"
+
+  echo "- [${pretty}]({{ '/categories/${slug}/' | relative_url }})" >>"$CAT_ROOT/index.md"
+done
 
 # 1200×630 Open Graph image (solid brand color + title)
 if command -v ffmpeg >/dev/null 2>&1 && [[ -f "$FONT" ]]; then
@@ -44,3 +115,4 @@ else
 fi
 
 echo "Wrote $INDEX"
+echo "Wrote category pages under $CAT_ROOT"

--- a/scripts/build-github-pages.sh
+++ b/scripts/build-github-pages.sh
@@ -45,7 +45,7 @@ tail -n +2 "$README" >>"$INDEX"
     echo "- [${pretty}]({{ '/categories/${slug}/' | relative_url }})"
   done
   echo ""
-  echo "_Last content update (git commit time): $(git -C "$ROOT" log -1 --format=%cI)_"
+  echo "_Last site build time: {{ site.time | date: '%Y-%m-%d %H:%M UTC' }}_"
 } >>"$INDEX"
 
 # Generate category landing pages (spokes)


### PR DESCRIPTION
### Motivation

- Improve site SEO and navigation by generating per-category landing pages and linking them from the main docs index.
- Keep generated documentation in sync with source content by making regeneration part of the contribution checklist and enforcing it in CI.

### Description

- Added generation of category landing pages and an SEO hub to `scripts/build-github-pages.sh`, and updated OG metadata generation and index front-matter to the 2026 site title and description.
- Created many `docs/categories/*.md` files and updated `docs/index.md` and `docs/_config.yml` and `docs/_includes/head-custom.html` to include updated metadata and JSON-LD structured list data.
- Added a GitHub Actions workflow `/.github/workflows/validate-generated-docs.yml` that runs `bash scripts/build-github-pages.sh` and fails the run if `docs/index.md` or `docs/categories` are out of date.
- Updated the PR template `.github/PULL_REQUEST_TEMPLATE.md` to require regenerating docs with `bash scripts/build-github-pages.sh` when `README.md` or `services/**` are changed.

### Testing

- Ran `bash scripts/build-github-pages.sh` locally and it completed successfully, producing `docs/index.md` and the `docs/categories/` files as expected.
- Added CI job `Validate generated docs` which will run on pull requests and push to `main` to ensure generated docs are committed, and will return non-zero if files are out of date.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e048fa9e60832ea9b1e382e1ebb41f)