### PR TITLE
Add ToolHive and Cyberdesk to catalog and update onboarding guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,10 @@ Source files are in `.skills/` in this repo. ClawHub CLI options (including the 
 |---|---|---|---|
 | 1 | [Communication](#1-communication-services) | 8 | Give agents a communication identity on the internet |
 | 2 | [Browser & Web Execution](#2-browser--web-execution-services) | 18 | Remote browser and web data extraction for agents |
-| 3 | [Tool Access & Integration](#3-tool-access--integration-services) | 9 | Runtime tool discovery, auth, and execution |
+| 3 | [Tool Access & Integration](#3-tool-access--integration-services) | 10 | Runtime tool discovery, auth, and execution |
 | 4 | [Oversight & Approval](#4-oversight--approval-services) | 1 | Human-in-the-loop approval and escalation |
 | 5 | [Commerce & Payments](#5-commerce--payment-services) | 6 | Agent-native wallets, identity, and transactions |
-| 6 | [Agent Runtime & Infrastructure](#6-agent-runtime--infrastructure-services) | 17 | Execution, session isolation, secrets, and gateway |
+| 6 | [Agent Runtime & Infrastructure](#6-agent-runtime--infrastructure-services) | 18 | Execution, session isolation, secrets, and gateway |
 | 7 | [Memory & State](#7-memory--state-services) | 9 | Persistent agent memory across sessions |
 | 8 | [Search & Web Intelligence](#8-search--web-intelligence-services) | 5 | LLM-optimized web search and content retrieval |
 | 9 | [Code Execution](#9-code-execution-services) | 7 | Secure sandboxes for AI-generated code |
@@ -146,6 +146,7 @@ Source files are in `.skills/` in this repo. ClawHub CLI options (including the 
 | [Framelink MCP for Figma](services/tool-access-and-integration/framelink-figma-mcp.md) [![⭐](https://img.shields.io/github/stars/GLips/Figma-Context-MCP?style=social)](https://github.com/GLips/Figma-Context-MCP) | Give your coding agent access to your Figma data | LLM-compacted layout/style context · Figma API · stdio MCP | ✅ | `npx -y figma-developer-mcp --figma-api-key=… --stdio` — [quickstart](https://www.framelink.ai/docs/quickstart) |
 | [GitHub MCP Server](services/tool-access-and-integration/github-mcp-server.md) [![⭐](https://img.shields.io/github/stars/github/github-mcp-server?style=social)](https://github.com/github/github-mcp-server) | Connect AI agents to GitHub — repos, issues, PRs, Actions | Remote HTTP MCP · OAuth or PAT · Toolsets · Enterprise paths | ✅ | `https://api.githubcopilot.com/mcp/` in MCP host — [repo README](https://github.com/github/github-mcp-server) |
 | [MCP Toolbox for Databases](services/tool-access-and-integration/google-mcp-toolbox.md) [![⭐](https://img.shields.io/github/stars/googleapis/mcp-toolbox?style=social)](https://github.com/googleapis/mcp-toolbox) | MCP server connecting agents to enterprise databases | Prebuilt DB tools · Custom governed tools · IAM · OpenTelemetry | ✅ | `npx -y @toolbox-sdk/server --prebuilt=postgres` + env — [mcp-toolbox.dev](https://mcp-toolbox.dev/) |
+| [ToolHive](services/tool-access-and-integration/toolhive.md) [![⭐](https://img.shields.io/github/stars/stacklok/toolhive-studio?style=social)](https://github.com/stacklok/toolhive-studio) | Run any MCP server securely, instantly, anywhere | MCP server discovery/deploy/manage · secure container runtime | ✅ | [toolhive.dev](https://toolhive.dev/) |
 
 ---
 
@@ -204,6 +205,7 @@ Source files are in `.skills/` in this repo. ClawHub CLI options (including the 
 | [Scrapybara](services/agent-runtime-and-infrastructure/scrapybara.md) [![⭐](https://img.shields.io/github/stars/Scrapybara/scrapybara-python?style=social)](https://github.com/Scrapybara/scrapybara-python) | Remote desktops for computer-use agents | Ubuntu/Browser/Windows instances · Act SDK (Computer/Bash/Edit) · scrapybara-mcp | ✅ | `pip install scrapybara` → `Scrapybara().start_ubuntu()` — [Act SDK](https://docs.scrapybara.com/act-sdk) |
 | [Agentuity](services/agent-runtime-and-infrastructure/agentuity.md) [![⭐](https://img.shields.io/github/stars/agentuity/sdk?style=social)](https://github.com/agentuity/sdk) | Full-stack platform for AI agents | Sandboxes · Storage tools · OTel · Evals on live traffic · Edge deploy | ⚠️ | [agentuity.dev](https://agentuity.dev) — SDK + CLI per docs |
 | [Modal](services/agent-runtime-and-infrastructure/modal.md) [![⭐](https://img.shields.io/github/stars/modal-labs/modal-client?style=social)](https://github.com/modal-labs/modal-client) | Serverless AI infra — GPUs, inference, sandboxes, batch | Elastic containers · Programmatic sandboxes · Sub-second cold start | ❌ | `pip install modal` → `modal setup` — [modal.com/docs](https://modal.com/docs) |
+| [Cyberdesk](services/agent-runtime-and-infrastructure/cyberdesk.md) [![⭐](https://img.shields.io/github/stars/cyberdesk-hq/cyberdesk?style=social)](https://github.com/cyberdesk-hq/cyberdesk) | Open source virtual desktops for AI agents | Desktop lifecycle API · computer actions · isolated sessions | ⚠️ | `pip install cyberdesk` — [docs.cyberdesk.io](https://docs.cyberdesk.io) |
 
 ---
 

--- a/docs/categories/agent-runtime-and-infrastructure.md
+++ b/docs/categories/agent-runtime-and-infrastructure.md
@@ -20,6 +20,7 @@ permalink: /categories/agent-runtime-and-infrastructure/
 | Claude Peers (claude-peers-mcp) | [services/agent-runtime-and-infrastructure/claude-peers.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/claude-peers.md) |
 | Codex plugin for Claude Code (codex-plugin-cc) | [services/agent-runtime-and-infrastructure/codex-plugin-cc.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/codex-plugin-cc.md) |
 | cx | [services/agent-runtime-and-infrastructure/cx.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/cx.md) |
+| Cyberdesk | [services/agent-runtime-and-infrastructure/cyberdesk.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/cyberdesk.md) |
 | db9 | [services/agent-runtime-and-infrastructure/db9.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/db9.md) |
 | Infisical Agent Sentinel | [services/agent-runtime-and-infrastructure/infisical-agent-sentinel.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/infisical-agent-sentinel.md) |
 | Letta | [services/agent-runtime-and-infrastructure/letta.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/letta.md) |

--- a/docs/categories/tool-access-and-integration.md
+++ b/docs/categories/tool-access-and-integration.md
@@ -19,4 +19,5 @@ permalink: /categories/tool-access-and-integration/
 | MCP Gateway | [services/tool-access-and-integration/mcpgateway.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/mcpgateway.md) |
 | Nango | [services/tool-access-and-integration/nango.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/nango.md) |
 | Smithery | [services/tool-access-and-integration/smithery.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/smithery.md) |
+| ToolHive | [services/tool-access-and-integration/toolhive.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/toolhive.md) |
 | Toolhouse | [services/tool-access-and-integration/toolhouse.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/toolhouse.md) |

--- a/docs/index.md
+++ b/docs/index.md
@@ -65,10 +65,10 @@ Source files are in `.skills/` in this repo. ClawHub CLI options (including the 
 |---|---|---|---|
 | 1 | [Communication](#1-communication-services) | 8 | Give agents a communication identity on the internet |
 | 2 | [Browser & Web Execution](#2-browser--web-execution-services) | 18 | Remote browser and web data extraction for agents |
-| 3 | [Tool Access & Integration](#3-tool-access--integration-services) | 9 | Runtime tool discovery, auth, and execution |
+| 3 | [Tool Access & Integration](#3-tool-access--integration-services) | 10 | Runtime tool discovery, auth, and execution |
 | 4 | [Oversight & Approval](#4-oversight--approval-services) | 1 | Human-in-the-loop approval and escalation |
 | 5 | [Commerce & Payments](#5-commerce--payment-services) | 6 | Agent-native wallets, identity, and transactions |
-| 6 | [Agent Runtime & Infrastructure](#6-agent-runtime--infrastructure-services) | 17 | Execution, session isolation, secrets, and gateway |
+| 6 | [Agent Runtime & Infrastructure](#6-agent-runtime--infrastructure-services) | 18 | Execution, session isolation, secrets, and gateway |
 | 7 | [Memory & State](#7-memory--state-services) | 9 | Persistent agent memory across sessions |
 | 8 | [Search & Web Intelligence](#8-search--web-intelligence-services) | 5 | LLM-optimized web search and content retrieval |
 | 9 | [Code Execution](#9-code-execution-services) | 7 | Secure sandboxes for AI-generated code |
@@ -151,6 +151,7 @@ Source files are in `.skills/` in this repo. ClawHub CLI options (including the 
 | [Framelink MCP for Figma](services/tool-access-and-integration/framelink-figma-mcp.md) [![⭐](https://img.shields.io/github/stars/GLips/Figma-Context-MCP?style=social)](https://github.com/GLips/Figma-Context-MCP) | Give your coding agent access to your Figma data | LLM-compacted layout/style context · Figma API · stdio MCP | ✅ | `npx -y figma-developer-mcp --figma-api-key=… --stdio` — [quickstart](https://www.framelink.ai/docs/quickstart) |
 | [GitHub MCP Server](services/tool-access-and-integration/github-mcp-server.md) [![⭐](https://img.shields.io/github/stars/github/github-mcp-server?style=social)](https://github.com/github/github-mcp-server) | Connect AI agents to GitHub — repos, issues, PRs, Actions | Remote HTTP MCP · OAuth or PAT · Toolsets · Enterprise paths | ✅ | `https://api.githubcopilot.com/mcp/` in MCP host — [repo README](https://github.com/github/github-mcp-server) |
 | [MCP Toolbox for Databases](services/tool-access-and-integration/google-mcp-toolbox.md) [![⭐](https://img.shields.io/github/stars/googleapis/mcp-toolbox?style=social)](https://github.com/googleapis/mcp-toolbox) | MCP server connecting agents to enterprise databases | Prebuilt DB tools · Custom governed tools · IAM · OpenTelemetry | ✅ | `npx -y @toolbox-sdk/server --prebuilt=postgres` + env — [mcp-toolbox.dev](https://mcp-toolbox.dev/) |
+| [ToolHive](services/tool-access-and-integration/toolhive.md) [![⭐](https://img.shields.io/github/stars/stacklok/toolhive-studio?style=social)](https://github.com/stacklok/toolhive-studio) | Run any MCP server securely, instantly, anywhere | MCP server discovery/deploy/manage · secure container runtime | ✅ | [toolhive.dev](https://toolhive.dev/) |
 
 ---
 
@@ -209,6 +210,7 @@ Source files are in `.skills/` in this repo. ClawHub CLI options (including the 
 | [Scrapybara](services/agent-runtime-and-infrastructure/scrapybara.md) [![⭐](https://img.shields.io/github/stars/Scrapybara/scrapybara-python?style=social)](https://github.com/Scrapybara/scrapybara-python) | Remote desktops for computer-use agents | Ubuntu/Browser/Windows instances · Act SDK (Computer/Bash/Edit) · scrapybara-mcp | ✅ | `pip install scrapybara` → `Scrapybara().start_ubuntu()` — [Act SDK](https://docs.scrapybara.com/act-sdk) |
 | [Agentuity](services/agent-runtime-and-infrastructure/agentuity.md) [![⭐](https://img.shields.io/github/stars/agentuity/sdk?style=social)](https://github.com/agentuity/sdk) | Full-stack platform for AI agents | Sandboxes · Storage tools · OTel · Evals on live traffic · Edge deploy | ⚠️ | [agentuity.dev](https://agentuity.dev) — SDK + CLI per docs |
 | [Modal](services/agent-runtime-and-infrastructure/modal.md) [![⭐](https://img.shields.io/github/stars/modal-labs/modal-client?style=social)](https://github.com/modal-labs/modal-client) | Serverless AI infra — GPUs, inference, sandboxes, batch | Elastic containers · Programmatic sandboxes · Sub-second cold start | ❌ | `pip install modal` → `modal setup` — [modal.com/docs](https://modal.com/docs) |
+| [Cyberdesk](services/agent-runtime-and-infrastructure/cyberdesk.md) [![⭐](https://img.shields.io/github/stars/cyberdesk-hq/cyberdesk?style=social)](https://github.com/cyberdesk-hq/cyberdesk) | Open source virtual desktops for AI agents | Desktop lifecycle API · computer actions · isolated sessions | ⚠️ | `pip install cyberdesk` — [docs.cyberdesk.io](https://docs.cyberdesk.io) |
 
 ---
 

--- a/services/agent-runtime-and-infrastructure/README.md
+++ b/services/agent-runtime-and-infrastructure/README.md
@@ -39,6 +39,8 @@ The services in this category were purpose-built to fill this gap.
 | [Scrapybara](scrapybara.md) [![⭐](https://img.shields.io/github/stars/Scrapybara/scrapybara-python?style=social)](https://github.com/Scrapybara/scrapybara-python) | Remote desktops for computer-use agents (CUA) | Ubuntu/Browser/Windows instances · Act SDK · scrapybara-mcp | ✅ |
 | [Agentuity](agentuity.md) [![⭐](https://img.shields.io/github/stars/agentuity/sdk?style=social)](https://github.com/agentuity/sdk) | The full-stack platform for AI agents | TypeScript/Python SDKs, CLI, sandboxes, storage, OTel, evals | ⚠️ |
 | [Modal](modal.md) [![⭐](https://img.shields.io/github/stars/modal-labs/modal-client?style=social)](https://github.com/modal-labs/modal-client) | AI infrastructure — serverless GPUs, inference, sandboxes, batch | Python SDK, CLI, HTTP endpoints | ❌ |
+| [Cyberdesk](cyberdesk.md) [![⭐](https://img.shields.io/github/stars/cyberdesk-hq/cyberdesk?style=social)](https://github.com/cyberdesk-hq/cyberdesk) | Open source virtual desktops for AI agents | SDK/API desktop lifecycle · computer actions · isolated sessions | ⚠️ |
+
 
 ---
 

--- a/services/agent-runtime-and-infrastructure/cyberdesk.md
+++ b/services/agent-runtime-and-infrastructure/cyberdesk.md
@@ -1,0 +1,89 @@
+# Cyberdesk
+
+> **"Open source virtual desktops for AI agents."**
+
+| | |
+|---|---|
+| **Website** | https://www.cyberdesk.io |
+| **Docs** | https://docs.cyberdesk.io |
+| **GitHub** | https://github.com/cyberdesk-hq/cyberdesk |
+| **Classification** | `agent-native` |
+| **Category** | [Agent Runtime & Infrastructure Services](README.md) |
+
+---
+
+## Official Website
+
+https://www.cyberdesk.io
+
+---
+
+## Official Repo
+
+https://github.com/cyberdesk-hq/cyberdesk
+
+---
+
+## ⭐ How to Use (Agent Onboarding)
+
+```bash
+pip install cyberdesk
+# then create a desktop and execute computer actions via SDK/API
+```
+
+Quickstart: https://docs.cyberdesk.io
+
+---
+
+## Agent Skills
+
+**Status:** ⚠️ No official `SKILL.md` package published yet.
+
+---
+
+## MCP
+
+**Status:** ⚠️ Not MCP-first.
+
+Cyberdesk is API/SDK-first for programmatic desktop lifecycle and computer actions.
+
+---
+
+## What It Does
+
+Cyberdesk provides cloud-hosted virtual desktops that AI agents can control programmatically (mouse, keyboard, screenshot, app/browser interaction) with isolated sessions and auditable execution.
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | Product tagline explicitly targets AI agents |
+| **Agent-specific primitive** | Programmatic computer actions + desktop lifecycle APIs |
+| **Autonomy-compatible control plane** | Headless API execution; no per-action human clicks required |
+| **M2M integration surface** | SDK + API as primary interface |
+| **Identity / delegation** | API-key controlled workspace and per-session attribution |
+
+---
+
+## Primary Primitives
+
+- Virtual desktop create/start/stop/delete
+- Computer-use actions (click, type, keypress, screenshot)
+- Isolated sessions for concurrent agents
+- Execution logs and auditability
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+- Generic VDI/remote desktop products are human-operator-first and do not expose agent-native computer-use primitives as the default product surface.
+
+---
+
+## Use Cases
+
+- Computer-use agents for back-office workflows
+- Browser-and-desktop automation with isolation
+- Human fallback review on recorded sessions

--- a/services/agent-runtime-and-infrastructure/cyberdesk.md
+++ b/services/agent-runtime-and-infrastructure/cyberdesk.md
@@ -76,6 +76,44 @@ Cyberdesk provides cloud-hosted virtual desktops that AI agents can control prog
 
 ---
 
+
+## Autonomy Model
+
+Cyberdesk supports autonomous computer-use loops:
+
+1. Agent creates an isolated desktop session
+2. Agent executes UI actions (click/type/navigate/screenshot)
+3. Agent reads outputs and continues task flow
+4. Session is terminated/archived programmatically
+
+This flow is API-driven and does not require per-step human approval.
+
+---
+
+## Identity and Delegation Model
+
+- API keys identify the workspace and caller.
+- Desktop sessions are isolated units attributable to specific runs/agents.
+- Delegation boundaries are enforced by account/workspace-level credentials and quotas.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| SDK/API | Desktop lifecycle + computer-use action primitives |
+| Session artifacts | Screenshots/logs for replay, debugging, or compliance review |
+| Cloud runtime | Remote execution environment for agent browser/desktop tasks |
+
+---
+
+## Human-in-the-Loop Support
+
+Optional. Humans can observe, review, or take over workflows when needed, but default operation is agent-driven.
+
+---
+
 ## Why Generic Alternatives Do Not Qualify
 
 - Generic VDI/remote desktop products are human-operator-first and do not expose agent-native computer-use primitives as the default product surface.

--- a/services/tool-access-and-integration/README.md
+++ b/services/tool-access-and-integration/README.md
@@ -26,6 +26,8 @@ Agent-native tool access services solve all three problems with primitives that 
 | [Framelink MCP for Figma](framelink-figma-mcp.md) [![⭐](https://img.shields.io/github/stars/GLips/Figma-Context-MCP?style=social)](https://github.com/GLips/Figma-Context-MCP) | Give your coding agent access to your Figma data — layout context for one-shot UI | MCP (`figma-developer-mcp`), Figma REST API | ✅ |
 | [GitHub MCP Server](github-mcp-server.md) [![⭐](https://img.shields.io/github/stars/github/github-mcp-server?style=social)](https://github.com/github/github-mcp-server) | Official GitHub MCP — agents work with repos, issues, PRs, Actions | Remote HTTP MCP, OAuth/PAT, local server option | ✅ |
 | [MCP Toolbox for Databases](google-mcp-toolbox.md) [![⭐](https://img.shields.io/github/stars/googleapis/mcp-toolbox?style=social)](https://github.com/googleapis/mcp-toolbox) | MCP server connecting agents to enterprise databases | `@toolbox-sdk/server`, prebuilt packs, multi-language SDKs, IAM, OTEL | ✅ |
+| [ToolHive](toolhive.md) [![⭐](https://img.shields.io/github/stars/stacklok/toolhive-studio?style=social)](https://github.com/stacklok/toolhive-studio) | Run any MCP server securely, instantly, anywhere | MCP server discovery/deploy/manage · secure container runtime | ✅ |
+
 
 ---
 

--- a/services/tool-access-and-integration/toolhive.md
+++ b/services/tool-access-and-integration/toolhive.md
@@ -1,0 +1,88 @@
+# ToolHive
+
+> **"Run any MCP server securely, instantly, anywhere."**
+
+| | |
+|---|---|
+| **Website** | https://toolhive.dev |
+| **Docs** | https://docs.toolhive.dev |
+| **GitHub** | https://github.com/stacklok/toolhive-studio |
+| **Classification** | `agent-native` |
+| **Category** | [Tool Access & Integration Services](README.md) |
+
+---
+
+## Official Website
+
+https://toolhive.dev
+
+---
+
+## Official Repo
+
+https://github.com/stacklok/toolhive-studio
+
+---
+
+## ⭐ How to Use (Agent Onboarding)
+
+```bash
+# install ToolHive and launch/manage MCP servers for your agent clients
+```
+
+Docs: https://docs.toolhive.dev
+
+---
+
+## Agent Skills
+
+**Status:** ⚠️ No official AgentSkills package yet.
+
+---
+
+## MCP
+
+**Status:** ✅ Core product.
+
+ToolHive is specifically built to discover, run, and manage MCP servers with secure isolation for agent clients.
+
+---
+
+## What It Does
+
+ToolHive provides a control plane for MCP servers: discovery, deployment, sandboxed execution, and secure connection for agent runtimes and coding assistants.
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | Product is centered on connecting MCP servers to AI agents |
+| **Agent-specific primitive** | MCP server lifecycle + agent-facing server catalog |
+| **Autonomy-compatible control plane** | Non-interactive server management + policy/security controls |
+| **M2M integration surface** | API/CLI/app interfaces focused on MCP runtime operations |
+| **Identity / delegation** | Per-environment credentials and controlled server exposure |
+
+---
+
+## Primary Primitives
+
+- MCP server install/discovery
+- Server runtime lifecycle management
+- Isolation/security policy for MCP execution
+- Agent-client connection management
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+- Generic container managers orchestrate processes but are not MCP-native control planes for agent tool connectivity.
+
+---
+
+## Use Cases
+
+- Standardizing MCP operations across teams
+- Securely exposing approved tool servers to agents
+- Reducing manual MCP setup in IDE agent environments

--- a/services/tool-access-and-integration/toolhive.md
+++ b/services/tool-access-and-integration/toolhive.md
@@ -27,8 +27,12 @@ https://github.com/stacklok/toolhive-studio
 ## ⭐ How to Use (Agent Onboarding)
 
 ```bash
-# install ToolHive and launch/manage MCP servers for your agent clients
+brew tap stacklok/tap
+brew install thv
+thv --help
 ```
+
+Then discover and run MCP servers via `thv` runtime commands per docs.
 
 Docs: https://docs.toolhive.dev
 
@@ -72,6 +76,44 @@ ToolHive provides a control plane for MCP servers: discovery, deployment, sandbo
 - Server runtime lifecycle management
 - Isolation/security policy for MCP execution
 - Agent-client connection management
+
+---
+
+
+## Autonomy Model
+
+Agents can bootstrap and operate ToolHive non-interactively through CLI/API workflows:
+
+1. Install `thv`
+2. Discover/select MCP servers
+3. Run servers in isolated runtime contexts
+4. Connect agent clients to approved server endpoints
+
+No per-action human confirmation is required for normal tool execution loops.
+
+---
+
+## Identity and Delegation Model
+
+- Tool access is controlled by runtime/environment credentials.
+- MCP servers are exposed intentionally via ToolHive-managed endpoints/sessions.
+- Teams can constrain which servers are available to which agent environments.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| CLI | `thv` install/run/manage lifecycle |
+| MCP | Runs MCP servers for stdio/socket/HTTP-compatible clients |
+| Docs/API | Operational configuration and server management workflows |
+
+---
+
+## Human-in-the-Loop Support
+
+Optional. Human operators can approve which MCP servers are allowed in an environment, while agents invoke approved tools autonomously at runtime.
 
 ---
 

--- a/skill.md
+++ b/skill.md
@@ -5,7 +5,7 @@ description: >
   the ground up for AI agents, not adapted from human-facing products. Use the
   catalog to find services by task, understand each service's onboarding pattern,
   and immediately start using any service with URL Onboarding in one instruction.
-version: "2026-04-07"
+version: "2026-05-02"
 license: CC0-1.0
 catalog: https://github.com/haoruilee/awesome-agent-native-services
 allowed-tools: WebSearch Read
@@ -20,6 +20,18 @@ This catalog lists services that treat agents as first-class entities — not as
 ---
 
 ## How to use this catalog
+
+### Step 0 — Prefer recent, high-signal services
+
+When multiple services can solve the same task, prioritize entries that are both:
+
+1. **High-star / active** in open source (strong maintenance signal)
+2. **Recently updated in this catalog** (new agent-native capabilities like MCP, URL onboarding, or dedicated agent identity)
+
+Quick filters to apply:
+- Prefer services with GitHub star badges in `README.md`
+- Prefer entries with **MCP ✅** or **URL Onboarding ⭐**
+- Prefer services with explicit per-agent identity, policy gating, or delegated auth primitives
 
 ### Step 1 — Find your task in the category map below
 


### PR DESCRIPTION
### Motivation

- Expand the catalog with two new agent-native services that provide MCP tool hosting and programmatic virtual desktops for agents. 
- Make the catalog more action-oriented for agents by surfacing recent, high-signal selection heuristics. 
- Keep the skill metadata current by bumping the `skill.md` version. 

### Description

- Added `services/tool-access-and-integration/toolhive.md` and inserted a `ToolHive` row into the tool-access category README, marking it as an MCP-native tool. 
- Added `services/agent-runtime-and-infrastructure/cyberdesk.md` and inserted a `Cyberdesk` row into the agent-runtime category README, marking it as an open-source virtual desktop offering. 
- Updated top-level `README.md` category tables to reflect the new counts for Tool Access (`9` → `10`) and Agent Runtime & Infrastructure (`17` → `18`). 
- Bumped `skill.md` version to `"2026-05-02"` and added a new "Step 0 — Prefer recent, high-signal services" guidance section to the onboarding instructions. 

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f605e84064832e8fcf61be97c27065)