### PR TITLE
Add NotHumanSearch to Search & Web Intelligence

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Source files are in `.skills/` in this repo. ClawHub CLI options (including the 
 | 5 | [Commerce & Payments](#5-commerce--payment-services) | 6 | Agent-native wallets, identity, and transactions |
 | 6 | [Agent Runtime & Infrastructure](#6-agent-runtime--infrastructure-services) | 17 | Execution, session isolation, secrets, and gateway |
 | 7 | [Memory & State](#7-memory--state-services) | 8 | Persistent agent memory across sessions |
-| 8 | [Search & Web Intelligence](#8-search--web-intelligence-services) | 4 | LLM-optimized web search and content retrieval |
+| 8 | [Search & Web Intelligence](#8-search--web-intelligence-services) | 5 | LLM-optimized web search and content retrieval |
 | 9 | [Code Execution](#9-code-execution-services) | 7 | Secure sandboxes for AI-generated code |
 | 10 | [Observability & Tracing](#10-observability--tracing-services) | 4 | Agent trajectory tracing and evaluation |
 | 11 | [Durable Execution & Scheduling](#11-durable-execution--scheduling-services) | 5 | Fault-tolerant long-running agent workflows |
@@ -237,6 +237,7 @@ Source files are in `.skills/` in this repo. ClawHub CLI options (including the 
 | [Exa](services/search-and-web-intelligence/exa.md) | The search engine designed for AI | Neural/semantic search · `exa-code` for coding agents · Websets | ✅ | `pip install exa-py` then `exa.search(query)` |
 | [Parallel](services/search-and-web-intelligence/parallel.md) [![⭐](https://img.shields.io/github/stars/parallel-web/search-mcp?style=social)](https://github.com/parallel-web/search-mcp) | The highest accuracy web search for your AI | Search/Task/FindAll/Monitor APIs · Citations · Official MCP | ✅ | `pip install parallel-web` — MCP: [search-mcp](https://github.com/parallel-web/search-mcp) · [task-mcp](https://github.com/parallel-web/task-mcp) |
 | [Jina Reader](services/search-and-web-intelligence/jina-reader.md) [![⭐](https://img.shields.io/github/stars/jina-ai/reader?style=social)](https://github.com/jina-ai/reader) | URL and SERP as LLM-friendly text | `r.jina.ai` · `s.jina.ai` · MCP · PDF/images | ✅ | `curl "https://r.jina.ai/https://example.com"` — MCP: `mcp.jina.ai` |
+| [NotHumanSearch](services/search-and-web-intelligence/nothumansearch.md) | Agent-first search — the index of services designed for AI, not humans | `agentic_score` rank · `check_agent_readiness` · `verify_mcp` JSON-RPC probe · URL Onboarding | ✅ | Read https://nothumansearch.ai/llms.txt and follow the instructions — MCP: `https://nothumansearch.ai/mcp` |
 
 ---
 

--- a/services/search-and-web-intelligence/README.md
+++ b/services/search-and-web-intelligence/README.md
@@ -24,6 +24,7 @@ The services in this category were designed with these requirements as the prima
 | [Exa](exa.md) | The search engine designed for AI | REST API, Python SDK, LangChain/CrewAI/LlamaIndex/Mastra integrations | ✅ |
 | [Parallel](parallel.md) [![⭐](https://img.shields.io/github/stars/parallel-web/search-mcp?style=social)](https://github.com/parallel-web/search-mcp) | The highest accuracy web search for your AI | Search/Task/FindAll/Monitor APIs · SDKs · search-mcp & task-mcp | ✅ |
 | [Jina Reader](jina-reader.md) [![⭐](https://img.shields.io/github/stars/jina-ai/reader?style=social)](https://github.com/jina-ai/reader) | URL and search results as LLM-friendly text | `r.jina.ai` / `s.jina.ai` · MCP · PDF & image handling | ✅ |
+| [NotHumanSearch](nothumansearch.md) | Agent-first search — the index of services designed for AI, not humans | REST API · OpenAPI 3.0 · MCP (`ai.nothumansearch/search`) · `llms.txt` onboarding | ✅ |
 
 ---
 

--- a/services/search-and-web-intelligence/nothumansearch.md
+++ b/services/search-and-web-intelligence/nothumansearch.md
@@ -1,0 +1,134 @@
+# NotHumanSearch
+
+> **"Agent-first search — the index of services designed for AI, not humans."**
+
+| | |
+|---|---|
+| **Website** | https://nothumansearch.ai |
+| **Docs** | https://nothumansearch.ai/llms.txt |
+| **OpenAPI** | https://nothumansearch.ai/openapi.yaml |
+| **MCP** | https://nothumansearch.ai/mcp |
+| **Classification** | `agent-native` |
+| **Category** | [Search & Web Intelligence Services](README.md) |
+
+---
+
+## Official Website
+
+https://nothumansearch.ai
+
+---
+
+## Agent Onboarding (URL Onboarding)
+
+Point any agent at the `llms.txt` to discover capabilities, primitives, and the MCP endpoint in one fetch:
+
+```
+Read https://nothumansearch.ai/llms.txt and follow the instructions.
+```
+
+No account, no SDK install, no dashboard click — the agent reads the onboarding doc and can begin calling the search, scoring, and verification tools immediately.
+
+---
+
+## MCP
+
+**Status:** ✅ Available — published to the official [Model Context Protocol registry](https://github.com/modelcontextprotocol/registry) as `ai.nothumansearch/search` (latest v1.5.0).
+
+| Detail | Value |
+|---|---|
+| **Endpoint** | `https://nothumansearch.ai/mcp` |
+| **Transport** | Streamable HTTP (JSON-RPC 2.0) |
+| **Registry** | [modelcontextprotocol/registry](https://github.com/modelcontextprotocol/registry) — `ai.nothumansearch/search` |
+| **Tools** | `search_sites`, `get_site`, `check_agent_readiness`, `verify_mcp`, `list_categories`, `get_top_sites`, `submit_site`, `monitor_site` |
+
+---
+
+## What It Does
+
+NotHumanSearch is a search engine whose index only contains sites that are actually usable by AI agents. Every indexed site must ship at least one real agent signal — `llms.txt`, `ai-plugin.json`, OpenAPI spec, MCP server, or a structured REST API with machine-readable schemas. Sites are scored on an agent-readiness scale and ranked so that the most agent-ready result wins, not the one with the most backlinks.
+
+Where general web search returns HTML pages written for humans, NHS returns a ranked list of services an agent can *immediately consume* — with an `agentic_score`, the MCP endpoint URL if present, the `llms.txt` URL if present, and category tags already attached.
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | Name, homepage tagline, and entire index thesis is "for AI agents, not humans." Every result is filtered by machine-readability signals. |
+| **Agent-specific primitive** | `agentic_score` (0–100 readiness index), `check_agent_readiness(url)` live scorer, `verify_mcp(url)` JSON-RPC probe — none of these exist in human search engines. |
+| **Autonomy-compatible control plane** | Agent calls `search_sites` or `GET /api/v1/search?q=` and gets JSON back; no login, no CAPTCHA, no rate-limited-for-scrapers friction. Rate limits expose `X-RateLimit-*` headers so agents can pace themselves. |
+| **M2M integration surface** | REST API (OpenAPI 3.0 at `/openapi.yaml`), MCP server at `/mcp`, `llms.txt` for discovery, `ai-plugin.json` manifest, `Link: <…>; rel="alternate"` header on every response. No dashboard required. |
+| **Agent identity / delegation** | API-key-per-agent (optional); all search and scoring calls are read-only and attributed to the calling key. No user impersonation surface. |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **`search_sites(query, category?, min_score?, per_page?)`** | Full-text + semantic rank across the agent-native index, sorted by `agentic_score` with text-match tiebreaker |
+| **`check_agent_readiness(url)`** | Live probe: fetches `llms.txt`, `ai-plugin.json`, `/openapi.yaml`, robots.txt, structured data — returns a score and the exact signals found/missing |
+| **`verify_mcp(url)`** | Real JSON-RPC probe of the candidate MCP endpoint — distinguishes actual MCP servers from sites that merely mention MCP |
+| **`get_site(slug)`** | Full metadata for an indexed site including category, tags, score history, agent-signal inventory |
+| **`list_categories` / `get_top_sites`** | Category discovery and top-by-score browsing for agents building directories |
+| **`submit_site(url)`** | Agent-submittable inclusion endpoint — no human gatekeeper |
+| **`monitor_site(url)`** | Weekly recrawl alerts when an indexed site loses an agent signal (e.g., `llms.txt` returns 404) |
+
+---
+
+## Why This Is Different from Generic Web Search
+
+| Alternative | Why It Is Not Sufficient for Agents |
+|---|---|
+| **Google / Bing Search API** | Indexes HTML for human readers; no filter for agent-readiness; `agentic_score` concept does not exist; results require HTML parsing before LLM use |
+| **Exa / Tavily / Jina Reader** | Return LLM-ready *web content*, but the corpus is the whole human web — not curated to sites that expose `llms.txt`, MCP, or structured APIs |
+| **Awesome-lists of MCP servers** | Static, human-maintained, not searchable over HTTP, no scoring, no live verification |
+
+NHS is to the agent web what DNS is to the human web — a discovery layer whose sole job is returning *working, agent-usable endpoints*.
+
+---
+
+## Autonomy Model
+
+1. Agent reads `https://nothumansearch.ai/llms.txt` to discover endpoints
+2. Agent calls `search_sites(query="vector database")` via MCP or REST
+3. NHS returns top N sites with `agentic_score`, `mcp_url`, `llms_url`, `openapi_url`, `tags` already attached
+4. Agent picks the highest-scoring result and calls its MCP/API directly — no HTML scrape, no human step
+
+---
+
+## Identity and Delegation Model
+
+- Anonymous access for all search/read tools (rate-limited per-IP)
+- Optional API key per agent for higher limits; keys are attributable in logs
+- No user-impersonation surface — NHS is a read-only discovery layer
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| REST API | `GET /api/v1/search`, `/api/v1/check`, `/api/v1/submit`, `/api/v1/monitor/register` — OpenAPI 3.0 |
+| MCP | Streamable HTTP transport at `/mcp`; 8 tools; published to MCP registry |
+| `llms.txt` | Machine-readable onboarding at `/llms.txt` |
+| `ai-plugin.json` | ChatGPT-style plugin manifest |
+| Webhook | Per-site change alerts via `/api/v1/monitor/register` |
+
+---
+
+## Human-in-the-Loop Support
+
+None required for search, check, or verify. Site submission is automated; curation rejections (sites without real agent signals) are also automated.
+
+---
+
+## Use Cases
+
+- **Agent discovery** — an agent needs "a service that does X" and finds one with `llms.txt` already published
+- **Tool-selection agents** — build dynamic tool catalogs filtered by `agentic_score ≥ 75`
+- **MCP-aware routers** — `verify_mcp` before wiring a new MCP server into the agent runtime
+- **Agent-readiness audits** — score your own service with `check_agent_readiness(url)` and get a list of missing signals
+- **Monitoring** — get alerted when a dependency's agent surface regresses


### PR DESCRIPTION
## Summary

Adds [NotHumanSearch](https://nothumansearch.ai) to **8. Search & Web Intelligence Services** as the 5th entry.

NotHumanSearch is an agent-first search engine whose index only contains sites shipping real agent signals (`llms.txt`, `ai-plugin.json`, OpenAPI, MCP, structured APIs). Results are ranked by an `agentic_score` and returned as JSON the LLM can consume directly — no HTML parsing.

## Why it qualifies (the five hard criteria)

1. **Agent-first positioning** — Name and homepage tagline: *\"Agent-first search — the index of services designed for AI, not humans.\"* The entire ranking model filters for agent-readiness; human users are not a target segment.
2. **Agent-specific primitives** — `agentic_score` (0-100), `check_agent_readiness(url)` live scorer, `verify_mcp(url)` JSON-RPC probe. None of these primitives have human-facing equivalents.
3. **Autonomy-compatible control plane** — No login, no CAPTCHA. Rate limits expose `X-RateLimit-*` headers for self-pacing. Submission is agent-automated.
4. **M2M integration surface** — REST API (`OpenAPI 3.0` at `/openapi.yaml`), MCP server at `/mcp`, `llms.txt`, `ai-plugin.json`, `Link: rel=\"alternate\"` header on every response.
5. **Agent identity / delegation** — Optional per-agent API key; read-only surface, so no user-impersonation concerns.

## Bonus signals

- **URL Onboarding** — `Read https://nothumansearch.ai/llms.txt and follow the instructions.`
- **MCP registry** — Published to the [official MCP registry](https://github.com/modelcontextprotocol/registry) as `ai.nothumansearch/search` (v1.5.0).
- **Eight MCP tools** — `search_sites`, `get_site`, `check_agent_readiness`, `verify_mcp`, `list_categories`, `get_top_sites`, `submit_site`, `monitor_site`.

## Changes

- New file: `services/search-and-web-intelligence/nothumansearch.md`
- Updated `services/search-and-web-intelligence/README.md` service table
- Updated root `README.md` category count (4 -> 5) and section 8 table

## Disclosure

I maintain NotHumanSearch. Happy to revise any wording, add a `SKILL.md`, or open a preceding issue if the maintainer prefers the full issue-first workflow.