### PR TITLE
docs: regenerate GitHub Pages index

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -439,18 +439,6 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full submission guide, criteria c
 
 ---
 
-## Star History
-
-<a href="https://www.star-history.com/?repos=haoruilee%2Fawesome-agent-native-services&type=date&legend=top-left">
- <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=haoruilee/awesome-agent-native-services&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=haoruilee/awesome-agent-native-services&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=haoruilee/awesome-agent-native-services&type=date&legend=top-left" />
- </picture>
-</a>
-
----
-
 ## License
 
 [![CC0](https://mirrors.creativecommons.org/presskit/buttons/88x31/svg/cc-zero.svg)](https://creativecommons.org/publicdomain/zero/1.0)


### PR DESCRIPTION
### Motivation
- Regenerate the GitHub Pages output so the generated site and repository stay in sync and to remove a stale "Star History" block from the public index.

### Description
- Ran the site generation to produce updated documentation and updated `docs/index.md` to match the generated output by removing the obsolete Star History section so the index flows from Contributing to License.

### Testing
- Ran `bash scripts/build-github-pages.sh` (succeeded) and verified the generated-docs diff check reported out-of-date before regeneration and no outstanding generated-docs changes afterwards, with the working tree clean.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb0dfbe1e0832eb4f252cac757f510)