### PR TITLE
[New Service] Riza

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Source files are in `.skills/` in this repo. ClawHub CLI options (including the 
 | 6 | [Agent Runtime & Infrastructure](#6-agent-runtime--infrastructure-services) | 17 | Execution, session isolation, secrets, and gateway |
 | 7 | [Memory & State](#7-memory--state-services) | 8 | Persistent agent memory across sessions |
 | 8 | [Search & Web Intelligence](#8-search--web-intelligence-services) | 4 | LLM-optimized web search and content retrieval |
-| 9 | [Code Execution](#9-code-execution-services) | 6 | Secure sandboxes for AI-generated code |
+| 9 | [Code Execution](#9-code-execution-services) | 7 | Secure sandboxes for AI-generated code |
 | 10 | [Observability & Tracing](#10-observability--tracing-services) | 4 | Agent trajectory tracing and evaluation |
 | 11 | [Durable Execution & Scheduling](#11-durable-execution--scheduling-services) | 5 | Fault-tolerant long-running agent workflows |
 | 12 | [Meeting & Conversation](#12-meeting--conversation-services) | 3 | Agent presence in voice and video meetings |
@@ -254,6 +254,7 @@ Source files are in `.skills/` in this repo. ClawHub CLI options (including the 
 | [Vercel Sandbox](services/code-execution/vercel-sandbox.md) [![⭐](https://img.shields.io/github/stars/vercel/sandbox?style=social)](https://github.com/vercel/sandbox) | Firecracker microVMs for AI-generated code | Node/Python runtimes · Snapshots · REST + `@vercel/sandbox` SDK | ❌ | `npm install @vercel/sandbox` — [vercel.com/docs/vercel-sandbox](https://vercel.com/docs/vercel-sandbox) |
 | [AIO Sandbox](services/code-execution/agent-infra-sandbox.md) [![⭐](https://img.shields.io/github/stars/agent-infra/sandbox?style=social)](https://github.com/agent-infra/sandbox) | All-in-one Docker sandbox for AI agents | Browser + shell + files + VS Code + Jupyter + MCP · Shared filesystem | ✅ | `docker run -p 8080:8080 ghcr.io/agent-infra/sandbox:latest` — MCP `http://localhost:8080/mcp` |
 | [Agent Sandbox](services/code-execution/agent-sandbox.md) | The trusted runtime for untrusted code | Hosted code sessions · Dependency install · Files/artifacts API · URL onboarding | ⚠️ | Read https://agentsandbox.co/skill.md and follow the instructions |
+| [Riza](services/code-execution/riza.md) | AI writes code. Riza runs it. | Command Exec API · Tools API · Secrets · MCP · Self-hosting | ✅ | `uv add rizaio` then `riza.command.exec(...)` — [docs.riza.io](https://docs.riza.io/) |
 
 ---
 

--- a/docs/categories/code-execution.md
+++ b/docs/categories/code-execution.md
@@ -14,5 +14,6 @@ permalink: /categories/code-execution/
 | Agent Sandbox | [services/code-execution/agent-sandbox.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/agent-sandbox.md) |
 | Daytona | [services/code-execution/daytona.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/daytona.md) |
 | E2B | [services/code-execution/e2b.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/e2b.md) |
+| Riza | [services/code-execution/riza.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/riza.md) |
 | Runloop | [services/code-execution/runloop.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/runloop.md) |
 | Vercel Sandbox | [services/code-execution/vercel-sandbox.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/vercel-sandbox.md) |

--- a/docs/index.md
+++ b/docs/index.md
@@ -71,7 +71,7 @@ Source files are in `.skills/` in this repo. ClawHub CLI options (including the 
 | 6 | [Agent Runtime & Infrastructure](#6-agent-runtime--infrastructure-services) | 17 | Execution, session isolation, secrets, and gateway |
 | 7 | [Memory & State](#7-memory--state-services) | 8 | Persistent agent memory across sessions |
 | 8 | [Search & Web Intelligence](#8-search--web-intelligence-services) | 4 | LLM-optimized web search and content retrieval |
-| 9 | [Code Execution](#9-code-execution-services) | 6 | Secure sandboxes for AI-generated code |
+| 9 | [Code Execution](#9-code-execution-services) | 7 | Secure sandboxes for AI-generated code |
 | 10 | [Observability & Tracing](#10-observability--tracing-services) | 4 | Agent trajectory tracing and evaluation |
 | 11 | [Durable Execution & Scheduling](#11-durable-execution--scheduling-services) | 5 | Fault-tolerant long-running agent workflows |
 | 12 | [Meeting & Conversation](#12-meeting--conversation-services) | 3 | Agent presence in voice and video meetings |
@@ -259,6 +259,7 @@ Source files are in `.skills/` in this repo. ClawHub CLI options (including the 
 | [Vercel Sandbox](services/code-execution/vercel-sandbox.md) [![⭐](https://img.shields.io/github/stars/vercel/sandbox?style=social)](https://github.com/vercel/sandbox) | Firecracker microVMs for AI-generated code | Node/Python runtimes · Snapshots · REST + `@vercel/sandbox` SDK | ❌ | `npm install @vercel/sandbox` — [vercel.com/docs/vercel-sandbox](https://vercel.com/docs/vercel-sandbox) |
 | [AIO Sandbox](services/code-execution/agent-infra-sandbox.md) [![⭐](https://img.shields.io/github/stars/agent-infra/sandbox?style=social)](https://github.com/agent-infra/sandbox) | All-in-one Docker sandbox for AI agents | Browser + shell + files + VS Code + Jupyter + MCP · Shared filesystem | ✅ | `docker run -p 8080:8080 ghcr.io/agent-infra/sandbox:latest` — MCP `http://localhost:8080/mcp` |
 | [Agent Sandbox](services/code-execution/agent-sandbox.md) | The trusted runtime for untrusted code | Hosted code sessions · Dependency install · Files/artifacts API · URL onboarding | ⚠️ | Read https://agentsandbox.co/skill.md and follow the instructions |
+| [Riza](services/code-execution/riza.md) | AI writes code. Riza runs it. | Command Exec API · Tools API · Secrets · MCP · Self-hosting | ✅ | `uv add rizaio` then `riza.command.exec(...)` — [docs.riza.io](https://docs.riza.io/) |
 
 ---
 

--- a/services/code-execution/README.md
+++ b/services/code-execution/README.md
@@ -26,6 +26,7 @@ Agent-native code execution services solve this with:
 | [Vercel Sandbox](vercel-sandbox.md) [![⭐](https://img.shields.io/github/stars/vercel/sandbox?style=social)](https://github.com/vercel/sandbox) | Firecracker microVMs for AI-generated and untrusted code | `@vercel/sandbox` SDK, REST API, Sandbox CLI | ❌ |
 | [AIO Sandbox](agent-infra-sandbox.md) [![⭐](https://img.shields.io/github/stars/agent-infra/sandbox?style=social)](https://github.com/agent-infra/sandbox) | All-in-one Docker sandbox — browser, shell, VS Code, Jupyter, MCP | Docker image, OpenAPI, Python/JS/Go SDKs, MCP HTTP | ✅ |
 | [Agent Sandbox](agent-sandbox.md) | The trusted runtime for untrusted code | REST API, Python SDK, URL onboarding (`skill.md`) | ⚠️ |
+| [Riza](riza.md) | AI writes code. Riza runs it. | REST API, Python/TypeScript/Go SDKs, MCP server, self-hosting | ✅ |
 
 ---
 

--- a/services/code-execution/riza.md
+++ b/services/code-execution/riza.md
@@ -1,0 +1,153 @@
+# Riza
+
+> **"AI writes code. Riza runs it."**
+
+| | |
+|---|---|
+| **Website** | https://riza.io/ |
+| **Docs** | https://docs.riza.io/ |
+| **GitHub** | https://github.com/riza-io |
+| **Classification** | `agent-native` |
+| **Category** | [Code Execution Services](README.md) |
+| **Funding / Compliance** | API-first cloud with self-hosting option |
+
+---
+
+## Official Website
+
+https://riza.io/
+
+---
+
+## Official Repo
+
+https://github.com/riza-io
+
+---
+
+## How to Use (Agent Onboarding)
+
+**The quickest path for an agent to start using this service.**
+
+```bash
+uv add rizaio
+```
+
+Then execute generated code directly via the API/SDK:
+
+```python
+import rizaio
+riza = rizaio.Riza()
+response = riza.command.exec(code="print('Hello, World!')", language="python")
+```
+
+---
+
+## Agent Skills
+
+**Status:** ⚠️ Not yet published
+
+No official AgentSkills `SKILL.md` package is published by Riza as of April 2026.
+
+Search community skills: `npx clawhub@latest search riza`. For faster access in China, use the official ClawHub mirror: set `CLAWHUB_REGISTRY=https://cn.clawhub-mirror.com` or `--registry https://cn.clawhub-mirror.com` — [mirror-cn.clawhub.com](https://mirror-cn.clawhub.com).
+
+See: https://agentskills.io/specification to contribute one.
+
+---
+
+## MCP
+
+**Status:** ✅ Available
+
+| Detail | Value |
+|---|---|
+| **MCP Repo** | https://github.com/riza-io/riza-mcp |
+| **Transport** | stdio (package) |
+| **Compatible Clients** | Claude Desktop, Cursor, other MCP-compatible clients |
+
+---
+
+## What It Does
+
+Riza is a code-execution runtime built for AI systems that need to run untrusted, LLM-generated code safely and quickly. It provides an API-first execution layer with low startup latency, configurable network/env controls, and structured outputs (`stdout`, `stderr`, exit codes).
+
+Riza also supports tool-style execution patterns where agents can create reusable tools and execute them on demand, making it a strong fit for autonomous agents that need repeatable programmable actions.
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | Homepage: "AI writes code. Riza runs it." and "giving LLMs the ability to run code" (https://riza.io/) |
+| **Agent-specific primitive** | LLM code execution, reusable tool execution, and MCP integration for agent tool-use workflows |
+| **Autonomy-compatible control plane** | Agents can execute code via API without per-action human clicks; policy controls include execution isolation and runtime config |
+| **M2M integration surface** | REST API, Python/TypeScript/Go SDKs, MCP server |
+| **Identity / delegation** | API-key based project identity, execution-level configuration, and attributable tool/code runs per account |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **Command Exec API** | Executes untrusted code in isolated runtime and returns structured result artifacts |
+| **Tools API** | Save and invoke reusable agent-callable tools with schema-validated inputs |
+| **Secrets API** | Store secrets and attach them at execution time instead of injecting raw credentials into prompts |
+| **MCP Server** | Exposes Riza execution as MCP tools for standardized agent integrations |
+| **Self-Hosting** | Deploy Riza on your own infrastructure with similar API surface |
+
+---
+
+## Autonomy Model
+
+1. Agent receives a task requiring code execution or transformation.
+2. Agent generates code or picks a stored tool.
+3. Agent calls Riza via SDK/API/MCP with runtime constraints.
+4. Riza executes in isolated environment and returns structured outputs.
+5. Agent uses outputs to continue planning, retry, or produce final result.
+
+---
+
+## Identity and Delegation Model
+
+- Agent uses service credentials (API key / project-scoped auth) to execute actions.
+- Runtime policy is delegated at request-time (allowed hosts, env vars, resource constraints).
+- Executions are attributable to the calling account/project for auditability.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| REST API | Primary execution and tooling interface |
+| Python SDK | `rizaio` package for command/tool execution |
+| TypeScript SDK | Official JS/TS API client |
+| Go SDK | Official Go API client |
+| MCP | Official `riza-mcp` integration |
+
+---
+
+## Human-in-the-Loop Support
+
+Optional. Riza is designed for autonomous calls, but teams can insert review gates in their own orchestration layer before submitting execution requests.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **Generic serverless functions** | Not purpose-built for LLM-generated untrusted code; usually require app-specific deployment and lack agent-oriented tool primitives |
+| **Raw Docker on your own infra** | Requires manual sandbox lifecycle, scaling, and security engineering that Riza provides as an API-first agent runtime |
+| **Traditional CI runners** | Built for human/dev pipelines, not low-latency agent tool-calling loops |
+
+---
+
+## Use Cases
+
+- **LLM-generated code execution** in production agent loops.
+- **Data extraction/transformation agents** on heterogeneous inputs.
+- **Tool-writing agents** that generate and later reuse functions.
+- **Code-generation eval harnesses** for model/prompt iteration.

--- a/skill.md
+++ b/skill.md
@@ -57,7 +57,7 @@ These services can be joined with a single instruction, right now, with no human
 
 ---
 
-## Full Catalog — 15 Categories, 96+ Services
+## Full Catalog — 15 Categories, 97+ Services
 
 ### 1. Communication
 *Give agents a first-class communication identity on the internet.*
@@ -202,6 +202,7 @@ These services can be joined with a single instruction, right now, with no human
 | [Runloop](https://runloop.ai) | Your AI agent accelerator — Devboxes and benchmarks | `npm install -g @runloop/rl-cli` → `rli mcp install` — [CLI docs](https://docs.runloop.ai/docs/tools/rl-cli) |
 | [Vercel Sandbox](https://vercel.com/docs/vercel-sandbox) | Firecracker microVMs for AI-generated code | `npm install @vercel/sandbox` — [vercel.com/docs/vercel-sandbox](https://vercel.com/docs/vercel-sandbox) |
 | [AIO Sandbox](https://github.com/agent-infra/sandbox) | Browser + shell + VS Code + Jupyter + MCP in one Docker sandbox | `docker run -p 8080:8080 ghcr.io/agent-infra/sandbox:latest` — MCP `http://localhost:8080/mcp` |
+| [Riza](https://riza.io) | AI writes code. Riza runs it. | `uv add rizaio` → `riza.command.exec(...)` — [docs.riza.io](https://docs.riza.io) |
 
 ---
 


### PR DESCRIPTION
### Motivation
- Add a recent, well-known agent-native code-execution service to the catalog so agents and maintainers can discover a modern runtime for running LLM-generated code.
- Surface a service that provides MCP integration and self-hosting options within the existing Code Execution category for completeness and agent onboarding.

### Description
- Added `services/code-execution/riza.md` describing Riza with onboarding, MCP details, primitives, autonomy and identity models, protocol surface, and use cases. 
- Updated `services/code-execution/README.md` to include Riza in the Code Execution table. 
- Updated the root catalog `README.md` to increment the Code Execution count from `6` to `7` and add Riza's row with a short onboarding snippet. 
- Updated `skill.md` to increase the total catalog count from `96+` to `97+` and add Riza to the Code Execution onboarding list, and updated `docs/categories/code-execution.md` to include the new link.

### Testing
- Ran `git diff --check` to verify there are no whitespace/patch problems and it completed successfully. 
- Attempted a `python -m py_compile` check via an inline heredoc which failed due to incorrect invocation in the automation step (command usage error), not a repository Python syntax failure. 
- Verified changes were staged and committed (`git commit` completed for the changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1cbb5c4f0832e9ca8cc052e3f491e)