### PR TITLE
Add weekly impact updates (2026-05-11 → 2026-05-18) for multiple categories

### DIFF
--- a/docs/categories/browser-and-web-execution.md
+++ b/docs/categories/browser-and-web-execution.md
@@ -29,3 +29,4 @@ permalink: /categories/browser-and-web-execution/
 | Skyvern | [services/browser-and-web-execution/skyvern.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/browser-and-web-execution/skyvern.md) |
 | Steel | [services/browser-and-web-execution/steel.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/browser-and-web-execution/steel.md) |
 | Vessel Browser | [services/browser-and-web-execution/vessel-browser.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/browser-and-web-execution/vessel-browser.md) |
+| Weekly Impact Update (2026-05-11 → 2026-05-18) | [services/browser-and-web-execution/weekly-impact-2026-05-18.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/browser-and-web-execution/weekly-impact-2026-05-18.md) |

--- a/docs/categories/communication.md
+++ b/docs/categories/communication.md
@@ -20,3 +20,4 @@ permalink: /categories/communication/
 | MCP Agent Mail | [services/communication/mcp-agent-mail.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/communication/mcp-agent-mail.md) |
 | Novu | [services/communication/novu.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/communication/novu.md) |
 | OpenMail | [services/communication/openmail.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/communication/openmail.md) |
+| Weekly Impact Update (2026-05-11 → 2026-05-18) | [services/communication/weekly-impact-2026-05-18.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/communication/weekly-impact-2026-05-18.md) |

--- a/docs/categories/durable-execution-and-scheduling.md
+++ b/docs/categories/durable-execution-and-scheduling.md
@@ -16,3 +16,4 @@ permalink: /categories/durable-execution-and-scheduling/
 | MCP-Cloud (mcp-agent) | [services/durable-execution-and-scheduling/mcp-cloud-mcp-agent.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/durable-execution-and-scheduling/mcp-cloud-mcp-agent.md) |
 | Restate | [services/durable-execution-and-scheduling/restate.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/durable-execution-and-scheduling/restate.md) |
 | Trigger.dev | [services/durable-execution-and-scheduling/trigger-dev.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/durable-execution-and-scheduling/trigger-dev.md) |
+| Weekly Impact Update (2026-05-11 → 2026-05-18) | [services/durable-execution-and-scheduling/weekly-impact-2026-05-18.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/durable-execution-and-scheduling/weekly-impact-2026-05-18.md) |

--- a/docs/categories/memory-and-state.md
+++ b/docs/categories/memory-and-state.md
@@ -20,4 +20,5 @@ permalink: /categories/memory-and-state/
 | MemOS | [services/memory-and-state/memos.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/memos.md) |
 | memU | [services/memory-and-state/memu.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/memu.md) |
 | OpenViking | [services/memory-and-state/openviking.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/openviking.md) |
+| Weekly Impact Update (2026-05-11 → 2026-05-18) | [services/memory-and-state/weekly-impact-2026-05-18.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/weekly-impact-2026-05-18.md) |
 | Zep | [services/memory-and-state/zep.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/zep.md) |

--- a/docs/categories/observability-and-tracing.md
+++ b/docs/categories/observability-and-tracing.md
@@ -18,3 +18,4 @@ permalink: /categories/observability-and-tracing/
 | Langfuse | [services/observability-and-tracing/langfuse.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/observability-and-tracing/langfuse.md) |
 | LangWatch | [services/observability-and-tracing/langwatch.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/observability-and-tracing/langwatch.md) |
 | OpenLIT | [services/observability-and-tracing/openlit.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/observability-and-tracing/openlit.md) |
+| Weekly Impact Update (2026-05-11 → 2026-05-18) | [services/observability-and-tracing/weekly-impact-2026-05-18.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/observability-and-tracing/weekly-impact-2026-05-18.md) |

--- a/docs/categories/tool-access-and-integration.md
+++ b/docs/categories/tool-access-and-integration.md
@@ -23,3 +23,4 @@ permalink: /categories/tool-access-and-integration/
 | Smithery | [services/tool-access-and-integration/smithery.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/smithery.md) |
 | ToolHive | [services/tool-access-and-integration/toolhive.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/toolhive.md) |
 | Toolhouse | [services/tool-access-and-integration/toolhouse.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/toolhouse.md) |
+| Weekly Impact Update (2026-05-11 → 2026-05-18) | [services/tool-access-and-integration/weekly-impact-2026-05-18.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/weekly-impact-2026-05-18.md) |

--- a/services/browser-and-web-execution/README.md
+++ b/services/browser-and-web-execution/README.md
@@ -35,6 +35,15 @@ The web was designed for humans sitting in front of browsers. AI agents that nee
 | [Apify](apify.md) [![⭐](https://img.shields.io/github/stars/apify/crawlee?style=social)](https://github.com/apify/crawlee) | Real-time web data for AI — Actor marketplace & API | REST API v2, JS/Python clients, webhooks, schedules | ⚠️ |
 | [Vessel Browser](vessel-browser.md) [![⭐](https://img.shields.io/github/stars/unmodeled-tyler/vessel-browser?style=social)](https://github.com/unmodeled-tyler/vessel-browser) | Built from the ground-up for agents — durable state, action undo, MCP control, BYOK | MCP (stdio), npm CLI, AppImage (Linux/Windows) | ✅ |
 
+
+
+## Weekly Impact Update (2026-05-11 → 2026-05-18)
+
+- 详见独立周报文档：[weekly-impact-2026-05-18.md](weekly-impact-2026-05-18.md)
+
+- **Crawl4AI**: 维持高 star 与高讨论度，开源可自托管、MCP 友好的网页抓取能力继续成为 Agent Web Data 默认选项之一。
+- **Browser Use Cloud**: 在“托管浏览器 + 反检测 + 会话化执行”方向持续活跃，适合需要稳定大规模网页操作的代理系统。
+
 ---
 
 ## Criteria Reminder

--- a/services/browser-and-web-execution/weekly-impact-2026-05-18.md
+++ b/services/browser-and-web-execution/weekly-impact-2026-05-18.md
@@ -1,0 +1,12 @@
+# Weekly Impact Update (2026-05-11 → 2026-05-18)
+
+> 本周高关注（高 star / 高讨论）agent-native 项目速览。
+
+## Highlights
+
+- **Crawl4AI**：维持高 star 与高讨论度，MCP 友好的网页抓取能力持续活跃。
+- **Browser Use Cloud**：托管浏览器 + 会话化执行方向讨论持续。
+
+## Notes
+
+- 该文档用于沉淀每周观察，避免仅在分类 README 中出现“短条目”而难以追踪历史。

--- a/services/communication/README.md
+++ b/services/communication/README.md
@@ -21,6 +21,15 @@ Human communication infrastructure (Gmail, Outlook, Slack) was built around the 
 | [MCP Agent Mail (Rust)](mcp-agent-mail-rust.md) | "Gmail for coding agents" with high-performance MCP runtime | MCP tools/resources, local HTTP runtime, TUI + robot CLI | ✅ |
 | [AgenticMail](agenticmail.md) [![⭐](https://img.shields.io/github/stars/agenticmail/agenticmail?style=social)](https://github.com/agenticmail/agenticmail) | Email & SMS infrastructure for AI agents | REST API (75+ endpoints), self-hosted Stalwart + Google Voice bridge, Webhooks | ⚠️ |
 
+
+
+## Weekly Impact Update (2026-05-11 → 2026-05-18)
+
+- 详见独立周报文档：[weekly-impact-2026-05-18.md](weekly-impact-2026-05-18.md)
+
+- **AgenticMail**: 社区关注度持续上升，作为“Email + SMS for agents”双通道基础设施，适合作为本周 Communication 方向重点跟踪项目。
+- **MCP Agent Mail (Rust)**: 在编码代理协作场景讨论热度较高，凭借完整的 MCP tools/resources + 本地 CLI 形态，适合多代理异步协调。
+
 ---
 
 ## Criteria Reminder

--- a/services/communication/weekly-impact-2026-05-18.md
+++ b/services/communication/weekly-impact-2026-05-18.md
@@ -1,0 +1,12 @@
+# Weekly Impact Update (2026-05-11 → 2026-05-18)
+
+> 本周高关注（高 star / 高讨论）agent-native 项目速览。
+
+## Highlights
+
+- **AgenticMail**：社区关注度持续上升，作为“Email + SMS for agents”双通道基础设施。
+- **MCP Agent Mail (Rust)**：编码代理协作场景讨论热度较高，适合多代理异步协调。
+
+## Notes
+
+- 该文档用于沉淀每周观察，避免仅在分类 README 中出现“短条目”而难以追踪历史。

--- a/services/durable-execution-and-scheduling/README.md
+++ b/services/durable-execution-and-scheduling/README.md
@@ -27,6 +27,15 @@ Durable execution for agents requires:
 | [MCP-Cloud (mcp-agent)](mcp-cloud-mcp-agent.md) [![⭐](https://img.shields.io/github/stars/lastmile-ai/mcp-agent?style=social)](https://github.com/lastmile-ai/mcp-agent) | Host mcp-agents on cloud — Temporal-backed durable MCP servers | `uvx mcp-agent` CLI, HTTPS MCP endpoint, secrets, observability | ✅ |
 | [Inferable](inferable.md) [![⭐](https://img.shields.io/github/stars/inferablehq/inferable?style=social)](https://github.com/inferablehq/inferable) | Reliable AI workflows — humans in the loop, structured outputs, durable execution | TypeScript SDK, Python SDK, REST API, Slack/email HITL | ⚠️ |
 
+
+
+## Weekly Impact Update (2026-05-11 → 2026-05-18)
+
+- 详见独立周报文档：[weekly-impact-2026-05-18.md](weekly-impact-2026-05-18.md)
+
+- **Inferable**: 在“durable execution + HITL + structured outputs”方向讨论升温，适合生产级 agent workflow。
+- **MCP-Cloud (mcp-agent)**: Temporal-backed durable MCP server 架构持续受到关注，适合长周期任务与失败恢复场景。
+
 ---
 
 ## Criteria Reminder

--- a/services/durable-execution-and-scheduling/weekly-impact-2026-05-18.md
+++ b/services/durable-execution-and-scheduling/weekly-impact-2026-05-18.md
@@ -1,0 +1,12 @@
+# Weekly Impact Update (2026-05-11 → 2026-05-18)
+
+> 本周高关注（高 star / 高讨论）agent-native 项目速览。
+
+## Highlights
+
+- **Inferable**：durable execution + HITL + structured outputs 讨论升温。
+- **MCP-Cloud (mcp-agent)**：Temporal-backed durable MCP server 架构持续受关注。
+
+## Notes
+
+- 该文档用于沉淀每周观察，避免仅在分类 README 中出现“短条目”而难以追踪历史。

--- a/services/memory-and-state/README.md
+++ b/services/memory-and-state/README.md
@@ -36,6 +36,15 @@ Agent-native memory services solve this by providing:
 | [MemMachine](memmachine.md) [![⭐](https://img.shields.io/github/stars/MemMachine/MemMachine?style=social)](https://github.com/MemMachine/MemMachine) | Universal memory layer — episodic graph + profile SQL + working memory | Python SDK, LangChain/CrewAI adapters, REST API | ⚠️ |
 | [Cognee](cognee.md) [![⭐](https://img.shields.io/github/stars/topoteretes/cognee?style=social)](https://github.com/topoteretes/cognee) | Memory control plane for AI agents — managed world model with auto ontology | Python SDK, 28+ connectors, MCP server, framework adapters | ✅ |
 
+
+
+## Weekly Impact Update (2026-05-11 → 2026-05-18)
+
+- 详见独立周报文档：[weekly-impact-2026-05-18.md](weekly-impact-2026-05-18.md)
+
+- **Cognee**: 在“memory control plane + world model”方向保持高关注，适合需要结构化长期记忆的代理应用。
+- **MemMachine**: 围绕 episodic graph + profile memory 的实践讨论增多，适合需要多层记忆策略的复杂代理。
+
 ---
 
 ## Criteria Reminder

--- a/services/memory-and-state/weekly-impact-2026-05-18.md
+++ b/services/memory-and-state/weekly-impact-2026-05-18.md
@@ -1,0 +1,12 @@
+# Weekly Impact Update (2026-05-11 → 2026-05-18)
+
+> 本周高关注（高 star / 高讨论）agent-native 项目速览。
+
+## Highlights
+
+- **Cognee**：memory control plane + world model 方向关注度高。
+- **MemMachine**：episodic graph + profile memory 的实践讨论增多。
+
+## Notes
+
+- 该文档用于沉淀每周观察，避免仅在分类 README 中出现“短条目”而难以追踪历史。

--- a/services/observability-and-tracing/README.md
+++ b/services/observability-and-tracing/README.md
@@ -31,6 +31,15 @@ Agent-native observability services capture **agent trajectory** — the semanti
 | [Galileo](galileo.md) | Agent reliability platform — observability, evals, and IDE MCP loop | Tracing + evals + Signals, MCP HTTP endpoint, Python/TS SDKs | ✅ |
 | [Laminar](laminar.md) [![⭐](https://img.shields.io/github/stars/lmnr-ai/lmnr?style=social)](https://github.com/lmnr-ai/lmnr) | Open-source observability for long-running agents — agent debugger, browser session replay, Signals | OTLP, Python/TS SDK, SQL API, Evals SDK, self-host | ⚠️ |
 
+
+
+## Weekly Impact Update (2026-05-11 → 2026-05-18)
+
+- 详见独立周报文档：[weekly-impact-2026-05-18.md](weekly-impact-2026-05-18.md)
+
+- **LangWatch**: 开源 LLM/Agent 可观测性话题热度持续，适合作为 trace + eval 统一入口。
+- **AgentEvals**: 基于 OpenTelemetry trace 的“无需重跑评估”范式在本周讨论中较受关注。
+
 ---
 
 ## Criteria Reminder

--- a/services/observability-and-tracing/weekly-impact-2026-05-18.md
+++ b/services/observability-and-tracing/weekly-impact-2026-05-18.md
@@ -1,0 +1,12 @@
+# Weekly Impact Update (2026-05-11 → 2026-05-18)
+
+> 本周高关注（高 star / 高讨论）agent-native 项目速览。
+
+## Highlights
+
+- **LangWatch**：开源 LLM/Agent 可观测性话题热度持续。
+- **AgentEvals**：基于 OpenTelemetry trace 的无需重跑评估范式受关注。
+
+## Notes
+
+- 该文档用于沉淀每周观察，避免仅在分类 README 中出现“短条目”而难以追踪历史。

--- a/services/tool-access-and-integration/README.md
+++ b/services/tool-access-and-integration/README.md
@@ -31,6 +31,15 @@ Agent-native tool access services solve all three problems with primitives that 
 | [Obot](obot.md) [![⭐](https://img.shields.io/github/stars/obot-platform/obot?style=social)](https://github.com/obot-platform/obot) | Complete MCP Platform — Hosting, Registry, Gateway, Chat Client | MCP (Streamable HTTP), REST admin API, OAuth 2.1, Helm chart | ✅ |
 
 
+
+
+## Weekly Impact Update (2026-05-11 → 2026-05-18)
+
+- 详见独立周报文档：[weekly-impact-2026-05-18.md](weekly-impact-2026-05-18.md)
+
+- **ClawHub**: 技能市场/分发层讨论热度较高，适合作为 Agent 工具发现与安装入口。
+- **GitHub MCP Server**: 作为官方生态入口之一，围绕仓库、Issue、PR、Actions 的 agent workflow 讨论持续增长。
+
 ---
 
 ## Criteria Reminder

--- a/services/tool-access-and-integration/weekly-impact-2026-05-18.md
+++ b/services/tool-access-and-integration/weekly-impact-2026-05-18.md
@@ -1,0 +1,12 @@
+# Weekly Impact Update (2026-05-11 → 2026-05-18)
+
+> 本周高关注（高 star / 高讨论）agent-native 项目速览。
+
+## Highlights
+
+- **ClawHub**：技能市场/分发层讨论热度较高。
+- **GitHub MCP Server**：官方生态入口之一，agent workflow 讨论持续增长。
+
+## Notes
+
+- 该文档用于沉淀每周观察，避免仅在分类 README 中出现“短条目”而难以追踪历史。


### PR DESCRIPTION
### Motivation

- Capture and persist weekly observations about high-impact agent-native projects so short notes don't get lost inside long README files. 
- Surface those weekly summaries in the category indexes to make them discoverable alongside service catalog entries. 
- Provide a consistent place per category to record ongoing community interest and discussion trends for historical tracking.

### Description

- Added new weekly impact documents `services/*/weekly-impact-2026-05-18.md` for the following categories: `browser-and-web-execution`, `communication`, `durable-execution-and-scheduling`, `memory-and-state`, `observability-and-tracing`, and `tool-access-and-integration`.
- Updated each category's service README (e.g. `services/browser-and-web-execution/README.md`, `services/communication/README.md`, etc.) to include a `## Weekly Impact Update (2026-05-11 → 2026-05-18)` section linking the new weekly document.
- Updated the category index pages under `docs/categories/*.md` to add a `Weekly Impact Update (2026-05-11 → 2026-05-18)` entry and point to the corresponding `weekly-impact-2026-05-18.md` file for each category.
- Content added summarizes highlights and notes for each category (short, high-level bullets in Chinese) and documents the intent to keep weekly observations separate from primary READMEs.

### Testing

- No automated tests were executed for these documentation-only changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a6a9ca3d8832ea80bc6fecc7998a8)