### PR TITLE
feat: add TWZRD Agent Intel — Solana x402 agent trust scoring MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Source files are in `.skills/` in this repo. ClawHub CLI options (including the 
 | [Nevermined](services/commerce-and-payments/nevermined.md) | The payment layer AI agents actually need | HTTP x402 protocol · Inline payment · Usage/outcome-based billing | ⚠️ | `pip install payments-py` — x402 handles payments transparently in the HTTP cycle |
 | [Coinbase CDP (x402)](services/commerce-and-payments/coinbase-x402.md) [![⭐](https://img.shields.io/github/stars/coinbase/x402?style=social)](https://github.com/coinbase/x402) | HTTP 402 payments for autonomous API clients | Facilitator verify/settle · Multi-language SDKs · Bazaar discovery | ⚠️ | [docs.cdp.coinbase.com/x402](https://docs.cdp.coinbase.com/x402/welcome) — `pip install x402` or `@x402/*` per [coinbase/x402](https://github.com/coinbase/x402) |
 | [Openwork](services/agent-social-network/openwork.md) | The agent-only labor marketplace — agents hire agents on-chain | Agent-to-agent hiring · On-chain escrow · $OPENWORK earnings | ⚠️ | `npx playbooks add skill openclaw/skills --skill openwork` |
+| [TWZRD Agent Intel](https://intel.twzrd.xyz) | Solana agent trust scoring and on-chain receipt verification | Agent resolve/score · Preflight trust check · x402/USDC receipt · Verify receipt | ✅ | `{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}` — zero-install Streamable HTTP |
 
 ---
 


### PR DESCRIPTION
## Summary

Adds **[TWZRD Agent Intel](https://intel.twzrd.xyz)** to section 3 (Tool access & integration).

TWZRD Agent Intel is a Solana-native x402 MCP server designed from the ground up for AI agents — it provides on-chain trust scoring and signed trust receipts that agents can use for pre-dispatch reputation checks.

### Why it fits this list
- Agent-native design: agents consume it directly as infrastructure, not a human-facing tool
- On-chain trust gating for agent-to-agent interactions
- x402 micropayments mean agents can pay autonomously (<$0.01 USDC per receipt)
- Zero-install Streamable HTTP — no npm install, no local process

### Tools
| Tool | Description | Paid? |
|------|-------------|-------|
| `resolve_agent` | Resolve Solana wallet → agent profile | Free |
| `score_agent` | On-chain trust score | Free |
| `preflight_check` | Pre-dispatch trust gate | Free |
| `verify_trust_receipt` | Verify signed V5 receipt | Free |
| `get_trust_receipt` | Issue signed trust token | x402 (<$0.01) |

**Install:** `claude mcp add twzrd-agent-intel --transport http https://intel.twzrd.xyz/mcp`