### PR TITLE
fix: add GitHub sponsor handle to .github/FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,4 +1,7 @@
+# GitHub reads this file to render the "Sponsor" button on the repository page.
+# Keep at most 4 custom links.
+github: [haoruilee]
 custom:
-  - 'https://buy.stripe.com/4gM6oJ5KU7MX0Ewe3S0Ny02'
-  - 'https://buy.stripe.com/7sYbJ31uE9V55YQf7W0Ny04'
-  - 'https://buy.stripe.com/fZu14pddm2sD3QIgc00Ny03'
+  - https://buy.stripe.com/4gM6oJ5KU7MX0Ewe3S0Ny02
+  - https://buy.stripe.com/7sYbJ31uE9V55YQf7W0Ny04
+  - https://buy.stripe.com/fZu14pddm2sD3QIgc00Ny03


### PR DESCRIPTION
### Motivation
- Ensure GitHub can surface a native Sponsor target on the repository page by providing an explicit GitHub Sponsors handle in the funding configuration.

### Description
- Added `github: [haoruilee]` to `.github/FUNDING.yml`, preserved the existing `custom` Stripe links, normalized YAML formatting, and added top-line comments explaining that the file controls the repository Sponsor button.

### Testing
- Parsed the file with `ruby -ryaml -e 'p YAML.load_file(".github/FUNDING.yml")'` which succeeded, inspected the patch with `git diff -- .github/FUNDING.yml`, and committed the change with `git commit`; a Python-based YAML check using `PyYAML` failed only because the `yaml` module is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec366194f8832ea5a16cd312b93d64)