### PR TITLE
Improve sponsor UX with a single clear funding entry

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -2,6 +2,4 @@
 # Keep at most 4 custom links.
 github: [haoruilee]
 custom:
-  - https://buy.stripe.com/4gM6oJ5KU7MX0Ewe3S0Ny02
-  - https://buy.stripe.com/7sYbJ31uE9V55YQf7W0Ny04
-  - https://buy.stripe.com/fZu14pddm2sD3QIgc00Ny03
+  - https://github.com/haoruilee/awesome-agent-native-services#-support-this-project

--- a/README.md
+++ b/README.md
@@ -425,6 +425,20 @@ For the full criteria and contribution instructions, see [CONTRIBUTING.md](CONTR
 
 ---
 
+## 💖 Support this project
+
+If this catalog helps you, you can support maintenance and new reviews via Stripe.
+
+| Tier | Purpose | Link |
+|---|---|---|
+| ☕ Buy me a token | Say thanks and support basic upkeep | [Support (small)](https://buy.stripe.com/4gM6oJ5KU7MX0Ewe3S0Ny02) |
+| 🚀 Keep it growing | Fund deeper research and entry updates | [Support (medium)](https://buy.stripe.com/7sYbJ31uE9V55YQf7W0Ny04) |
+| 🏗️ Sustain the project | Help long-term maintenance and new categories | [Support (large)](https://buy.stripe.com/fZu14pddm2sD3QIgc00Ny03) |
+
+Prefer GitHub UI? Click **Sponsor** at the top of this repository — it links here with clear tier descriptions.
+
+---
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the full submission guide, criteria checklist, and entry format.


### PR DESCRIPTION
### Motivation
- Replace three opaque Stripe URLs shown in the repository Sponsor panel with a human-friendly, tiered support section so visitors understand what each funding option is for.

### Description
- Add a `💖 Support this project` section to `README.md` containing a 3-tier table that links to the existing Stripe checkout pages, and update `.github/FUNDING.yml` to point the Sponsor sidebar to the new README anchor instead of exposing the three raw Stripe URLs.

### Testing
- Verified the changes and commit with `git diff`, `git show --stat --oneline HEAD`, and inspected the inserted README lines with `nl -ba README.md | sed -n '420,460p'`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef38d273f0832e991a3e2940787576)