### PR TITLE
Add TWZRD Agent Intel — Solana x402 agent trust MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Source files are in `.skills/` in this repo. ClawHub CLI options (including the 
 | [Nevermined](services/commerce-and-payments/nevermined.md) | The payment layer AI agents actually need | HTTP x402 protocol · Inline payment · Usage/outcome-based billing | ⚠️ | `pip install payments-py` — x402 handles payments transparently in the HTTP cycle |
 | [Coinbase CDP (x402)](services/commerce-and-payments/coinbase-x402.md) [![⭐](https://img.shields.io/github/stars/coinbase/x402?style=social)](https://github.com/coinbase/x402) | HTTP 402 payments for autonomous API clients | Facilitator verify/settle · Multi-language SDKs · Bazaar discovery | ⚠️ | [docs.cdp.coinbase.com/x402](https://docs.cdp.coinbase.com/x402/welcome) — `pip install x402` or `@x402/*` per [coinbase/x402](https://github.com/coinbase/x402) |
 | [Openwork](services/agent-social-network/openwork.md) | The agent-only labor marketplace — agents hire agents on-chain | Agent-to-agent hiring · On-chain escrow · $OPENWORK earnings | ⚠️ | `npx playbooks add skill openclaw/skills --skill openwork` |
+| [TWZRD Agent Intel](https://intel.twzrd.xyz) | Solana agent trust scoring and on-chain receipt verification | Agent resolve/score · Preflight trust check · x402/USDC receipt · Verify receipt | ✅ | `{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}` — zero-install Streamable HTTP |
 
 ---
 


### PR DESCRIPTION
Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to **Section 5: Commerce & Payments**.

TWZRD Agent Intel is an agent-native MCP server on Solana for trust scoring, identity resolution, and on-chain receipt generation. It fits the commerce/payments category alongside the existing x402 entries (Nevermined, Coinbase CDP x402).

**What it does**:
- Resolve and score agent identity on Solana via `resolve_agent` / `score_agent` / `preflight_check` — free tools for trust verification before a transaction
- Generate signed on-chain trust receipts via `get_trust_receipt` — paid via x402/USDC micropayment
- Verify existing receipts via `verify_trust_receipt` — free

**Install** (zero-install Streamable HTTP transport):
```json
{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}
```

Satisfies the "designed from the ground up for AI agents" criterion: the endpoint, tools, and payment model are all AI-native — no human-facing product layer.