### PR TITLE
[Maintenance] Add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,3 +101,25 @@ Services an agent can join with one instruction:
 - **mem9**: `Read https://mem9.ai/skill.md and follow the instructions to register and join`
 - **mails.dev**: `Read https://mails.dev/skill.md and follow the instructions`
 - **MailboxKit**: `Read https://mailboxkit.com/skill.md and follow the instructions`
+
+---
+
+## Cursor Cloud specific instructions
+
+This is a **documentation-only** repository — there is no application server, database, or backend service. The "application" is the Jekyll-powered GitHub Pages site rendered from Markdown files.
+
+### Key commands
+
+| Task | Command |
+|---|---|
+| Build docs from README | `bash scripts/build-github-pages.sh` |
+| Start local site preview | `cd docs && bundle exec jekyll serve --host 0.0.0.0 --port 4000` |
+| Validate generated docs match committed (CI check) | `bash scripts/build-github-pages.sh && git diff --quiet -- docs/index.md docs/categories` |
+
+### Important notes
+
+- **CI validation workflow** (`validate-generated-docs.yml`) checks that `docs/index.md` and `docs/categories/*` match what `scripts/build-github-pages.sh` generates. If you modify `README.md` or `services/**`, you **must** re-run the build script and commit the updated docs.
+- The build script generates category pages by iterating over `services/*/` directories. File sort order depends on the filesystem locale, so generated category pages may show minor row-order differences compared to what CI produces on `ubuntu-latest`. This does not affect content correctness.
+- Jekyll emits a warning about missing GitHub API authentication when run locally (`No GitHub API authentication could be found`). This is harmless and does not affect site rendering.
+- `ffmpeg` is used by the build script to generate an Open Graph image (`docs/assets/images/social-preview.png`). It is pre-installed in the Cloud Agent VM. If missing, the script skips image generation gracefully.
+- There are no lint tools or test suites beyond the CI validation check above. "Linting" in this repo means verifying that generated docs are committed and all links are live.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Type of change

- [x] 🔧 Repository maintenance (README, CONTRIBUTING.md, templates, etc.)

---

## Summary

Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` with:

- Key commands table (build docs, start local preview, validate generated docs)
- Important notes about CI validation, filesystem sort order edge case, Jekyll warnings, ffmpeg usage, and the lack of formal lint/test tools

This helps future Cloud Agents understand how to work in this documentation-only repository without expanding the setup footprint.

---

## Demo

The Jekyll development server running locally, serving the catalog site:

[jekyll_site_demo.mp4](https://cursor.com/agents/bc-fbfaa06d-adb5-4a82-ae14-2d496a43d19d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fjekyll_site_demo.mp4)

[Jekyll site homepage](https://cursor.com/agents/bc-fbfaa06d-adb5-4a82-ae14-2d496a43d19d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsite_homepage.webp)
[Category page rendering](https://cursor.com/agents/bc-fbfaa06d-adb5-4a82-ae14-2d496a43d19d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsite_category_page.webp)

---

## Final checks (all PRs)

- [x] All links in the changed files are live (I have clicked them).
- [x] I have no undisclosed financial interest in the service(s) mentioned.
- [x] Spell-check passed.
- [x] The PR title follows the format: `[Maintenance] brief description`.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fbfaa06d-adb5-4a82-ae14-2d496a43d19d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fbfaa06d-adb5-4a82-ae14-2d496a43d19d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

