### PR TITLE
[Update] Add MCP Agent Mail and MCP Agent Mail (Rust) to Communication catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Source files are in `.skills/` in this repo. ClawHub CLI options (including the 
 
 | # | Category | Services | Description |
 |---|---|---|---|
-| 1 | [Communication](#1-communication-services) | 6 | Give agents a communication identity on the internet |
+| 1 | [Communication](#1-communication-services) | 8 | Give agents a communication identity on the internet |
 | 2 | [Browser & Web Execution](#2-browser--web-execution-services) | 18 | Remote browser and web data extraction for agents |
 | 3 | [Tool Access & Integration](#3-tool-access--integration-services) | 9 | Runtime tool discovery, auth, and execution |
 | 4 | [Oversight & Approval](#4-oversight--approval-services) | 1 | Human-in-the-loop approval and escalation |
@@ -92,6 +92,8 @@ Source files are in `.skills/` in this repo. ClawHub CLI options (including the 
 | [OpenMail](services/communication/openmail.md) | Email API for AI agents | One inbox per agent · Webhook/WebSocket inbound · RAG-ready attachment parsing | ⚠️ | `npm install -g @openmail/cli` → `openmail setup` — [docs.openmail.sh](https://docs.openmail.sh/quickstart) |
 | [MailboxKit](services/communication/mailboxkit.md) | Email infrastructure for AI agents | Per-agent address · REST v1 · Inbound webhooks · URL Onboarding | ⚠️ | Read https://mailboxkit.com/skill.md and follow the instructions |
 | [Agents Mail](services/communication/agents-mail.md) | Email for AI Agents | Agent registration · Inbox lifecycle · Send/reply API · URL Onboarding | ⚠️ | Read https://agentsmail.org/skill.md and follow the instructions |
+| [MCP Agent Mail](services/communication/mcp-agent-mail.md) [![⭐](https://img.shields.io/github/stars/Dicklesworthstone/mcp_agent_mail?style=social)](https://github.com/Dicklesworthstone/mcp_agent_mail) | Async coordination layer for AI coding agents | Agent identity · Inbox/outbox · Thread search · Advisory file reservations | ✅ | `uvx mcp_agent_mail` then connect MCP client and call `register_agent`/`send_message` |
+| [MCP Agent Mail (Rust)](services/communication/mcp-agent-mail-rust.md) [![⭐](https://img.shields.io/github/stars/Dicklesworthstone/mcp_agent_mail_rust?style=social)](https://github.com/Dicklesworthstone/mcp_agent_mail_rust) | It's like Gmail for your coding agents | 30+ MCP tools · 20+ resources · Git-backed archive · TUI/robot CLI | ✅ | `curl -fsSL \"https://raw.githubusercontent.com/Dicklesworthstone/mcp_agent_mail_rust/main/install.sh?$(date +%s)\" \| bash` then `am` |
 
 ---
 

--- a/docs/categories/communication.md
+++ b/docs/categories/communication.md
@@ -14,5 +14,7 @@ permalink: /categories/communication/
 | Agents Mail | [services/communication/agents-mail.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/communication/agents-mail.md) |
 | MailboxKit | [services/communication/mailboxkit.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/communication/mailboxkit.md) |
 | mails.dev | [services/communication/mails-dev.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/communication/mails-dev.md) |
+| MCP Agent Mail (Rust) | [services/communication/mcp-agent-mail-rust.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/communication/mcp-agent-mail-rust.md) |
+| MCP Agent Mail | [services/communication/mcp-agent-mail.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/communication/mcp-agent-mail.md) |
 | Novu | [services/communication/novu.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/communication/novu.md) |
 | OpenMail | [services/communication/openmail.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/communication/openmail.md) |

--- a/docs/index.md
+++ b/docs/index.md
@@ -63,7 +63,7 @@ Source files are in `.skills/` in this repo. ClawHub CLI options (including the 
 
 | # | Category | Services | Description |
 |---|---|---|---|
-| 1 | [Communication](#1-communication-services) | 6 | Give agents a communication identity on the internet |
+| 1 | [Communication](#1-communication-services) | 8 | Give agents a communication identity on the internet |
 | 2 | [Browser & Web Execution](#2-browser--web-execution-services) | 18 | Remote browser and web data extraction for agents |
 | 3 | [Tool Access & Integration](#3-tool-access--integration-services) | 9 | Runtime tool discovery, auth, and execution |
 | 4 | [Oversight & Approval](#4-oversight--approval-services) | 1 | Human-in-the-loop approval and escalation |
@@ -97,6 +97,8 @@ Source files are in `.skills/` in this repo. ClawHub CLI options (including the 
 | [OpenMail](services/communication/openmail.md) | Email API for AI agents | One inbox per agent · Webhook/WebSocket inbound · RAG-ready attachment parsing | ⚠️ | `npm install -g @openmail/cli` → `openmail setup` — [docs.openmail.sh](https://docs.openmail.sh/quickstart) |
 | [MailboxKit](services/communication/mailboxkit.md) | Email infrastructure for AI agents | Per-agent address · REST v1 · Inbound webhooks · URL Onboarding | ⚠️ | Read https://mailboxkit.com/skill.md and follow the instructions |
 | [Agents Mail](services/communication/agents-mail.md) | Email for AI Agents | Agent registration · Inbox lifecycle · Send/reply API · URL Onboarding | ⚠️ | Read https://agentsmail.org/skill.md and follow the instructions |
+| [MCP Agent Mail](services/communication/mcp-agent-mail.md) [![⭐](https://img.shields.io/github/stars/Dicklesworthstone/mcp_agent_mail?style=social)](https://github.com/Dicklesworthstone/mcp_agent_mail) | Async coordination layer for AI coding agents | Agent identity · Inbox/outbox · Thread search · Advisory file reservations | ✅ | `uvx mcp_agent_mail` then connect MCP client and call `register_agent`/`send_message` |
+| [MCP Agent Mail (Rust)](services/communication/mcp-agent-mail-rust.md) [![⭐](https://img.shields.io/github/stars/Dicklesworthstone/mcp_agent_mail_rust?style=social)](https://github.com/Dicklesworthstone/mcp_agent_mail_rust) | It's like Gmail for your coding agents | 30+ MCP tools · 20+ resources · Git-backed archive · TUI/robot CLI | ✅ | `curl -fsSL \"https://raw.githubusercontent.com/Dicklesworthstone/mcp_agent_mail_rust/main/install.sh?$(date +%s)\" \| bash` then `am` |
 
 ---
 

--- a/services/communication/README.md
+++ b/services/communication/README.md
@@ -16,6 +16,8 @@ Human communication infrastructure (Gmail, Outlook, Slack) was built around the 
 | [OpenMail](openmail.md) | Email API for AI agents | REST API, WebSocket, Webhooks, CLI (`@openmail/cli`) | ⚠️ |
 | [MailboxKit](mailboxkit.md) | Email infrastructure for AI agents | REST API v1, Webhooks, URL Onboarding (`skill.md`) | ⚠️ |
 | [Agents Mail](agents-mail.md) | Email for AI Agents | REST API, URL Onboarding (`skill.md`), `.well-known/agent.json` discovery | ⚠️ |
+| [MCP Agent Mail](mcp-agent-mail.md) | Async coordination layer for AI coding agents | MCP tools/resources, FastMCP, Git + SQLite | ✅ |
+| [MCP Agent Mail (Rust)](mcp-agent-mail-rust.md) | "Gmail for coding agents" with high-performance MCP runtime | MCP tools/resources, local HTTP runtime, TUI + robot CLI | ✅ |
 
 ---
 

--- a/services/communication/mcp-agent-mail-rust.md
+++ b/services/communication/mcp-agent-mail-rust.md
@@ -1,0 +1,147 @@
+# MCP Agent Mail (Rust)
+
+> **"It's like Gmail for your coding agents!"**
+
+| | |
+|---|---|
+| **Website** | https://github.com/Dicklesworthstone/mcp_agent_mail_rust |
+| **Docs** | https://github.com/Dicklesworthstone/mcp_agent_mail_rust/blob/main/README.md |
+| **GitHub** | https://github.com/Dicklesworthstone/mcp_agent_mail_rust |
+| **Classification** | `agent-native` |
+| **Category** | [Communication Services](README.md) |
+
+---
+
+## Official Website
+
+https://github.com/Dicklesworthstone/mcp_agent_mail_rust
+
+---
+
+## Official Repo
+
+https://github.com/Dicklesworthstone/mcp_agent_mail_rust
+
+---
+
+## How to Use (Agent Onboarding)
+
+**The quickest path for an agent to start using this service.**
+
+Install and start the Rust server:
+
+```bash
+curl -fsSL "https://raw.githubusercontent.com/Dicklesworthstone/mcp_agent_mail_rust/main/install.sh?$(date +%s)" | bash
+am
+```
+
+This boots the Agent Mail runtime (default local HTTP endpoint) and exposes MCP tools/resources for multi-agent collaboration.
+
+---
+
+## Agent Skills
+
+**Status:** ⚠️ No official first-party `SKILL.md` package published (as of April 2026).
+
+Search community skills:
+
+```bash
+npx clawhub@latest search "agent mail"
+```
+
+---
+
+## MCP
+
+**Status:** ✅ Available
+
+| Detail | Value |
+|---|---|
+| **MCP server** | Built-in (`am` runtime) |
+| **Tools** | 30+ tools (agent registration, messaging, reservations, macros) |
+| **Resources** | 20+ read-only resources for inbox/thread/project/tooling state |
+| **Client compatibility** | Claude Code, Codex CLI, Gemini CLI, Copilot CLI, and generic MCP clients |
+
+---
+
+## What It Does
+
+MCP Agent Mail (Rust) is a high-performance, production-grade coordination layer for autonomous coding agents. It provides mailbox identities, asynchronous threaded messaging, advisory file leases, and state/resource APIs optimized for concurrent multi-agent software delivery.
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | README frames the product as coordination infrastructure specifically for coding agents |
+| **Agent-specific primitive** | Agent mailboxes + advisory file reservations + MCP macros are primitives tailored to agent swarms |
+| **Autonomy-compatible control plane** | Agents can register, communicate, reserve files, and coordinate without per-step human confirmation |
+| **M2M integration surface** | MCP tools/resources and CLI runtime are the primary operational interface |
+| **Identity / delegation** | Named per-agent identities, per-project scopes, and attributable actions across message/reservation events |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **Persistent agent identities** | Stable agent mailbox identities for long-running collaborations |
+| **Threaded asynchronous messaging** | Structured messages across multiple cooperating agents |
+| **Advisory file reservations** | TTL-based file/glob leases to prevent accidental edit conflicts |
+| **Macro tools** | Composite MCP operations for faster small-model coordination loops |
+| **Diagnostics/ops surfaces** | TUI + resource views + operational health tools for reliable autonomous execution |
+
+---
+
+## Autonomy Model
+
+1. Agent runtime boots `am` and exposes MCP surface.
+2. Each agent registers identity in a project context.
+3. Agents coordinate via threads/messages instead of chat-room broadcast.
+4. Agents set file reservations before editing and resolve conflicts programmatically.
+5. Agents consume MCP resources to recover state after restarts and continue execution.
+
+---
+
+## Identity and Delegation Model
+
+- **Identity:** Named, project-scoped agent identities.
+- **Delegation:** Task ownership and message routing occur at agent identity layer.
+- **Auditability:** Git-backed artifacts + SQLite index provide traceable history for each action.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| MCP tools | Write/mutate operations for agent, message, reservation lifecycle |
+| MCP resources | Read-only views for mailbox, threads, agents, reservations, diagnostics |
+| Local HTTP runtime | Default local endpoint for connected clients |
+| TUI / robot CLI | Operator and automation interfaces over the same backing state |
+
+---
+
+## Human-in-the-Loop Support
+
+Optional. Humans can inspect/operate through TUI or web views, while autonomous agent loops remain first-class.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **Generic team chat tools** | Not built for autonomous agent identity, MCP-native coordination, or file lease semantics |
+| **Plain task boards** | Missing real-time mailbox protocol and per-message tooling contracts for agent loops |
+| **Shared branch conventions only** | Do not provide explicit inbox/thread/reservation primitives needed for robust multi-agent concurrency |
+
+---
+
+## Use Cases
+
+- **High-throughput coding swarms** across multiple specialized agents.
+- **Reliable agent handoffs** with thread continuity and replayable history.
+- **Conflict-aware collaborative editing** in monorepos.
+- **Autonomous project execution** with operator visibility and low-overhead recovery.

--- a/services/communication/mcp-agent-mail.md
+++ b/services/communication/mcp-agent-mail.md
@@ -1,0 +1,146 @@
+# MCP Agent Mail
+
+> **"Asynchronous coordination layer for AI coding agents: identities, inboxes, searchable threads, and advisory file leases over FastMCP + Git + SQLite."**
+
+| | |
+|---|---|
+| **Website** | https://github.com/Dicklesworthstone/mcp_agent_mail |
+| **Docs** | https://github.com/Dicklesworthstone/mcp_agent_mail/blob/main/README.md |
+| **GitHub** | https://github.com/Dicklesworthstone/mcp_agent_mail |
+| **Classification** | `agent-native` |
+| **Category** | [Communication Services](README.md) |
+
+---
+
+## Official Website
+
+https://github.com/Dicklesworthstone/mcp_agent_mail
+
+---
+
+## Official Repo
+
+https://github.com/Dicklesworthstone/mcp_agent_mail
+
+---
+
+## How to Use (Agent Onboarding)
+
+**The quickest path for an agent to start using this service.**
+
+Run Agent Mail via `uvx`:
+
+```bash
+uvx mcp_agent_mail
+```
+
+Then connect your MCP client (Claude Code/Codex/Gemini CLI, etc.) to the Agent Mail server and use tools such as `register_agent`, `send_message`, `fetch_inbox`, and `file_reservation_paths`.
+
+---
+
+## Agent Skills
+
+**Status:** ⚠️ Community skills exist, but no official first-party `SKILL.md` package is published as of April 2026.
+
+Search available skills:
+
+```bash
+npx clawhub@latest search mcp_agent_mail
+```
+
+---
+
+## MCP
+
+**Status:** ✅ Available
+
+| Detail | Value |
+|---|---|
+| **Transport** | HTTP and stdio (via MCP-compatible wrappers/clients) |
+| **Server package** | `mcp_agent_mail` |
+| **Primary tools** | Agent registration, inbox/outbox operations, threaded messaging, advisory file reservations |
+| **Resources** | Read-only mailbox/thread/project resources for low-cost state reads |
+
+---
+
+## What It Does
+
+MCP Agent Mail provides a mailbox-style coordination layer for coding agents. Agents register persistent identities, exchange structured messages, search threads, and coordinate edits via advisory file reservations. Message artifacts are persisted in Git while query and indexing workloads are handled by SQLite.
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | Project README explicitly positions the system as a coordination layer for AI coding agents |
+| **Agent-specific primitive** | `register_agent`, inbox/outbox workflows, and file-reservation leases are built for autonomous multi-agent collaboration |
+| **Autonomy-compatible control plane** | Agents can self-register, message peers, and reserve files without human approvals per action |
+| **M2M integration surface** | MCP tools/resources and CLI-driven API surface are the primary interface |
+| **Identity / delegation** | Per-agent identities, per-project scopes, and attributable message/reservation history |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **Agent identity registration** | Register persistent per-agent identity within a project scope |
+| **Inbox/outbox messaging** | Send, receive, acknowledge, and search structured agent messages |
+| **Threading** | Keep asynchronous multi-step work grouped by thread |
+| **File reservations** | Advisory leases on files/globs to reduce multi-agent edit collisions |
+| **Git-backed artifacts** | Durable, human-auditable message/reservation history |
+
+---
+
+## Autonomy Model
+
+1. Agent starts or connects to Agent Mail MCP server.
+2. Agent calls registration tools to create/restore identity in the target repo/project.
+3. Agent coordinates work through inbox/outbox and thread tools.
+4. Agent acquires advisory file reservations before edits and releases/renews as needed.
+5. Agent continues autonomous collaboration using mailbox state + MCP resources.
+
+---
+
+## Identity and Delegation Model
+
+- **Identity:** Each agent gets a named identity (`agent_name`) within a project scope.
+- **Delegation:** Agents operate under project-level delegation boundaries and tool-level permissions.
+- **Audit:** Message traffic and reservations are persisted with attribution for replay and debugging.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| MCP tools | Message, thread, reservation, and agent lifecycle operations |
+| MCP resources | Read-only mailbox, thread, reservation, and diagnostics views |
+| CLI | `uvx mcp_agent_mail` startup and ops utilities |
+| Git + SQLite | Durable artifact layer + indexed query layer |
+
+---
+
+## Human-in-the-Loop Support
+
+Optional. Human operators can inspect mailbox artifacts and intervene, but the core coordination loop is autonomous and agent-to-agent.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **Slack/Discord bots** | Human-centric channels, weak agent identity semantics, and no first-class file-reservation coordination primitives |
+| **Ad-hoc shared docs/issues** | Lacks structured MCP tools/resources for deterministic autonomous workflows |
+| **Raw Git commits only** | No inbox/outbox semantics, thread-level coordination, or lease-based collision reduction |
+
+---
+
+## Use Cases
+
+- **Parallel coding swarms** coordinating backend/frontend/infra agents.
+- **Cross-agent handoff workflows** where one agent delegates and another executes.
+- **Conflict-aware editing** with advisory file reservations.
+- **Long-running autonomous projects** requiring durable asynchronous communication.

--- a/skill.md
+++ b/skill.md
@@ -57,7 +57,7 @@ These services can be joined with a single instruction, right now, with no human
 
 ---
 
-## Full Catalog — 15 Categories, 97+ Services
+## Full Catalog — 15 Categories, 99+ Services
 
 ### 1. Communication
 *Give agents a first-class communication identity on the internet.*
@@ -69,6 +69,8 @@ These services can be joined with a single instruction, right now, with no human
 | [mails.dev](https://mails.dev) ⭐ | Email for AI Agents | `Read https://mails.dev/skill.md and follow the instructions` |
 | [OpenMail](https://openmail.sh) | Email API for AI agents | `npm install -g @openmail/cli` → `openmail setup` — [docs.openmail.sh/quickstart](https://docs.openmail.sh/quickstart) |
 | [MailboxKit](https://mailboxkit.com) ⭐ | Email infrastructure for AI agents | `Read https://mailboxkit.com/skill.md and follow the instructions` |
+| [MCP Agent Mail](https://github.com/Dicklesworthstone/mcp_agent_mail) | Async coordination layer for AI coding agents | `uvx mcp_agent_mail` then use MCP tools like `register_agent`/`send_message` |
+| [MCP Agent Mail (Rust)](https://github.com/Dicklesworthstone/mcp_agent_mail_rust) | "Gmail for coding agents" with MCP tools/resources | Install script from repo README, then run `am` |
 
 ---
 


### PR DESCRIPTION
### Motivation
- Add two fast-growing, agent-first communication projects so agents can discover high-throughput multi-agent coordination primitives in this catalog.
- Surface both a Python/uvx-hosted and a Rust production-grade runtime to cover different deployment footprints and operator workflows.
- Ensure the catalog and agent entry points reflect recent ecosystem activity and URL/CLI onboarding patterns.

### Description
- Added two new service pages: `services/communication/mcp-agent-mail.md` and `services/communication/mcp-agent-mail-rust.md` documenting website, onboarding, MCP tools/resources, primitives, autonomy and use cases.
- Updated `services/communication/README.md` to include both projects in the Communication table.
- Updated root `README.md` communication section with star badges and quick onboarding commands for both projects.
- Updated `skill.md` to include the two new entries and bump the total catalog count from `97+` to `99+`.

### Testing
- Ran repository searches to confirm new rows and identifiers are present (`rg -n "mcp-agent-mail|Full Catalog — 15 Categories" README.md services/communication/README.md skill.md`) and the results were as expected (success).
- Printed and inspected the updated sections (`nl`/`sed`) to verify the new service table lines and full service pages show the correct onboarding snippets (success).
- Verified workspace status with `git status --short` to confirm working tree reflects the changes (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec8fa620a0832eb98e92545a4c5fde)