### PR TITLE
Regenerate generated docs to include NotHumanSearch (fix validate-generated-docs CI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,6 +433,18 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full submission guide, criteria c
 
 ---
 
+## Star History
+
+<a href="https://www.star-history.com/?repos=haoruilee%2Fawesome-agent-native-services&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=haoruilee/awesome-agent-native-services&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=haoruilee/awesome-agent-native-services&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=haoruilee/awesome-agent-native-services&type=date&legend=top-left" />
+ </picture>
+</a>
+
+---
+
 ## License
 
 [![CC0](https://mirrors.creativecommons.org/presskit/buttons/88x31/svg/cc-zero.svg)](https://creativecommons.org/publicdomain/zero/1.0)

--- a/docs/categories/search-and-web-intelligence.md
+++ b/docs/categories/search-and-web-intelligence.md
@@ -12,5 +12,6 @@ permalink: /categories/search-and-web-intelligence/
 |---|---|
 | Exa | [services/search-and-web-intelligence/exa.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/search-and-web-intelligence/exa.md) |
 | Jina Reader | [services/search-and-web-intelligence/jina-reader.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/search-and-web-intelligence/jina-reader.md) |
+| NotHumanSearch | [services/search-and-web-intelligence/nothumansearch.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/search-and-web-intelligence/nothumansearch.md) |
 | Parallel | [services/search-and-web-intelligence/parallel.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/search-and-web-intelligence/parallel.md) |
 | Tavily | [services/search-and-web-intelligence/tavily.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/search-and-web-intelligence/tavily.md) |

--- a/docs/index.md
+++ b/docs/index.md
@@ -438,6 +438,18 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full submission guide, criteria c
 
 ---
 
+## Star History
+
+<a href="https://www.star-history.com/?repos=haoruilee%2Fawesome-agent-native-services&type=date&legend=top-left">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=haoruilee/awesome-agent-native-services&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=haoruilee/awesome-agent-native-services&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=haoruilee/awesome-agent-native-services&type=date&legend=top-left" />
+ </picture>
+</a>
+
+---
+
 ## License
 
 [![CC0](https://mirrors.creativecommons.org/presskit/buttons/88x31/svg/cc-zero.svg)](https://creativecommons.org/publicdomain/zero/1.0)

--- a/docs/index.md
+++ b/docs/index.md
@@ -70,7 +70,7 @@ Source files are in `.skills/` in this repo. ClawHub CLI options (including the 
 | 5 | [Commerce & Payments](#5-commerce--payment-services) | 6 | Agent-native wallets, identity, and transactions |
 | 6 | [Agent Runtime & Infrastructure](#6-agent-runtime--infrastructure-services) | 17 | Execution, session isolation, secrets, and gateway |
 | 7 | [Memory & State](#7-memory--state-services) | 8 | Persistent agent memory across sessions |
-| 8 | [Search & Web Intelligence](#8-search--web-intelligence-services) | 4 | LLM-optimized web search and content retrieval |
+| 8 | [Search & Web Intelligence](#8-search--web-intelligence-services) | 5 | LLM-optimized web search and content retrieval |
 | 9 | [Code Execution](#9-code-execution-services) | 7 | Secure sandboxes for AI-generated code |
 | 10 | [Observability & Tracing](#10-observability--tracing-services) | 4 | Agent trajectory tracing and evaluation |
 | 11 | [Durable Execution & Scheduling](#11-durable-execution--scheduling-services) | 5 | Fault-tolerant long-running agent workflows |
@@ -242,6 +242,7 @@ Source files are in `.skills/` in this repo. ClawHub CLI options (including the 
 | [Exa](services/search-and-web-intelligence/exa.md) | The search engine designed for AI | Neural/semantic search · `exa-code` for coding agents · Websets | ✅ | `pip install exa-py` then `exa.search(query)` |
 | [Parallel](services/search-and-web-intelligence/parallel.md) [![⭐](https://img.shields.io/github/stars/parallel-web/search-mcp?style=social)](https://github.com/parallel-web/search-mcp) | The highest accuracy web search for your AI | Search/Task/FindAll/Monitor APIs · Citations · Official MCP | ✅ | `pip install parallel-web` — MCP: [search-mcp](https://github.com/parallel-web/search-mcp) · [task-mcp](https://github.com/parallel-web/task-mcp) |
 | [Jina Reader](services/search-and-web-intelligence/jina-reader.md) [![⭐](https://img.shields.io/github/stars/jina-ai/reader?style=social)](https://github.com/jina-ai/reader) | URL and SERP as LLM-friendly text | `r.jina.ai` · `s.jina.ai` · MCP · PDF/images | ✅ | `curl "https://r.jina.ai/https://example.com"` — MCP: `mcp.jina.ai` |
+| [NotHumanSearch](services/search-and-web-intelligence/nothumansearch.md) | Agent-first search — the index of services designed for AI, not humans | `agentic_score` rank · `check_agent_readiness` · `verify_mcp` JSON-RPC probe · URL Onboarding | ✅ | Read https://nothumansearch.ai/llms.txt and follow the instructions — MCP: `https://nothumansearch.ai/mcp` |
 
 ---
 


### PR DESCRIPTION
### Motivation
- The `validate-generated-docs` job failed because generated documentation was out of date after adding the `NotHumanSearch` catalog entry in `services/search-and-web-intelligence/`.

### Description
- Regenerated the GitHub Pages artifacts so generated content reflects the new `NotHumanSearch` service entry.
- Updated `docs/index.md` to increment the Search & Web Intelligence service count and include the new table row.
- Updated `docs/categories/search-and-web-intelligence.md` to list `NotHumanSearch` in the category page.

### Testing
- Ran the site generation script `bash scripts/build-github-pages.sh` successfully. 
- Verified the generated files `docs/index.md` and `docs/categories/search-and-web-intelligence.md` were updated and match the current source state (validation equivalent to the CI check passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e392892a08832ebb9233079f833a13)