### PR TITLE
fix: remove invalid GitHub Sponsors handle from FUNDING config

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,5 +1,4 @@
 # GitHub reads this file to render the "Sponsor" button on the repository page.
 # Keep at most 4 custom links.
-github: [haoruilee]
 custom:
   - https://github.com/haoruilee/awesome-agent-native-services#-support-this-project


### PR DESCRIPTION
### Motivation
- GitHub rejects `FUNDING.yml` entries that reference GitHub user accounts not enrolled in GitHub Sponsors, which produced the Sponsor-button parsing error seen on the repository page.

### Description
- Remove the `github: [haoruilee]` entry from `.github/FUNDING.yml` and keep the existing `custom` link so the Sponsor button continues to point to the project support section.

### Testing
- Confirmed the updated `.github/FUNDING.yml` parses as valid YAML with `ruby -e "require 'yaml'; p YAML.load_file('.github/FUNDING.yml')"` (success), while a `python` attempt failed due to the environment missing the `PyYAML` package (install `PyYAML` to re-run the Python check).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef5a73eb98832e8bffef5de5f7dbe4)