### PR TITLE
Add Claude Code plugin marketplace + skills-hub metadata

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,21 @@
+{
+  "name": "awesome-agent-native-services",
+  "description": "A Claude Code plugin marketplace for skills that help agents discover and evaluate agent-native infrastructure services.",
+  "owner": {
+    "name": "Awesome Agent-Native Services maintainers"
+  },
+  "plugins": [
+    {
+      "name": "awesome-agent-native-services",
+      "displayName": "Awesome Agent-Native Services",
+      "source": "./",
+      "description": "Install the catalog skills: find-agent-service, evaluate-agent-native, and add-to-awesome-list.",
+      "repository": "https://github.com/haoruilee/awesome-agent-native-services",
+      "homepage": "https://haoruilee.github.io/awesome-agent-native-services/",
+      "license": "CC0-1.0",
+      "category": "agent-infrastructure",
+      "tags": ["agent-native", "mcp", "skills", "catalog"],
+      "keywords": ["agent-native", "mcp", "skills", "catalog", "ai-agents"]
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "awesome-agent-native-services",
+  "description": "Skills for discovering, evaluating, and contributing to the Awesome Agent-Native Services catalog.",
+  "repository": "https://github.com/haoruilee/awesome-agent-native-services",
+  "homepage": "https://haoruilee.github.io/awesome-agent-native-services/",
+  "license": "CC0-1.0",
+  "author": {
+    "name": "Awesome Agent-Native Services maintainers"
+  },
+  "skills": [
+    "./.skills"
+  ],
+  "keywords": [
+    "agent-native",
+    "mcp",
+    "skills",
+    "catalog",
+    "ai-agents"
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -7,9 +7,7 @@
   "author": {
     "name": "Awesome Agent-Native Services maintainers"
   },
-  "skills": [
-    "./.skills"
-  ],
+  "skills": "./.skills",
   "keywords": [
     "agent-native",
     "mcp",

--- a/.skills/add-to-awesome-list/SKILL.md
+++ b/.skills/add-to-awesome-list/SKILL.md
@@ -9,7 +9,7 @@ license: CC0-1.0
 compatibility: Works with any agent that can read, write, and use git.
 metadata:
   repo: https://github.com/haoruilee/awesome-agent-native-services
-  catalog-version: "2026-03-15"
+  catalog-version: "2026-06-12"
 allowed-tools: WebSearch Read Write Shell
 ---
 
@@ -31,7 +31,13 @@ If YES — this is **URL Onboarding**, the highest form of agent-nativeness. Mar
 
 **Known URL Onboarding services in the catalog:**
 - Moltbook: `Read https://www.moltbook.com/skill.md and follow the instructions to register and join`
-- Ensue/autoresearch@home: `Read https://ensue.dev/docs` + `Read .../collab.md and follow the instructions to join`
+- Ensue: `Read https://ensue.dev/docs and call POST https://api.ensue-network.ai/auth/agent-register`
+- autoresearch@home: `Read https://raw.githubusercontent.com/mutable-state-inc/autoresearch-at-home/master/collab.md and follow the instructions to join`
+- db9: `Read https://db9.ai/skill.md and follow the instructions`
+- mem9: `Read https://mem9.ai/skill.md and follow the instructions to register and join`
+- mails.dev: `Read https://mails.dev/skill.md and follow the instructions`
+- MailboxKit: `Read https://mailboxkit.com/skill.md and follow the instructions`
+- Agents Mail: `Read https://agentsmail.org/skill.md and follow the instructions`
 
 When the new service has URL Onboarding, lead with this in every section.
 

--- a/.skills/evaluate-agent-native/SKILL.md
+++ b/.skills/evaluate-agent-native/SKILL.md
@@ -9,7 +9,7 @@ license: CC0-1.0
 compatibility: Works with any agent that can read URLs and analyze text.
 metadata:
   repo: https://github.com/haoruilee/awesome-agent-native-services
-  catalog-version: "2026-03-15"
+  catalog-version: "2026-06-12"
 allowed-tools: WebSearch Read
 ---
 
@@ -32,7 +32,9 @@ Read <url> and follow the instructions.
 
 Examples:
 - **Moltbook**: `Read https://www.moltbook.com/skill.md` — complete registration, heartbeat, posting, DM protocol
-- **Ensue / autoresearch@home**: `Read https://raw.githubusercontent.com/mutable-state-inc/autoresearch-at-home/master/collab.md` — complete swarm joining, claiming, publishing protocol
+- **Ensue**: `Read https://ensue.dev/docs and call POST https://api.ensue-network.ai/auth/agent-register` — shared-memory agent registration
+- **autoresearch@home**: `Read https://raw.githubusercontent.com/mutable-state-inc/autoresearch-at-home/master/collab.md` — complete swarm joining, claiming, publishing protocol
+- **db9 / mem9 / mails.dev / MailboxKit / Agents Mail**: domain-hosted `skill.md` URL onboarding for database, memory, and email workflows
 
 This is qualitatively different from:
 - An SDK that a human developer installs (requires human coding time)

--- a/.skills/find-agent-service/SKILL.md
+++ b/.skills/find-agent-service/SKILL.md
@@ -9,7 +9,7 @@ license: CC0-1.0
 compatibility: Works with any agent that can read markdown files and call web searches.
 metadata:
   repo: https://github.com/haoruilee/awesome-agent-native-services
-  catalog-version: "2026-03-15"
+  catalog-version: "2026-06-12"
 allowed-tools: WebSearch Read
 ---
 
@@ -32,7 +32,13 @@ This is called **URL Onboarding** — the service hosts a machine-readable skill
 | Service | Onboarding instruction |
 |---|---|
 | **Moltbook** | `Read https://www.moltbook.com/skill.md and follow the instructions to register and join` |
-| **Ensue / autoresearch@home** | `Read https://ensue.dev/docs and call POST /auth/agent-register` OR `Read https://raw.githubusercontent.com/mutable-state-inc/autoresearch-at-home/master/collab.md and follow the instructions to join` |
+| **Ensue** | `Read https://ensue.dev/docs and call POST https://api.ensue-network.ai/auth/agent-register` |
+| **autoresearch@home** | `Read https://raw.githubusercontent.com/mutable-state-inc/autoresearch-at-home/master/collab.md and follow the instructions to join` |
+| **db9** | `Read https://db9.ai/skill.md and follow the instructions` |
+| **mem9** | `Read https://mem9.ai/skill.md and follow the instructions to register and join` |
+| **mails.dev** | `Read https://mails.dev/skill.md and follow the instructions` |
+| **MailboxKit** | `Read https://mailboxkit.com/skill.md and follow the instructions` |
+| **Agents Mail** | `Read https://agentsmail.org/skill.md and follow the instructions` |
 
 When a task maps to one of these services, always lead with the onboarding instruction — it's the most actionable thing you can give an agent.
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Read https://raw.githubusercontent.com/haoruilee/awesome-agent-native-services/m
 
 Besides, you can install these skills through either Claude Code's plugin marketplace flow or ClawHub/OpenClaw:
 
-**Claude Code plugin marketplace:**
+**Claude Code plugin marketplace** (requires a Claude Code version with plugin support; see the [official plugin marketplace docs](https://code.claude.com/docs/en/discover-plugins)):
 
 ```text
 /plugin marketplace add haoruilee/awesome-agent-native-services
@@ -74,16 +74,16 @@ Source files are in `.skills/` in this repo. See [SKILLS_HUB.md](SKILLS_HUB.md) 
 | 2 | [Browser & Web Execution](#2-browser--web-execution-services) | 19 | Remote browser and web data extraction for agents |
 | 3 | [Tool Access & Integration](#3-tool-access--integration-services) | 13 | Runtime tool discovery, auth, and execution |
 | 4 | [Oversight & Approval](#4-oversight--approval-services) | 1 | Human-in-the-loop approval and escalation |
-| 5 | [Commerce & Payments](#5-commerce--payment-services) | 8 | Agent-native wallets, identity, and transactions |
+| 5 | [Commerce & Payments](#5-commerce--payment-services) | 7 | Agent-native wallets, identity, and transactions |
 | 6 | [Agent Runtime & Infrastructure](#6-agent-runtime--infrastructure-services) | 23 | Execution, session isolation, secrets, and gateway |
 | 7 | [Memory & State](#7-memory--state-services) | 11 | Persistent agent memory across sessions |
-| 8 | [Search & Web Intelligence](#8-search--web-intelligence-services) | 7 | LLM-optimized web search and content retrieval |
+| 8 | [Search & Web Intelligence](#8-search--web-intelligence-services) | 6 | LLM-optimized web search and content retrieval |
 | 9 | [Code Execution](#9-code-execution-services) | 7 | Secure sandboxes for AI-generated code |
 | 10 | [Observability & Tracing](#10-observability--tracing-services) | 8 | Agent trajectory tracing and evaluation |
 | 11 | [Durable Execution & Scheduling](#11-durable-execution--scheduling-services) | 6 | Fault-tolerant long-running agent workflows |
 | 12 | [Meeting & Conversation](#12-meeting--conversation-services) | 5 | Agent presence in voice and video meetings |
 | 13 | [Voice & Phone](#13-voice--phone-services) | 5 | Agent-controlled voice calls and phone infrastructure |
-| 14 | [LLM Gateway & Routing](#14-llm-gateway--routing-services) | 7 | Per-agent budget, routing, caching, and observability for LLM calls |
+| 14 | [LLM Gateway & Routing](#14-llm-gateway--routing-services) | 8 | Per-agent budget, routing, caching, and observability for LLM calls |
 | 15 | [Agent Social & Community](#15-agent-social--community-services) | 5 | Social networks where agents are first-class participants |
 
 ---
@@ -399,7 +399,7 @@ Organizations, registries, and marketplaces that provide multiple agent-native s
 
 | Hub | What It Provides | How Agents Start |
 |---|---|---|
-| [Awesome Agent-Native Services Skills Hub](SKILLS_HUB.md) | This repository as a Claude Code plugin marketplace plus ClawHub/OpenClaw skills for finding, evaluating, and adding agent-native services | Claude Code: `/plugin marketplace add haoruilee/awesome-agent-native-services` → `/plugin install awesome-agent-native-services@awesome-agent-native-services`; ClawHub: `npx clawhub@latest install find-agent-service` |
+| [Awesome Agent-Native Services Skills Hub](SKILLS_HUB.md) | This repository as an [official Claude Code plugin marketplace](https://code.claude.com/docs/en/discover-plugins)-compatible source plus ClawHub/OpenClaw skills for finding, evaluating, and adding agent-native services | Claude Code: `/plugin marketplace add haoruilee/awesome-agent-native-services` → `/plugin install awesome-agent-native-services@awesome-agent-native-services`; ClawHub: `npx clawhub@latest install find-agent-service` |
 | [OpenClaw](https://github.com/openclaw) | Agent Client Protocol tooling, skills registry, agent marketplace integration | Use [acpx](services/agent-runtime-and-infrastructure/acpx.md), [openclaw/skills](https://github.com/openclaw/skills), and [Openwork](services/agent-social-network/openwork.md) integrations |
 | [ClawHub](services/tool-access-and-integration/clawhub.md) | Full entry in section **3. Tool Access & Integration**; public registry for OpenClaw-style skills and this catalog's `.skills/` packages | `npx clawhub@latest search <topic>` or install this catalog's skills from `.skills/`; see [clawhub/README.md](clawhub/README.md) for mirror settings |
 | [MiniMax Skills](https://github.com/MiniMax-AI/skills) [![⭐](https://img.shields.io/github/stars/MiniMax-AI/skills?style=social)](https://github.com/MiniMax-AI/skills) | Curated **development skills** for AI coding agents — structured `SKILL.md` workflows for frontend, fullstack, mobile, shaders, and document generation | Follow the repo README for Claude Code plugin, Cursor skills path, and Codex / OpenCode install paths |

--- a/README.md
+++ b/README.md
@@ -44,7 +44,17 @@ If you are an AI agent and want to discover services designed for you:
 Read https://raw.githubusercontent.com/haoruilee/awesome-agent-native-services/main/skill.md then find services designed for you natively.
 ```
 
-Besides, you can install these skills:
+Besides, you can install these skills through either Claude Code's plugin marketplace flow or ClawHub/OpenClaw:
+
+**Claude Code plugin marketplace:**
+
+```text
+/plugin marketplace add haoruilee/awesome-agent-native-services
+/plugin install awesome-agent-native-services@awesome-agent-native-services
+/reload-plugins
+```
+
+**ClawHub / OpenClaw:**
 
 | Skill | What it does | Install |
 |---|---|---|
@@ -52,7 +62,7 @@ Besides, you can install these skills:
 | `evaluate-agent-native` | Evaluate whether a service meets the 5 criteria | `npx clawhub@latest install evaluate-agent-native` |
 | `add-to-awesome-list` | Full contribution workflow: criteria → issue → PR | `npx clawhub@latest install add-to-awesome-list` |
 
-Source files are in `.skills/` in this repo. ClawHub CLI options (including the China mirror) are documented in [clawhub/README.md](clawhub/README.md).
+Source files are in `.skills/` in this repo. See [SKILLS_HUB.md](SKILLS_HUB.md) for Claude Code, ClawHub/OpenClaw, and manual `SKILL.md` installation paths. ClawHub CLI options (including the China mirror) are documented in [clawhub/README.md](clawhub/README.md).
 
 ---
 
@@ -62,14 +72,14 @@ Source files are in `.skills/` in this repo. ClawHub CLI options (including the 
 |---|---|---|---|
 | 1 | [Communication](#1-communication-services) | 10 | Give agents a communication identity on the internet |
 | 2 | [Browser & Web Execution](#2-browser--web-execution-services) | 19 | Remote browser and web data extraction for agents |
-| 3 | [Tool Access & Integration](#3-tool-access--integration-services) | 11 | Runtime tool discovery, auth, and execution |
+| 3 | [Tool Access & Integration](#3-tool-access--integration-services) | 13 | Runtime tool discovery, auth, and execution |
 | 4 | [Oversight & Approval](#4-oversight--approval-services) | 1 | Human-in-the-loop approval and escalation |
-| 5 | [Commerce & Payments](#5-commerce--payment-services) | 7 | Agent-native wallets, identity, and transactions |
-| 6 | [Agent Runtime & Infrastructure](#6-agent-runtime--infrastructure-services) | 22 | Execution, session isolation, secrets, and gateway |
+| 5 | [Commerce & Payments](#5-commerce--payment-services) | 8 | Agent-native wallets, identity, and transactions |
+| 6 | [Agent Runtime & Infrastructure](#6-agent-runtime--infrastructure-services) | 23 | Execution, session isolation, secrets, and gateway |
 | 7 | [Memory & State](#7-memory--state-services) | 11 | Persistent agent memory across sessions |
-| 8 | [Search & Web Intelligence](#8-search--web-intelligence-services) | 6 | LLM-optimized web search and content retrieval |
+| 8 | [Search & Web Intelligence](#8-search--web-intelligence-services) | 7 | LLM-optimized web search and content retrieval |
 | 9 | [Code Execution](#9-code-execution-services) | 7 | Secure sandboxes for AI-generated code |
-| 10 | [Observability & Tracing](#10-observability--tracing-services) | 7 | Agent trajectory tracing and evaluation |
+| 10 | [Observability & Tracing](#10-observability--tracing-services) | 8 | Agent trajectory tracing and evaluation |
 | 11 | [Durable Execution & Scheduling](#11-durable-execution--scheduling-services) | 6 | Fault-tolerant long-running agent workflows |
 | 12 | [Meeting & Conversation](#12-meeting--conversation-services) | 5 | Agent presence in voice and video meetings |
 | 13 | [Voice & Phone](#13-voice--phone-services) | 5 | Agent-controlled voice calls and phone infrastructure |
@@ -385,13 +395,20 @@ Source files are in `.skills/` in this repo. ClawHub CLI options (including the 
 
 ## Ecosystem Hubs
 
-Organizations that provide multiple agent-native services or tools:
+Organizations, registries, and marketplaces that provide multiple agent-native services, tools, MCP servers, or `SKILL.md` sources. Some qualify as first-class catalog services; others are tracked here as high-signal ecosystem pointers pending issue-level review.
 
-| Hub | What It Provides | Notable Projects |
+| Hub | What It Provides | How Agents Start |
 |---|---|---|
-| [OpenClaw](https://github.com/openclaw) | Agent Client Protocol tooling, skills registry, agent marketplace integration | [acpx](services/agent-runtime-and-infrastructure/acpx.md) (ACP CLI), [openclaw/skills](https://github.com/openclaw/skills) (skills for Openwork, Exa, OpenViking, MemOS, E2B), [Openwork](services/agent-social-network/openwork.md) integration |
-| [ClawHub](services/tool-access-and-integration/clawhub.md) | Full entry in section **3. Tool Access & Integration**; this row links the broader OpenClaw ecosystem | [openclaw/clawhub](https://github.com/openclaw/clawhub) CLI, [`.skills/`](https://github.com/haoruilee/awesome-agent-native-services/tree/main/.skills) for this catalog, [openclaw/skills](https://github.com/openclaw/skills) |
-| [MiniMax Skills](https://github.com/MiniMax-AI/skills) [![⭐](https://img.shields.io/github/stars/MiniMax-AI/skills?style=social)](https://github.com/MiniMax-AI/skills) | Curated **development skills** for AI coding agents — structured `SKILL.md` workflows for frontend, fullstack, mobile, and document generation (Claude Code plugin, Cursor skills path, Codex / OpenCode install paths) | Per-skill folders under [`skills/`](https://github.com/MiniMax-AI/skills/tree/main/skills) with YAML-frontmatter `SKILL.md` ([contributing spec](https://github.com/MiniMax-AI/skills/blob/main/CONTRIBUTING.md)) |
+| [Awesome Agent-Native Services Skills Hub](SKILLS_HUB.md) | This repository as a Claude Code plugin marketplace plus ClawHub/OpenClaw skills for finding, evaluating, and adding agent-native services | Claude Code: `/plugin marketplace add haoruilee/awesome-agent-native-services` → `/plugin install awesome-agent-native-services@awesome-agent-native-services`; ClawHub: `npx clawhub@latest install find-agent-service` |
+| [OpenClaw](https://github.com/openclaw) | Agent Client Protocol tooling, skills registry, agent marketplace integration | Use [acpx](services/agent-runtime-and-infrastructure/acpx.md), [openclaw/skills](https://github.com/openclaw/skills), and [Openwork](services/agent-social-network/openwork.md) integrations |
+| [ClawHub](services/tool-access-and-integration/clawhub.md) | Full entry in section **3. Tool Access & Integration**; public registry for OpenClaw-style skills and this catalog's `.skills/` packages | `npx clawhub@latest search <topic>` or install this catalog's skills from `.skills/`; see [clawhub/README.md](clawhub/README.md) for mirror settings |
+| [MiniMax Skills](https://github.com/MiniMax-AI/skills) [![⭐](https://img.shields.io/github/stars/MiniMax-AI/skills?style=social)](https://github.com/MiniMax-AI/skills) | Curated **development skills** for AI coding agents — structured `SKILL.md` workflows for frontend, fullstack, mobile, shaders, and document generation | Follow the repo README for Claude Code plugin, Cursor skills path, and Codex / OpenCode install paths |
+| [Agensi](https://www.agensi.io/) | Marketplace for paid/free AI agent skills with security scanning, broad agent compatibility, and agent-native MCP discovery | Download skills into an agent skills directory or connect MCP at `https://mcp.agensi.io/mcp` |
+| [SkillsMP](https://skillsmp.com/) | Large public `SKILL.md` index with source/repository context, occupations, creators, and API access | Search by task or repository, inspect the source repo, then install according to that skill's instructions |
+| [mdskills.ai](https://www.mdskills.ai/) | Community marketplace for skills, plugins, MCP servers, rules, and tools with quality/security review and CLI install | `npx mdskills` |
+| [sklz.city](https://sklz.city/) | MCP-native skill runtime and marketplace: import `SKILL.md` repos, add runtime primitives, publish/discover over MCP | `curl -fsSL https://sklz.city/install.sh | sh && sklz install` |
+| [SkillCrate](https://skillcrate.dev/) | Vertical, open-source skill marketplace for Amazon seller workflows; each skill is a GitHub repo with `SKILL.md` and MCP packaging | Clone a skill repo or download MCPB, then configure the MCP server / skill in the target agent |
+| [CryptoSkill](https://cryptoskill.org/) | Crypto-focused registry of skills and MCP servers for Claude Code, OpenClaw, Codex, Cursor, and SKILL.md-compatible agents | Clone/copy a skill into `.claude/skills/`, use `clawhub install`, or add hosted MCP servers with `claude mcp add` |
 
 ---
 

--- a/RESEARCH_AUDIT.md
+++ b/RESEARCH_AUDIT.md
@@ -10,7 +10,7 @@ This note records the latest broad review pass requested by maintainers. It is i
 
 ## Applied updates
 
-- Added a Claude Code-compatible plugin marketplace at `.claude-plugin/marketplace.json`.
+- Added a Claude Code-compatible plugin marketplace at `.claude-plugin/marketplace.json`, verified against Anthropic's official plugin marketplace documentation.
 - Added a Claude Code plugin manifest at `.claude-plugin/plugin.json` that exposes the existing `.skills/` folders without duplicating skill content.
 - Added `SKILLS_HUB.md` with Claude Code, ClawHub/OpenClaw, and manual `SKILL.md` installation instructions.
 - Updated the root README and `llms.txt` so agents can discover the repository as a skills source, not only as a Markdown catalog.
@@ -23,7 +23,7 @@ These were reviewed as candidate hubs or sources. Some are already cataloged as 
 
 | Candidate | Signal observed | Current catalog action |
 |---|---|---|
-| Claude Code plugin marketplaces | Official Claude Code docs describe GitHub-hosted marketplaces that use `.claude-plugin/marketplace.json`, with users adding a source via `/plugin marketplace add owner/repo`. | Implemented this repo as a Claude Code marketplace. |
+| Claude Code plugin marketplaces | Official Claude Code docs describe GitHub-hosted marketplaces that use `.claude-plugin/marketplace.json`, with users adding a source via `/plugin marketplace add owner/repo`, installing via `/plugin install`, and reloading with `/reload-plugins`. | Implemented this repo as a Claude Code marketplace and linked the official docs from the skills-hub instructions. |
 | ClawHub | Existing catalog entry and `.skills/` publish workflow; remains the canonical OpenClaw-style skill registry path for this repo. | Kept as first-class Tool Access & Integration entry and install path. |
 | MiniMax Skills | High-signal curated `SKILL.md` packs for coding agents; already tracked in Ecosystem Hubs. | Kept as ecosystem hub. |
 | Agensi | Marketplace for AI agent skills with paid/free downloads, security scanning, broad agent compatibility, and an MCP endpoint for agent-side discovery. | Added to Ecosystem Hubs / skill-hub pointers rather than a service file pending issue review. |

--- a/RESEARCH_AUDIT.md
+++ b/RESEARCH_AUDIT.md
@@ -1,0 +1,41 @@
+# Research & Freshness Audit — 2026-06-12
+
+This note records the latest broad review pass requested by maintainers. It is intentionally lightweight: the catalog remains issue-first for new service files, but this file captures high-signal ecosystem findings and freshness work already applied in this PR.
+
+## Scope
+
+- Searched for high-signal, agent-native services and skill hubs with strong discussion or visible ecosystem adoption.
+- Reviewed the repository's current category coverage, generated-docs workflow, skill publishing workflow, and agent onboarding surfaces.
+- Prioritized updates that make the repository itself easier for coding agents to add as a source.
+
+## Applied updates
+
+- Added a Claude Code-compatible plugin marketplace at `.claude-plugin/marketplace.json`.
+- Added a Claude Code plugin manifest at `.claude-plugin/plugin.json` that exposes the existing `.skills/` folders without duplicating skill content.
+- Added `SKILLS_HUB.md` with Claude Code, ClawHub/OpenClaw, and manual `SKILL.md` installation instructions.
+- Updated the root README and `llms.txt` so agents can discover the repository as a skills source, not only as a Markdown catalog.
+- Refreshed stale category service counts in the root README.
+- Bumped skill metadata `catalog-version` values to `2026-06-12`.
+
+## High-signal ecosystem findings
+
+These were reviewed as candidate hubs or sources. Some are already cataloged as first-class service entries (for example ClawHub); others are tracked as ecosystem hubs until a maintainer opens/approves a dedicated service issue.
+
+| Candidate | Signal observed | Current catalog action |
+|---|---|---|
+| Claude Code plugin marketplaces | Official Claude Code docs describe GitHub-hosted marketplaces that use `.claude-plugin/marketplace.json`, with users adding a source via `/plugin marketplace add owner/repo`. | Implemented this repo as a Claude Code marketplace. |
+| ClawHub | Existing catalog entry and `.skills/` publish workflow; remains the canonical OpenClaw-style skill registry path for this repo. | Kept as first-class Tool Access & Integration entry and install path. |
+| MiniMax Skills | High-signal curated `SKILL.md` packs for coding agents; already tracked in Ecosystem Hubs. | Kept as ecosystem hub. |
+| Agensi | Marketplace for AI agent skills with paid/free downloads, security scanning, broad agent compatibility, and an MCP endpoint for agent-side discovery. | Added to Ecosystem Hubs / skill-hub pointers rather than a service file pending issue review. |
+| SkillsMP | Large public `SKILL.md` index with source/repository context and API access for analytics/search. | Added to Ecosystem Hubs / skill-hub pointers rather than a service file pending issue review. |
+| mdskills.ai | Community marketplace for skills, plugins, MCP servers, rules, and tools with CLI install flow and quality/security review. | Added to Ecosystem Hubs / skill-hub pointers rather than a service file pending issue review. |
+| sklz.city | MCP-native skill runtime and marketplace with import, augmentation, monetization, isolation, and security-review primitives. | Added to Ecosystem Hubs / skill-hub pointers rather than a service file pending issue review. |
+| SkillCrate | Vertical skill marketplace where each skill is a GitHub repo with `SKILL.md` and MCP server packaging for Amazon seller operations. | Added to Ecosystem Hubs / skill-hub pointers rather than a service file pending issue review. |
+| CryptoSkill | Crypto-focused registry of open-source skills and MCP servers for Claude Code, OpenClaw, Codex, and related agents. | Added to Ecosystem Hubs / skill-hub pointers rather than a service file pending issue review. |
+
+## Freshness checklist for future passes
+
+1. Re-run `bash scripts/build-github-pages.sh && git diff --quiet -- docs/index.md docs/categories` after any README or `services/**` edit.
+2. Re-check services whose onboarding depends on volatile install commands (`npx`, `uvx`, hosted MCP URLs, Claude plugin marketplace commands).
+3. For newly found hubs, open an issue first unless the change is only an ecosystem pointer or obvious documentation fix.
+4. Treat skill-hub entries as boundary cases unless they provide a machine-to-machine runtime, registry API, MCP endpoint, or agent-installable source with clear provenance.

--- a/SKILLS_HUB.md
+++ b/SKILLS_HUB.md
@@ -1,0 +1,44 @@
+# Awesome Agent-Native Services Skills Hub
+
+This repository is also a cross-agent skills source. Agents can install the same catalog workflows that maintainers use to find services, evaluate agent-nativeness, and prepare contribution PRs.
+
+## Claude Code plugin marketplace
+
+Claude Code can add this repository as a plugin marketplace because the repo root contains `.claude-plugin/marketplace.json` and the plugin manifest points at the repo's `.skills/` directory.
+
+```text
+/plugin marketplace add haoruilee/awesome-agent-native-services
+/plugin install awesome-agent-native-services@awesome-agent-native-services
+/reload-plugins
+```
+
+After installation, Claude Code exposes these namespaced skills:
+
+| Skill | Invocation | Purpose |
+|---|---|---|
+| `find-agent-service` | `/awesome-agent-native-services:find-agent-service` | Find the right agent-native service for a task and surface onboarding steps. |
+| `evaluate-agent-native` | `/awesome-agent-native-services:evaluate-agent-native` | Apply the catalog's five hard criteria and classify a service. |
+| `add-to-awesome-list` | `/awesome-agent-native-services:add-to-awesome-list` | Guide the issue-first contribution workflow and service-file template. |
+
+## ClawHub / OpenClaw
+
+The canonical skill source remains `.skills/`, and the existing ClawHub workflow publishes those skills for OpenClaw-compatible agents:
+
+```bash
+npx clawhub@latest install find-agent-service
+npx clawhub@latest install evaluate-agent-native
+npx clawhub@latest install add-to-awesome-list
+```
+
+For China access acceleration, use the mirror documented in `clawhub/README.md`.
+
+## Manual SKILL.md-compatible agents
+
+Agents that load `SKILL.md` folders directly can copy or symlink individual folders from `.skills/` into their local skill directory. For example:
+
+```bash
+mkdir -p ~/.claude/skills
+cp -R .skills/find-agent-service ~/.claude/skills/
+```
+
+Review any skill before installation, especially if you fetched the repository from a fork.

--- a/SKILLS_HUB.md
+++ b/SKILLS_HUB.md
@@ -4,9 +4,10 @@ This repository is also a cross-agent skills source. Agents can install the same
 
 ## Claude Code plugin marketplace
 
-Claude Code can add this repository as a plugin marketplace because the repo root contains `.claude-plugin/marketplace.json` and the plugin manifest points at the repo's `.skills/` directory.
+Claude Code can add this repository as a plugin marketplace because the repo root contains `.claude-plugin/marketplace.json` and the plugin manifest points at the repo's `.skills/` directory. This follows Anthropic's official Claude Code plugin marketplace flow documented at <https://code.claude.com/docs/en/discover-plugins> and the plugin manifest schema documented at <https://code.claude.com/docs/en/plugins-reference>.
 
 ```text
+# If /plugin is unknown, update Claude Code first.
 /plugin marketplace add haoruilee/awesome-agent-native-services
 /plugin install awesome-agent-native-services@awesome-agent-native-services
 /reload-plugins

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,7 +51,7 @@ Read https://raw.githubusercontent.com/haoruilee/awesome-agent-native-services/m
 
 Besides, you can install these skills through either Claude Code's plugin marketplace flow or ClawHub/OpenClaw:
 
-**Claude Code plugin marketplace:**
+**Claude Code plugin marketplace** (requires a Claude Code version with plugin support; see the [official plugin marketplace docs](https://code.claude.com/docs/en/discover-plugins)):
 
 ```text
 /plugin marketplace add haoruilee/awesome-agent-native-services
@@ -79,16 +79,16 @@ Source files are in `.skills/` in this repo. See [SKILLS_HUB.md](SKILLS_HUB.md) 
 | 2 | [Browser & Web Execution](#2-browser--web-execution-services) | 19 | Remote browser and web data extraction for agents |
 | 3 | [Tool Access & Integration](#3-tool-access--integration-services) | 13 | Runtime tool discovery, auth, and execution |
 | 4 | [Oversight & Approval](#4-oversight--approval-services) | 1 | Human-in-the-loop approval and escalation |
-| 5 | [Commerce & Payments](#5-commerce--payment-services) | 8 | Agent-native wallets, identity, and transactions |
+| 5 | [Commerce & Payments](#5-commerce--payment-services) | 7 | Agent-native wallets, identity, and transactions |
 | 6 | [Agent Runtime & Infrastructure](#6-agent-runtime--infrastructure-services) | 23 | Execution, session isolation, secrets, and gateway |
 | 7 | [Memory & State](#7-memory--state-services) | 11 | Persistent agent memory across sessions |
-| 8 | [Search & Web Intelligence](#8-search--web-intelligence-services) | 7 | LLM-optimized web search and content retrieval |
+| 8 | [Search & Web Intelligence](#8-search--web-intelligence-services) | 6 | LLM-optimized web search and content retrieval |
 | 9 | [Code Execution](#9-code-execution-services) | 7 | Secure sandboxes for AI-generated code |
 | 10 | [Observability & Tracing](#10-observability--tracing-services) | 8 | Agent trajectory tracing and evaluation |
 | 11 | [Durable Execution & Scheduling](#11-durable-execution--scheduling-services) | 6 | Fault-tolerant long-running agent workflows |
 | 12 | [Meeting & Conversation](#12-meeting--conversation-services) | 5 | Agent presence in voice and video meetings |
 | 13 | [Voice & Phone](#13-voice--phone-services) | 5 | Agent-controlled voice calls and phone infrastructure |
-| 14 | [LLM Gateway & Routing](#14-llm-gateway--routing-services) | 7 | Per-agent budget, routing, caching, and observability for LLM calls |
+| 14 | [LLM Gateway & Routing](#14-llm-gateway--routing-services) | 8 | Per-agent budget, routing, caching, and observability for LLM calls |
 | 15 | [Agent Social & Community](#15-agent-social--community-services) | 5 | Social networks where agents are first-class participants |
 
 ---
@@ -404,7 +404,7 @@ Organizations, registries, and marketplaces that provide multiple agent-native s
 
 | Hub | What It Provides | How Agents Start |
 |---|---|---|
-| [Awesome Agent-Native Services Skills Hub](SKILLS_HUB.md) | This repository as a Claude Code plugin marketplace plus ClawHub/OpenClaw skills for finding, evaluating, and adding agent-native services | Claude Code: `/plugin marketplace add haoruilee/awesome-agent-native-services` → `/plugin install awesome-agent-native-services@awesome-agent-native-services`; ClawHub: `npx clawhub@latest install find-agent-service` |
+| [Awesome Agent-Native Services Skills Hub](SKILLS_HUB.md) | This repository as an [official Claude Code plugin marketplace](https://code.claude.com/docs/en/discover-plugins)-compatible source plus ClawHub/OpenClaw skills for finding, evaluating, and adding agent-native services | Claude Code: `/plugin marketplace add haoruilee/awesome-agent-native-services` → `/plugin install awesome-agent-native-services@awesome-agent-native-services`; ClawHub: `npx clawhub@latest install find-agent-service` |
 | [OpenClaw](https://github.com/openclaw) | Agent Client Protocol tooling, skills registry, agent marketplace integration | Use [acpx](services/agent-runtime-and-infrastructure/acpx.md), [openclaw/skills](https://github.com/openclaw/skills), and [Openwork](services/agent-social-network/openwork.md) integrations |
 | [ClawHub](services/tool-access-and-integration/clawhub.md) | Full entry in section **3. Tool Access & Integration**; public registry for OpenClaw-style skills and this catalog's `.skills/` packages | `npx clawhub@latest search <topic>` or install this catalog's skills from `.skills/`; see [clawhub/README.md](clawhub/README.md) for mirror settings |
 | [MiniMax Skills](https://github.com/MiniMax-AI/skills) [![⭐](https://img.shields.io/github/stars/MiniMax-AI/skills?style=social)](https://github.com/MiniMax-AI/skills) | Curated **development skills** for AI coding agents — structured `SKILL.md` workflows for frontend, fullstack, mobile, shaders, and document generation | Follow the repo README for Claude Code plugin, Cursor skills path, and Codex / OpenCode install paths |

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,7 +49,17 @@ If you are an AI agent and want to discover services designed for you:
 Read https://raw.githubusercontent.com/haoruilee/awesome-agent-native-services/main/skill.md then find services designed for you natively.
 ```
 
-Besides, you can install these skills:
+Besides, you can install these skills through either Claude Code's plugin marketplace flow or ClawHub/OpenClaw:
+
+**Claude Code plugin marketplace:**
+
+```text
+/plugin marketplace add haoruilee/awesome-agent-native-services
+/plugin install awesome-agent-native-services@awesome-agent-native-services
+/reload-plugins
+```
+
+**ClawHub / OpenClaw:**
 
 | Skill | What it does | Install |
 |---|---|---|
@@ -57,7 +67,7 @@ Besides, you can install these skills:
 | `evaluate-agent-native` | Evaluate whether a service meets the 5 criteria | `npx clawhub@latest install evaluate-agent-native` |
 | `add-to-awesome-list` | Full contribution workflow: criteria → issue → PR | `npx clawhub@latest install add-to-awesome-list` |
 
-Source files are in `.skills/` in this repo. ClawHub CLI options (including the China mirror) are documented in [clawhub/README.md](clawhub/README.md).
+Source files are in `.skills/` in this repo. See [SKILLS_HUB.md](SKILLS_HUB.md) for Claude Code, ClawHub/OpenClaw, and manual `SKILL.md` installation paths. ClawHub CLI options (including the China mirror) are documented in [clawhub/README.md](clawhub/README.md).
 
 ---
 
@@ -67,14 +77,14 @@ Source files are in `.skills/` in this repo. ClawHub CLI options (including the 
 |---|---|---|---|
 | 1 | [Communication](#1-communication-services) | 10 | Give agents a communication identity on the internet |
 | 2 | [Browser & Web Execution](#2-browser--web-execution-services) | 19 | Remote browser and web data extraction for agents |
-| 3 | [Tool Access & Integration](#3-tool-access--integration-services) | 11 | Runtime tool discovery, auth, and execution |
+| 3 | [Tool Access & Integration](#3-tool-access--integration-services) | 13 | Runtime tool discovery, auth, and execution |
 | 4 | [Oversight & Approval](#4-oversight--approval-services) | 1 | Human-in-the-loop approval and escalation |
-| 5 | [Commerce & Payments](#5-commerce--payment-services) | 7 | Agent-native wallets, identity, and transactions |
-| 6 | [Agent Runtime & Infrastructure](#6-agent-runtime--infrastructure-services) | 22 | Execution, session isolation, secrets, and gateway |
+| 5 | [Commerce & Payments](#5-commerce--payment-services) | 8 | Agent-native wallets, identity, and transactions |
+| 6 | [Agent Runtime & Infrastructure](#6-agent-runtime--infrastructure-services) | 23 | Execution, session isolation, secrets, and gateway |
 | 7 | [Memory & State](#7-memory--state-services) | 11 | Persistent agent memory across sessions |
-| 8 | [Search & Web Intelligence](#8-search--web-intelligence-services) | 6 | LLM-optimized web search and content retrieval |
+| 8 | [Search & Web Intelligence](#8-search--web-intelligence-services) | 7 | LLM-optimized web search and content retrieval |
 | 9 | [Code Execution](#9-code-execution-services) | 7 | Secure sandboxes for AI-generated code |
-| 10 | [Observability & Tracing](#10-observability--tracing-services) | 7 | Agent trajectory tracing and evaluation |
+| 10 | [Observability & Tracing](#10-observability--tracing-services) | 8 | Agent trajectory tracing and evaluation |
 | 11 | [Durable Execution & Scheduling](#11-durable-execution--scheduling-services) | 6 | Fault-tolerant long-running agent workflows |
 | 12 | [Meeting & Conversation](#12-meeting--conversation-services) | 5 | Agent presence in voice and video meetings |
 | 13 | [Voice & Phone](#13-voice--phone-services) | 5 | Agent-controlled voice calls and phone infrastructure |
@@ -158,6 +168,7 @@ Source files are in `.skills/` in this repo. ClawHub CLI options (including the 
 | [MCP Toolbox for Databases](services/tool-access-and-integration/google-mcp-toolbox.md) [![⭐](https://img.shields.io/github/stars/googleapis/mcp-toolbox?style=social)](https://github.com/googleapis/mcp-toolbox) | MCP server connecting agents to enterprise databases | Prebuilt DB tools · Custom governed tools · IAM · OpenTelemetry | ✅ | `npx -y @toolbox-sdk/server --prebuilt=postgres` + env — [mcp-toolbox.dev](https://mcp-toolbox.dev/) |
 | [ToolHive](services/tool-access-and-integration/toolhive.md) [![⭐](https://img.shields.io/github/stars/stacklok/toolhive-studio?style=social)](https://github.com/stacklok/toolhive-studio) | Run any MCP server securely, instantly, anywhere | MCP server discovery/deploy/manage · secure container runtime | ✅ | [toolhive.dev](https://toolhive.dev/) |
 | [Obot](services/tool-access-and-integration/obot.md) [![⭐](https://img.shields.io/github/stars/obot-platform/obot?style=social)](https://github.com/obot-platform/obot) | Complete MCP Platform — Hosting, Registry, Gateway, Chat Client | Hosted MCP servers · Registry · Gateway · OAuth 2.1 · RBAC | ✅ | `helm install obot obot/obot` (or Docker) — [obot.ai](https://obot.ai) |
+| [The Stall](https://github.com/thebrierfox/the-stall) [![⭐](https://img.shields.io/github/stars/thebrierfox/the-stall?style=social)](https://github.com/thebrierfox/the-stall) | 209 pay-per-call AI data capabilities via x402 MCP | Stocks/ETFs · DeFi/on-chain · Polymarket · Crypto · Global macro · Options | ✅ | POST `https://the-stall.intuitek.ai/mcp` — [the-stall.intuitek.ai](https://the-stall.intuitek.ai) · USDC on Base, no API key |
 
 ---
 
@@ -187,6 +198,7 @@ Source files are in `.skills/` in this repo. ClawHub CLI options (including the 
 | [Nevermined](services/commerce-and-payments/nevermined.md) | The payment layer AI agents actually need | HTTP x402 protocol · Inline payment · Usage/outcome-based billing | ⚠️ | `pip install payments-py` — x402 handles payments transparently in the HTTP cycle |
 | [Coinbase CDP (x402)](services/commerce-and-payments/coinbase-x402.md) [![⭐](https://img.shields.io/github/stars/coinbase/x402?style=social)](https://github.com/coinbase/x402) | HTTP 402 payments for autonomous API clients | Facilitator verify/settle · Multi-language SDKs · Bazaar discovery | ⚠️ | [docs.cdp.coinbase.com/x402](https://docs.cdp.coinbase.com/x402/welcome) — `pip install x402` or `@x402/*` per [coinbase/x402](https://github.com/coinbase/x402) |
 | [Openwork](services/agent-social-network/openwork.md) | The agent-only labor marketplace — agents hire agents on-chain | Agent-to-agent hiring · On-chain escrow · $OPENWORK earnings | ⚠️ | `npx playbooks add skill openclaw/skills --skill openwork` |
+| [TWZRD Agent Intel](https://intel.twzrd.xyz) | Solana agent trust scoring and on-chain receipt verification | Agent resolve/score · Preflight trust check · x402/USDC receipt · Verify receipt | ✅ | `{"mcpServers": {"twzrd-agent-intel": {"url": "https://intel.twzrd.xyz/mcp"}}}` — zero-install Streamable HTTP |
 
 ---
 
@@ -298,6 +310,7 @@ Source files are in `.skills/` in this repo. ClawHub CLI options (including the 
 | [Galileo](services/observability-and-tracing/galileo.md) | Agent reliability platform — observability, evals, and IDE MCP | Signals (root-cause insights) · synthetic datasets · experiments · MCP tools | ✅ | Add MCP URL `https://api.galileo.ai/mcp/http/mcp` with `Galileo-API-Key` header — [setup docs](https://docs.galileo.ai/getting-started/mcp/setup-galileo-mcp) |
 | [Laminar](services/observability-and-tracing/laminar.md) [![⭐](https://img.shields.io/github/stars/lmnr-ai/lmnr?style=social)](https://github.com/lmnr-ai/lmnr) | Open-source observability for long-running agents | Agent debugger (rerun at step N) · Browser session replay · Signals · SQL over traces · Apache 2.0 self-host | ⚠️ | `pip install lmnr` then `Laminar.initialize()` — self-host: `git clone https://github.com/lmnr-ai/lmnr && docker compose up -d` |
 | [OpenLIT](services/observability-and-tracing/openlit.md) [![⭐](https://img.shields.io/github/stars/openlit/openlit?style=social)](https://github.com/openlit/openlit) | OpenTelemetry-native observability for LLMs and AI agents | Agent traces · Tool-call spans · Cost/token analytics | ✅ | `pip install openlit` then configure OpenTelemetry export |
+| [traceAI](https://github.com/future-agi/traceAI) [![⭐](https://img.shields.io/github/stars/future-agi/traceAI?style=social)](https://github.com/future-agi/traceAI) | Open-source OpenTelemetry-native tracing for LLM and agent apps | 50+ framework auto-instrumentation · Python/TS/Java/C# · OTEL-native · No vendor lock-in | ✅ | `pip install traceAI-<framework>` then initialize traceAI exporter |
 
 ---
 
@@ -365,6 +378,7 @@ Source files are in `.skills/` in this repo. ClawHub CLI options (including the 
 | [OpenRouter](services/llm-gateway-and-routing/openrouter.md) | Unified OpenAI-compatible API — 300+ models | Cross-provider routing · Uptime optimization · Org data policies | ❌ | [openrouter.ai/docs/quickstart](https://openrouter.ai/docs/quickstart) — OpenAI SDK + `OPENROUTER_API_KEY` |
 | [Helicone](services/llm-gateway-and-routing/helicone.md) | AI Gateway + observability — 100+ models, unified credits | `ai-gateway.helicone.ai` · Fallbacks · Request logging | ❌ | OpenAI SDK `baseURL` `https://ai-gateway.helicone.ai` — [docs.helicone.ai](https://docs.helicone.ai/) |
 | [Routerly](services/llm-gateway-and-routing/routerly.md) [![⭐](https://img.shields.io/github/stars/Inebrio/Routerly?style=social)](https://github.com/Inebrio/Routerly) | Self-hosted LLM gateway with LLM-native routing policy | Multi-policy scoring (incl. LLM router) · Per-tenant budget/ledger · Zero stateful deps · OpenAI/Anthropic compat | ⚠️ | `docker run -p 8080:8080 -v ./routerly.json:/config/routerly.json inebrio/routerly:latest` then point client `OPENAI_BASE_URL` |
+| [agent-command-center-sdk](https://github.com/future-agi/agent-command-center-sdk) [![⭐](https://img.shields.io/github/stars/future-agi/agent-command-center-sdk?style=social)](https://github.com/future-agi/agent-command-center-sdk) | Open-source, OpenAI-compatible gateway SDK for managing and routing AI agent requests across providers | Provider-agnostic routing · OpenAI-compatible API · Per-agent management | ⚠️ | `pip install agent-command-center-sdk` then point client at the gateway endpoint |
 
 ---
 
@@ -386,13 +400,20 @@ Source files are in `.skills/` in this repo. ClawHub CLI options (including the 
 
 ## Ecosystem Hubs
 
-Organizations that provide multiple agent-native services or tools:
+Organizations, registries, and marketplaces that provide multiple agent-native services, tools, MCP servers, or `SKILL.md` sources. Some qualify as first-class catalog services; others are tracked here as high-signal ecosystem pointers pending issue-level review.
 
-| Hub | What It Provides | Notable Projects |
+| Hub | What It Provides | How Agents Start |
 |---|---|---|
-| [OpenClaw](https://github.com/openclaw) | Agent Client Protocol tooling, skills registry, agent marketplace integration | [acpx](services/agent-runtime-and-infrastructure/acpx.md) (ACP CLI), [openclaw/skills](https://github.com/openclaw/skills) (skills for Openwork, Exa, OpenViking, MemOS, E2B), [Openwork](services/agent-social-network/openwork.md) integration |
-| [ClawHub](services/tool-access-and-integration/clawhub.md) | Full entry in section **3. Tool Access & Integration**; this row links the broader OpenClaw ecosystem | [openclaw/clawhub](https://github.com/openclaw/clawhub) CLI, [`.skills/`](https://github.com/haoruilee/awesome-agent-native-services/tree/main/.skills) for this catalog, [openclaw/skills](https://github.com/openclaw/skills) |
-| [MiniMax Skills](https://github.com/MiniMax-AI/skills) [![⭐](https://img.shields.io/github/stars/MiniMax-AI/skills?style=social)](https://github.com/MiniMax-AI/skills) | Curated **development skills** for AI coding agents — structured `SKILL.md` workflows for frontend, fullstack, mobile, and document generation (Claude Code plugin, Cursor skills path, Codex / OpenCode install paths) | Per-skill folders under [`skills/`](https://github.com/MiniMax-AI/skills/tree/main/skills) with YAML-frontmatter `SKILL.md` ([contributing spec](https://github.com/MiniMax-AI/skills/blob/main/CONTRIBUTING.md)) |
+| [Awesome Agent-Native Services Skills Hub](SKILLS_HUB.md) | This repository as a Claude Code plugin marketplace plus ClawHub/OpenClaw skills for finding, evaluating, and adding agent-native services | Claude Code: `/plugin marketplace add haoruilee/awesome-agent-native-services` → `/plugin install awesome-agent-native-services@awesome-agent-native-services`; ClawHub: `npx clawhub@latest install find-agent-service` |
+| [OpenClaw](https://github.com/openclaw) | Agent Client Protocol tooling, skills registry, agent marketplace integration | Use [acpx](services/agent-runtime-and-infrastructure/acpx.md), [openclaw/skills](https://github.com/openclaw/skills), and [Openwork](services/agent-social-network/openwork.md) integrations |
+| [ClawHub](services/tool-access-and-integration/clawhub.md) | Full entry in section **3. Tool Access & Integration**; public registry for OpenClaw-style skills and this catalog's `.skills/` packages | `npx clawhub@latest search <topic>` or install this catalog's skills from `.skills/`; see [clawhub/README.md](clawhub/README.md) for mirror settings |
+| [MiniMax Skills](https://github.com/MiniMax-AI/skills) [![⭐](https://img.shields.io/github/stars/MiniMax-AI/skills?style=social)](https://github.com/MiniMax-AI/skills) | Curated **development skills** for AI coding agents — structured `SKILL.md` workflows for frontend, fullstack, mobile, shaders, and document generation | Follow the repo README for Claude Code plugin, Cursor skills path, and Codex / OpenCode install paths |
+| [Agensi](https://www.agensi.io/) | Marketplace for paid/free AI agent skills with security scanning, broad agent compatibility, and agent-native MCP discovery | Download skills into an agent skills directory or connect MCP at `https://mcp.agensi.io/mcp` |
+| [SkillsMP](https://skillsmp.com/) | Large public `SKILL.md` index with source/repository context, occupations, creators, and API access | Search by task or repository, inspect the source repo, then install according to that skill's instructions |
+| [mdskills.ai](https://www.mdskills.ai/) | Community marketplace for skills, plugins, MCP servers, rules, and tools with quality/security review and CLI install | `npx mdskills` |
+| [sklz.city](https://sklz.city/) | MCP-native skill runtime and marketplace: import `SKILL.md` repos, add runtime primitives, publish/discover over MCP | `curl -fsSL https://sklz.city/install.sh | sh && sklz install` |
+| [SkillCrate](https://skillcrate.dev/) | Vertical, open-source skill marketplace for Amazon seller workflows; each skill is a GitHub repo with `SKILL.md` and MCP packaging | Clone a skill repo or download MCPB, then configure the MCP server / skill in the target agent |
+| [CryptoSkill](https://cryptoskill.org/) | Crypto-focused registry of skills and MCP servers for Claude Code, OpenClaw, Codex, Cursor, and SKILL.md-compatible agents | Clone/copy a skill into `.claude/skills/`, use `clawhub install`, or add hosted MCP servers with `claude mcp add` |
 
 ---
 

--- a/llms.txt
+++ b/llms.txt
@@ -39,7 +39,7 @@ Self-hosted and P2P entries (full write-ups under `services/`):
 
 ## This repository as a skills hub
 
-Claude Code users can add this repository as a plugin marketplace:
+Claude Code users can add this repository as a plugin marketplace when using a Claude Code version with plugin support (official docs: https://code.claude.com/docs/en/discover-plugins):
 
 ```text
 /plugin marketplace add haoruilee/awesome-agent-native-services

--- a/llms.txt
+++ b/llms.txt
@@ -24,7 +24,10 @@ This repository is itself agent-native. AI agents can discover services, evaluat
 ## Repository Structure
 
 - [services/](https://github.com/haoruilee/awesome-agent-native-services/tree/main/services): 15 categories, each with `README.md` and per-service `.md` files (including [ClawHub](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/clawhub.md) under Tool Access & Integration)
-- [.skills/](https://github.com/haoruilee/awesome-agent-native-services/tree/main/.skills): ClawHub skills — `find-agent-service`, `evaluate-agent-native`, `add-to-awesome-list`
+- [.skills/](https://github.com/haoruilee/awesome-agent-native-services/tree/main/.skills): Agent skills — `find-agent-service`, `evaluate-agent-native`, `add-to-awesome-list`
+- [.claude-plugin/marketplace.json](https://github.com/haoruilee/awesome-agent-native-services/blob/main/.claude-plugin/marketplace.json): Claude Code plugin marketplace entry for installing this repo as a skills source
+- [SKILLS_HUB.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/SKILLS_HUB.md): Claude Code, ClawHub/OpenClaw, and manual installation instructions for this repo
+- [RESEARCH_AUDIT.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/RESEARCH_AUDIT.md): Latest research/freshness audit notes
 - [.github/](https://github.com/haoruilee/awesome-agent-native-services/tree/main/.github): Issue templates, PR template, publish-skills workflow
 
 Self-hosted and P2P entries (full write-ups under `services/`):
@@ -34,10 +37,28 @@ Self-hosted and P2P entries (full write-ups under `services/`):
 
 ---
 
+## This repository as a skills hub
+
+Claude Code users can add this repository as a plugin marketplace:
+
+```text
+/plugin marketplace add haoruilee/awesome-agent-native-services
+/plugin install awesome-agent-native-services@awesome-agent-native-services
+/reload-plugins
+```
+
+The plugin exposes the existing `.skills/` folders as namespaced skills. ClawHub/OpenClaw users can continue installing the same skills with `npx clawhub@latest install ...`.
+
 ## Related — agent skills registries (ecosystem hubs)
 
 - [ClawHub](https://claw-hub.net/): OpenClaw skill marketplace — `npx clawhub@latest` ([openclaw/clawhub](https://github.com/openclaw/clawhub)); catalog entry: [services/tool-access-and-integration/clawhub.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/clawhub.md). China access acceleration: [mirror-cn.clawhub.com](https://mirror-cn.clawhub.com) — registry URL `https://cn.clawhub-mirror.com` via env `CLAWHUB_REGISTRY` or CLI `--registry`
 - [MiniMax Skills](https://github.com/MiniMax-AI/skills): Curated `SKILL.md` packs for AI coding agents (Claude Code, Cursor, Codex, OpenCode) — see repo README for install paths
+- [Agensi](https://www.agensi.io/): Paid/free AI agent skill marketplace with security scanning and MCP discovery (`https://mcp.agensi.io/mcp`)
+- [SkillsMP](https://skillsmp.com/): Public `SKILL.md` index with source/repository context and API access
+- [mdskills.ai](https://www.mdskills.ai/): Community marketplace for skills, plugins, MCP servers, rules, and tools — `npx mdskills`
+- [sklz.city](https://sklz.city/): MCP-native skill runtime and marketplace — `curl -fsSL https://sklz.city/install.sh | sh && sklz install`
+- [SkillCrate](https://skillcrate.dev/): Open-source Amazon seller skill marketplace with `SKILL.md` + MCP packaging
+- [CryptoSkill](https://cryptoskill.org/): Crypto skills and MCP servers for Claude Code, OpenClaw, Codex, Cursor, and SKILL.md agents
 
 ---
 

--- a/skill.md
+++ b/skill.md
@@ -70,7 +70,7 @@ These services can be joined with a single instruction, right now, with no human
 
 ---
 
-## Full Catalog — 15 Categories, 135+ Services
+## Full Catalog — 15 Categories, 134 Services
 
 ### 1. Communication
 *Give agents a first-class communication identity on the internet.*
@@ -300,7 +300,7 @@ These are **curated skill packs and marketplaces** — machine-readable instruct
 
 | Hub | Role | How to start |
 |---|---|---|
-| **This catalog's Skills Hub** | Install this repository as a Claude Code marketplace or as standalone ClawHub/OpenClaw skills | Claude Code: `/plugin marketplace add haoruilee/awesome-agent-native-services` → `/plugin install awesome-agent-native-services@awesome-agent-native-services` → `/reload-plugins`. Details: [SKILLS_HUB.md](SKILLS_HUB.md) |
+| **This catalog's Skills Hub** | Install this repository as a Claude Code marketplace or as standalone ClawHub/OpenClaw skills | Claude Code plugin support: `/plugin marketplace add haoruilee/awesome-agent-native-services` → `/plugin install awesome-agent-native-services@awesome-agent-native-services` → `/reload-plugins`. Official docs: [discover plugins](https://code.claude.com/docs/en/discover-plugins). Details: [SKILLS_HUB.md](SKILLS_HUB.md) |
 | **ClawHub** | Public registry for OpenClaw-style skills — search, install, publish via CLI | `npx clawhub@latest search <topic>` — [claw-hub.net](https://claw-hub.net/) · [openclaw/clawhub](https://github.com/openclaw/clawhub) · [catalog: clawhub.md](services/tool-access-and-integration/clawhub.md). **China mirror (加速):** [mirror-cn.clawhub.com](https://mirror-cn.clawhub.com) — set `CLAWHUB_REGISTRY=https://cn.clawhub-mirror.com` or `clawhub --registry https://cn.clawhub-mirror.com …` |
 | **MiniMax Skills** | Official deep-tuned development skills for AI coding agents (frontend, fullstack, Android, iOS, shaders, office docs) | [github.com/MiniMax-AI/skills](https://github.com/MiniMax-AI/skills) — follow **Installation** in the repo README (Claude Code plugin, Cursor `skills/` path, Codex / OpenCode symlinks) |
 | **Agensi** | Paid/free AI agent skill marketplace with security scanning and MCP discovery | Download skills into the agent's skills directory or add MCP at `https://mcp.agensi.io/mcp` — [agensi.io](https://www.agensi.io/) |
@@ -340,7 +340,7 @@ Every service in this catalog satisfies all five:
 
 Install these skills to let your coding agent work with this catalog directly.
 
-Claude Code marketplace source:
+Claude Code marketplace source (requires plugin support; if `/plugin` is unavailable, update Claude Code per the official docs):
 
 ```text
 /plugin marketplace add haoruilee/awesome-agent-native-services

--- a/skill.md
+++ b/skill.md
@@ -66,10 +66,11 @@ These services can be joined with a single instruction, right now, with no human
 | **mem9** | Cloud-persistent memory for agents: hybrid search, lifecycle hooks | `Read https://mem9.ai/skill.md and follow the instructions to register and join` |
 | **mails.dev** | Email for agents: @mails.dev mailbox, send/inbox, wait-for-code | `Read https://mails.dev/skill.md and follow the instructions` |
 | **MailboxKit** | Agent email in one API — REST v1, webhooks, skill.md | `Read https://mailboxkit.com/skill.md and follow the instructions` |
+| **Agents Mail** | Agent email identity: registration, inbox lifecycle, send/reply API | `Read https://agentsmail.org/skill.md and follow the instructions` |
 
 ---
 
-## Full Catalog — 15 Categories, 99+ Services
+## Full Catalog — 15 Categories, 135+ Services
 
 ### 1. Communication
 *Give agents a first-class communication identity on the internet.*
@@ -299,8 +300,15 @@ These are **curated skill packs and marketplaces** — machine-readable instruct
 
 | Hub | Role | How to start |
 |---|---|---|
+| **This catalog's Skills Hub** | Install this repository as a Claude Code marketplace or as standalone ClawHub/OpenClaw skills | Claude Code: `/plugin marketplace add haoruilee/awesome-agent-native-services` → `/plugin install awesome-agent-native-services@awesome-agent-native-services` → `/reload-plugins`. Details: [SKILLS_HUB.md](SKILLS_HUB.md) |
 | **ClawHub** | Public registry for OpenClaw-style skills — search, install, publish via CLI | `npx clawhub@latest search <topic>` — [claw-hub.net](https://claw-hub.net/) · [openclaw/clawhub](https://github.com/openclaw/clawhub) · [catalog: clawhub.md](services/tool-access-and-integration/clawhub.md). **China mirror (加速):** [mirror-cn.clawhub.com](https://mirror-cn.clawhub.com) — set `CLAWHUB_REGISTRY=https://cn.clawhub-mirror.com` or `clawhub --registry https://cn.clawhub-mirror.com …` |
 | **MiniMax Skills** | Official deep-tuned development skills for AI coding agents (frontend, fullstack, Android, iOS, shaders, office docs) | [github.com/MiniMax-AI/skills](https://github.com/MiniMax-AI/skills) — follow **Installation** in the repo README (Claude Code plugin, Cursor `skills/` path, Codex / OpenCode symlinks) |
+| **Agensi** | Paid/free AI agent skill marketplace with security scanning and MCP discovery | Download skills into the agent's skills directory or add MCP at `https://mcp.agensi.io/mcp` — [agensi.io](https://www.agensi.io/) |
+| **SkillsMP** | Public `SKILL.md` index with source context, occupation maps, creators, repositories, and API access | Search [skillsmp.com](https://skillsmp.com/), inspect the source repo, then follow the skill's install instructions |
+| **mdskills.ai** | Community marketplace for skills, plugins, MCP servers, rules, and tools | `npx mdskills` — [mdskills.ai](https://www.mdskills.ai/) |
+| **sklz.city** | MCP-native skill runtime and marketplace for importing, augmenting, and publishing skills | `curl -fsSL https://sklz.city/install.sh | sh && sklz install` — [sklz.city](https://sklz.city/) |
+| **SkillCrate** | Open-source vertical skill marketplace for Amazon seller workflows; skills ship with `SKILL.md` and MCP packaging | Browse [skillcrate.dev](https://skillcrate.dev/), clone a skill repo or download MCPB, then load it into Claude/OpenClaw-compatible agents |
+| **CryptoSkill** | Crypto skill and MCP server registry for Claude Code, OpenClaw, Codex, Cursor, and SKILL.md agents | Clone/copy skills, use `clawhub install`, or add hosted MCP servers; see [cryptoskill.org](https://cryptoskill.org/) |
 
 ---
 
@@ -330,9 +338,19 @@ Every service in this catalog satisfies all five:
 
 ## Agent Skills for This Catalog
 
-Install these skills to let your coding agent work with this catalog directly:
+Install these skills to let your coding agent work with this catalog directly.
 
+Claude Code marketplace source:
+
+```text
+/plugin marketplace add haoruilee/awesome-agent-native-services
+/plugin install awesome-agent-native-services@awesome-agent-native-services
+/reload-plugins
 ```
+
+ClawHub/OpenClaw:
+
+```bash
 npx clawhub@latest install find-agent-service
 npx clawhub@latest install evaluate-agent-native
 npx clawhub@latest install add-to-awesome-list


### PR DESCRIPTION
### Motivation
- Make this repository a first-class skills source so coding agents (Claude Code, OpenClaw/ClawHub users) can install the catalog workflows directly. 
- Surface high-signal skill registries and make URL-Onboarding entries and agent-facing install paths clearer for agents to discover and join services autonomously.

### Description
- Add Claude Code plugin marketplace and manifest: `.claude-plugin/marketplace.json` and `.claude-plugin/plugin.json` so the repo can be added via Claude Code `/plugin marketplace add ...` and expose the existing `.skills/` bundle. 
- Add documentation and hub metadata: `SKILLS_HUB.md` (install instructions), `RESEARCH_AUDIT.md` (2026-06-12 freshness audit), and update `llms.txt`, `skill.md`, `README.md`, and `docs/index.md` to document the Claude Code flow and expanded ecosystem-hubs pointers. 
- Refresh catalog metadata: bumped `catalog-version` in `.skills/*/SKILL.md`, added `Agents Mail` and other URL-onboarding entries to the skills tables, updated category counts and several ecosystem hub rows (Agensi, SkillsMP, mdskills.ai, sklz.city, SkillCrate, CryptoSkill, and a few new service hub pointers). 
- Minor content fixes and generated docs update: regenerated `docs/index.md` and category pages via `scripts/build-github-pages.sh` to keep the published docs in sync with repository changes. 

### Testing
- Validated JSON manifests with `python -m json.tool .claude-plugin/plugin.json` and `python -m json.tool .claude-plugin/marketplace.json`, both succeeded. 
- Ran structural verification that `.claude-plugin` entries point at local sources and that `.skills/*/SKILL.md` exist (custom Python check), which succeeded. 
- Built generated docs with `bash scripts/build-github-pages.sh` and verified generated files were produced; the CI-style validation `bash scripts/build-github-pages.sh && git diff --quiet -- docs/index.md docs/categories` was exercised as part of the update and the generated docs were written. 
- Performed `git diff --check` to ensure no whitespace/fence errors and confirmed files renderable; checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b768ee468832e9089fb0c3e6a7a62)