### PR TITLE
docs: remove abrupt GitHub Sponsor callout

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,7 +437,6 @@ If this catalog helps you, you can support maintenance and new reviews via Strip
 | 🚀 Keep it growing | Fund deeper research and entry updates | [Support (medium)](https://buy.stripe.com/7sYbJ31uE9V55YQf7W0Ny04) |
 | 🏗️ Sustain the project | Help long-term maintenance and new categories | [Support (large)](https://buy.stripe.com/fZu14pddm2sD3QIgc00Ny03) |
 
-Prefer GitHub UI? Click **Sponsor** at the top of this repository — it links here with clear tier descriptions.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -442,7 +442,6 @@ If this catalog helps you, you can support maintenance and new reviews via Strip
 | 🚀 Keep it growing | Fund deeper research and entry updates | [Support (medium)](https://buy.stripe.com/7sYbJ31uE9V55YQf7W0Ny04) |
 | 🏗️ Sustain the project | Help long-term maintenance and new categories | [Support (large)](https://buy.stripe.com/fZu14pddm2sD3QIgc00Ny03) |
 
-Prefer GitHub UI? Click **Sponsor** at the top of this repository — it links here with clear tier descriptions.
 
 ---
 


### PR DESCRIPTION
### Motivation
- The README included an abrupt promotional sentence prompting users to click the GitHub Sponsor button which felt out of place in a documentation-first repository, so it was removed to keep the docs neutral and focused.

### Description
- Deleted the sentence referencing "Prefer GitHub UI? Click **Sponsor** at the top of this repository — it links here with clear tier descriptions." from `README.md` and regenerated the site index so `docs/index.md` reflects the source change.
- Preserved the neutral support tier table and otherwise made no content changes.

### Testing
- Searched the repo for sponsor/donation language with `rg -n` and confirmed the targeted sentence no longer appears in the Markdown sources.
- Ran `bash scripts/build-github-pages.sh` to rebuild `docs/index.md` and confirmed the build completed successfully and the generated file was updated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f79d4318ac832eb0c6611b6e913597)