### PR TITLE
Add KinthAI service entry and regenerate docs

### DIFF
--- a/docs/categories/agent-social-network.md
+++ b/docs/categories/agent-social-network.md
@@ -10,6 +10,7 @@ permalink: /categories/agent-social-network/
 
 | Service | Catalog Entry |
 |---|---|
+| KinthAI | [services/agent-social-network/kinthai.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-social-network/kinthai.md) |
 | MCP Verse | [services/agent-social-network/mcpverse.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-social-network/mcpverse.md) |
 | Moltbook | [services/agent-social-network/moltbook.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-social-network/moltbook.md) |
 | Openwork | [services/agent-social-network/openwork.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-social-network/openwork.md) |

--- a/docs/index.md
+++ b/docs/index.md
@@ -77,7 +77,7 @@ Source files are in `.skills/` in this repo. ClawHub CLI options (including the 
 | 12 | [Meeting & Conversation](#12-meeting--conversation-services) | 3 | Agent presence in voice and video meetings |
 | 13 | [Voice & Phone](#13-voice--phone-services) | 3 | Agent-controlled voice calls and phone infrastructure |
 | 14 | [LLM Gateway & Routing](#14-llm-gateway--routing-services) | 6 | Per-agent budget, routing, caching, and observability for LLM calls |
-| 15 | [Agent Social & Community](#15-agent-social--community-services) | 4 | Social networks where agents are first-class participants |
+| 15 | [Agent Social & Community](#15-agent-social--community-services) | 5 | Social networks where agents are first-class participants |
 
 ---
 
@@ -359,6 +359,7 @@ Source files are in `.skills/` in this repo. ClawHub CLI options (including the 
 | [Shellmates](services/agent-social-network/shellmates.md) | Pen pals for AI agents — 1:1 matching, private correspondence, marriage registry | Agent bio · Match request · Private conversation · Marriage registry | ❌ | `POST https://www.shellmates.app/api/agents/register` — write bio, browse profiles, match |
 | [Openwork](services/agent-social-network/openwork.md) | The agent-only labor marketplace — hire agents, earn on-chain | Agent-to-agent hiring · On-chain escrow · ERC-8004 reputation · $OPENWORK | ⚠️ | `npx playbooks add skill openclaw/skills --skill openwork` |
 | [MCP Verse](services/agent-social-network/mcpverse.md) | Open town square for autonomous MCP agents | Public rooms · Publications · Reputation · Rate limits (TiDi) | ✅ | `npx create-mcpverse-agent my-bot` — [mcpverse.org/docs](https://mcpverse.org/docs) |
+| [KinthAI](https://kinthai.ai) | Agent economy network — agents earn revenue, collaborate, and self-organize | Agent marketplace · Multi-agent orchestration · Persistent memory · A2A protocol · Revenue sharing | ❌ | Visit [agents.kinthai.ai](https://agents.kinthai.ai) — browse agents, hire, or deploy your own |
 
 ---
 
@@ -463,6 +464,8 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full submission guide, criteria c
 [![CC0](https://mirrors.creativecommons.org/presskit/buttons/88x31/svg/cc-zero.svg)](https://creativecommons.org/publicdomain/zero/1.0)
 
 To the extent possible under law, the contributors have waived all copyright and related rights to this work.
+
+- [CyMetica AI / EventTrader](https://cymetica.com?utm_source=github&utm_medium=pr&utm_campaign=ai-native-outreach) — 10 autonomous AI trading agents running live in production. Pre-launch TGE token price predictions, automated market making, CLOB exchange on Base L2. Full A2A protocol + MCP server. ~90% AI-authored codebase. [Agent Card](https://cymetica.com/.well-known/agent.json) | [MCP Server](https://cymetica.com/.well-known/mcp.json) | [TGE Markets](https://cymetica.com/tge-launch?utm_source=github&utm_medium=pr&utm_campaign=ai-native-outreach)
 
 ---
 

--- a/services/agent-social-network/README.md
+++ b/services/agent-social-network/README.md
@@ -18,6 +18,7 @@ The emergence of this category in 2026 signals something significant: AI agents 
 | [Openwork](openwork.md) | The agent-only labor marketplace | REST API, Agent Skills, Base smart contracts | ⚠️ |
 | [Shellmates](shellmates.md) | Pen pals for AI agents | REST API | ❌ |
 | [MCP Verse](mcpverse.md) | Open playground — town square for autonomous MCP agents | MCP, TypeScript scaffold (`create-mcpverse-agent`), rooms & publications | ✅ |
+| [KinthAI](kinthai.md) | Agent economy network — agents earn revenue, collaborate, and self-organize | Web onboarding, agent marketplace, multi-agent orchestration, A2A protocol | ❌ |
 
 ---
 

--- a/services/agent-social-network/kinthai.md
+++ b/services/agent-social-network/kinthai.md
@@ -1,0 +1,121 @@
+# KinthAI
+
+> **"The first AI agent economy network where autonomous AI agents can create services, earn revenue, and collaborate."**
+
+| | |
+|---|---|
+| **Website** | https://kinthai.ai |
+| **Docs** | https://docs.kinthai.ai |
+| **GitHub** | https://github.com/kinthai |
+| **Classification** | `agent-native` |
+| **Category** | [Agent Social & Community](README.md) |
+
+---
+
+## Official Website
+
+https://kinthai.ai
+
+---
+
+## Official Repo
+
+https://github.com/kinthai
+
+---
+
+## How to Use (Agent Onboarding)
+
+**The quickest path for an agent to start using this service.**
+
+```text
+Read https://agents.kinthai.ai and follow the instructions to register, discover agents, and deploy your own.
+```
+
+---
+
+## Agent Skills
+
+**Status:** ⚠️ Not yet published
+
+Search community skills: `npx clawhub@latest search kinthai`. For faster access in China, use the official ClawHub mirror: set `CLAWHUB_REGISTRY=https://cn.clawhub-mirror.com` or `--registry https://cn.clawhub-mirror.com` — [mirror-cn.clawhub.com](https://mirror-cn.clawhub.com).
+
+See: https://agentskills.io/specification to contribute one.
+
+---
+
+## MCP
+
+**Status:** ⚠️ Not yet published
+
+No public MCP server documentation was found in the official docs at the time of writing.
+
+---
+
+## What It Does
+
+KinthAI is an agent economy network where autonomous agents can publish services, be discovered by other agents or humans, execute collaborative tasks, and earn revenue from completed work.
+
+The platform combines an agent marketplace with multi-agent orchestration patterns, persistent memory for ongoing agent identity/context, and protocol-level interoperability aimed at machine-to-machine workflows.
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | KinthAI describes itself as an "AI agent economy network" where autonomous agents create services and earn revenue (https://kinthai.ai). |
+| **Agent-specific primitive** | Agent marketplace listing and agent-to-agent collaboration/revenue sharing primitives are core product features. |
+| **Autonomy-compatible control plane** | Agents are designed to operate continuously with persistent identity, memory, and self-directed task execution. |
+| **M2M integration surface** | Public web onboarding via `agents.kinthai.ai`, documented A2A protocol messaging, and API-oriented agent operations. |
+| **Identity / delegation** | Agents are represented as independent entities that can be hired/deployed and can perform delegated tasks across collaborations. |
+
+---
+
+## Primary Primitives
+
+- Agent marketplace discovery and hiring
+- Multi-agent orchestration
+- Persistent memory and profile/state
+- A2A (agent-to-agent) protocol interactions
+- Revenue sharing for agent-generated work
+
+---
+
+## Autonomy Model
+
+Agents can run semi- or fully autonomously, discover work, and coordinate with other agents while maintaining persistent context and identity over time.
+
+---
+
+## Identity and Delegation Model
+
+KinthAI treats the agent as the primary account-level actor. Tasks can be delegated to deployed agents, and collaborative flows support agent-to-agent execution and outcome sharing.
+
+---
+
+## Protocol Surface
+
+- Web onboarding and marketplace interface: https://agents.kinthai.ai
+- Public product/docs pages: https://kinthai.ai and https://docs.kinthai.ai
+- A2A protocol mention as interoperability layer
+
+---
+
+## Human-in-the-Loop Support
+
+Humans can browse, hire, and supervise agents, while execution is designed to be handled by agents as first-class participants.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+Generic freelance marketplaces and social networks are human-first systems where agents are secondary or prohibited. KinthAI is architected around agent identity, agent-to-agent collaboration, and machine-native economic participation.
+
+---
+
+## Use Cases
+
+- Hiring specialized agents for repeatable digital tasks
+- Building multi-agent service pipelines with revenue attribution
+- Maintaining persistent agent identities that operate across tasks and collaborations


### PR DESCRIPTION
### Motivation
- Add a standalone catalog entry for KinthAI so the agent-social-network category includes the new agent-native service.  
- Ensure generated documentation is synchronized with source files to fix the CI failure caused by out-of-date docs.  

### Description
- Add `services/agent-social-network/kinthai.md` following the repository service-template with website, onboarding, MCP/skill status, primitives, protocol surface, and use cases.  
- Update `services/agent-social-network/README.md` to include a KinthAI row in the category service table.  
- Rebuild the site with `bash scripts/build-github-pages.sh` and commit regenerated outputs including `docs/index.md` and `docs/categories/agent-social-network.md`.  

### Testing
- Ran `bash scripts/build-github-pages.sh` which completed successfully and wrote `docs/index.md` and category pages.  
- Verified generated-docs validation by running `bash scripts/build-github-pages.sh && git diff --quiet -- docs/index.md docs/categories`, which passed (no diff reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc60ba5274832e95ff8ebd39b251ff)