### PR TITLE
[New Service] Add high-signal agent-native services

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,12 +82,12 @@ Recommended flow for agents: start with `skill.md` for quick discovery, switch t
 | # | Category | Services | Description |
 |---|---|---|---|
 | 1 | [Communication](#1-communication-services) | 10 | Give agents a communication identity on the internet |
-| 2 | [Browser & Web Execution](#2-browser--web-execution-services) | 19 | Remote browser and web data extraction for agents |
-| 3 | [Tool Access & Integration](#3-tool-access--integration-services) | 13 | Runtime tool discovery, auth, and execution |
+| 2 | [Browser & Web Execution](#2-browser--web-execution-services) | 20 | Remote browser and web data extraction for agents |
+| 3 | [Tool Access & Integration](#3-tool-access--integration-services) | 14 | Runtime tool discovery, auth, and execution |
 | 4 | [Oversight & Approval](#4-oversight--approval-services) | 1 | Human-in-the-loop approval and escalation |
 | 5 | [Commerce & Payments](#5-commerce--payment-services) | 7 | Agent-native wallets, identity, and transactions |
 | 6 | [Agent Runtime & Infrastructure](#6-agent-runtime--infrastructure-services) | 23 | Execution, session isolation, secrets, and gateway |
-| 7 | [Memory & State](#7-memory--state-services) | 11 | Persistent agent memory across sessions |
+| 7 | [Memory & State](#7-memory--state-services) | 12 | Persistent agent memory across sessions |
 | 8 | [Search & Web Intelligence](#8-search--web-intelligence-services) | 6 | LLM-optimized web search and content retrieval |
 | 9 | [Code Execution](#9-code-execution-services) | 7 | Secure sandboxes for AI-generated code |
 | 10 | [Observability & Tracing](#10-observability--tracing-services) | 8 | Agent trajectory tracing and evaluation |
@@ -149,6 +149,7 @@ Recommended flow for agents: start with `skill.md` for quick discovery, switch t
 | [Olostep](services/browser-and-web-execution/olostep.md) [![⭐](https://img.shields.io/github/stars/olostep/olostep-mcp-server?style=social)](https://github.com/olostep/olostep-mcp-server) | Web data API for AI agents | Scrape · Search · Map · Crawl · Batch · Official MCP | ✅ | API key → [docs.olostep.com](https://docs.olostep.com) — `npx -y olostep-mcp` or remote `https://mcp.olostep.com/mcp` |
 | [Lightpanda](services/browser-and-web-execution/lightpanda.md) [![⭐](https://img.shields.io/github/stars/lightpanda-io/browser?style=social)](https://github.com/lightpanda-io/browser) | Headless browser for AI agents and automation | CDP · `fetch --dump markdown` · Built-in MCP (`lightpanda mcp`) | ✅ | [Install binary or Docker](https://github.com/lightpanda-io/browser#install) → `lightpanda serve` — [MCP guide](https://lightpanda.io/docs/open-source/guides/mcp-server) |
 | [Vessel Browser](services/browser-and-web-execution/vessel-browser.md) [![⭐](https://img.shields.io/github/stars/unmodeled-tyler/vessel-browser?style=social)](https://github.com/unmodeled-tyler/vessel-browser) | Built from the ground-up for agents — durable state, action undo, MCP control, BYOK | Named durable sessions · Action undo · Checkpoints · Agent-editable bookmarks · MCP | ✅ | `npm install -g vessel-browser` then `vessel-browser --mcp` (or Linux AppImage) |
+| [CamoFox Browser](services/browser-and-web-execution/camofox.md) [![⭐](https://img.shields.io/github/stars/jo-inc/camofox-browser?style=social)](https://github.com/jo-inc/camofox-browser) | Stealth headless browser for AI agents | Stealth sessions · Server/CLI control · Credential-safe profiles · Screenshots/extraction | ⚠️ | `npm install -g camofox-browser` then start the browser server |
 
 ---
 
@@ -175,6 +176,7 @@ Recommended flow for agents: start with `skill.md` for quick discovery, switch t
 | [ToolHive](services/tool-access-and-integration/toolhive.md) [![⭐](https://img.shields.io/github/stars/stacklok/toolhive-studio?style=social)](https://github.com/stacklok/toolhive-studio) | Run any MCP server securely, instantly, anywhere | MCP server discovery/deploy/manage · secure container runtime | ✅ | [toolhive.dev](https://toolhive.dev/) |
 | [Obot](services/tool-access-and-integration/obot.md) [![⭐](https://img.shields.io/github/stars/obot-platform/obot?style=social)](https://github.com/obot-platform/obot) | Complete MCP Platform — Hosting, Registry, Gateway, Chat Client | Hosted MCP servers · Registry · Gateway · OAuth 2.1 · RBAC | ✅ | `helm install obot obot/obot` (or Docker) — [obot.ai](https://obot.ai) |
 | [The Stall](https://github.com/thebrierfox/the-stall) [![⭐](https://img.shields.io/github/stars/thebrierfox/the-stall?style=social)](https://github.com/thebrierfox/the-stall) | 209 pay-per-call AI data capabilities via x402 MCP | Stocks/ETFs · DeFi/on-chain · Polymarket · Crypto · Global macro · Options | ✅ | POST `https://the-stall.intuitek.ai/mcp` — [the-stall.intuitek.ai](https://the-stall.intuitek.ai) · USDC on Base, no API key |
+| [Snyk Agent Scan](services/tool-access-and-integration/snyk-agent-scan.md) [![⭐](https://img.shields.io/github/stars/snyk/agent-scan?style=social)](https://github.com/snyk/agent-scan) | Security scanner for AI agents, MCP servers and agent skills | Agent component inventory · MCP inspection · Prompt/tool risk detection · CI gates | ✅ | `uvx snyk-agent-scan@latest scan` |
 
 ---
 
@@ -263,6 +265,7 @@ Recommended flow for agents: start with `skill.md` for quick discovery, switch t
 | [LycheeMem](services/memory-and-state/lycheemem.md) [![⭐](https://img.shields.io/github/stars/LycheeMem/LycheeMem?style=social)](https://github.com/LycheeMem/LycheeMem) | Compact memory framework for LLM agents | Working/semantic/procedural stores · Token-budget compression · HTTP MCP · OpenClaw plugin | ✅ | Clone repo → `pip install -e ".[dev]"` → `python main.py` — MCP at `http://localhost:8000/mcp` |
 | [MemMachine](services/memory-and-state/memmachine.md) [![⭐](https://img.shields.io/github/stars/MemMachine/MemMachine?style=social)](https://github.com/MemMachine/MemMachine) | Universal memory layer for AI Agents | Episodic graph · Profile SQL · Working memory · LangChain/CrewAI adapters | ⚠️ | `pip install memmachine` then `Memory().add(messages, agent_id=...)` |
 | [Cognee](services/memory-and-state/cognee.md) [![⭐](https://img.shields.io/github/stars/topoteretes/cognee?style=social)](https://github.com/topoteretes/cognee) | Memory control plane for AI agents — managed world model | Auto ontology · 28+ connectors · Per-agent permissions · MCP server | ✅ | `pip install cognee` → `cognee.add(docs)` → `cognee.cognify()` → `cognee.search(...)` |
+| [Hindsight](services/memory-and-state/hindsight.md) [![⭐](https://img.shields.io/github/stars/vectorize-io/hindsight?style=social)](https://github.com/vectorize-io/hindsight) | Agent Memory That Learns | `retain()` · `recall()` · `reflect()` · Dedicated memory banks | ⚠️ | `pip install hindsight-ai` then use retain/recall/reflect in the agent loop |
 
 ---
 

--- a/docs/categories/browser-and-web-execution.md
+++ b/docs/categories/browser-and-web-execution.md
@@ -17,6 +17,7 @@ permalink: /categories/browser-and-web-execution/
 | Bright Data Agent Browser | [services/browser-and-web-execution/bright-data-agent-browser.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/browser-and-web-execution/bright-data-agent-browser.md) |
 | Browser Use Cloud | [services/browser-and-web-execution/browser-use-cloud.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/browser-and-web-execution/browser-use-cloud.md) |
 | Browserbase | [services/browser-and-web-execution/browserbase.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/browser-and-web-execution/browserbase.md) |
+| CamoFox Browser | [services/browser-and-web-execution/camofox.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/browser-and-web-execution/camofox.md) |
 | Cloudflare Browser Rendering | [services/browser-and-web-execution/cloudflare-browser-rendering.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/browser-and-web-execution/cloudflare-browser-rendering.md) |
 | Crawl4AI | [services/browser-and-web-execution/crawl4ai.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/browser-and-web-execution/crawl4ai.md) |
 | Firecrawl | [services/browser-and-web-execution/firecrawl.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/browser-and-web-execution/firecrawl.md) |

--- a/docs/categories/memory-and-state.md
+++ b/docs/categories/memory-and-state.md
@@ -12,6 +12,7 @@ permalink: /categories/memory-and-state/
 |---|---|
 | Cognee | [services/memory-and-state/cognee.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/cognee.md) |
 | Ensue | [services/memory-and-state/ensue.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/ensue.md) |
+| Hindsight | [services/memory-and-state/hindsight.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/hindsight.md) |
 | LLM Wiki | [services/memory-and-state/llm-wiki.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/llm-wiki.md) |
 | LycheeMem | [services/memory-and-state/lycheemem.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/lycheemem.md) |
 | Mem0 | [services/memory-and-state/mem0.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/mem0.md) |

--- a/docs/categories/tool-access-and-integration.md
+++ b/docs/categories/tool-access-and-integration.md
@@ -21,5 +21,6 @@ permalink: /categories/tool-access-and-integration/
 | Nango | [services/tool-access-and-integration/nango.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/nango.md) |
 | Obot | [services/tool-access-and-integration/obot.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/obot.md) |
 | Smithery | [services/tool-access-and-integration/smithery.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/smithery.md) |
+| Snyk Agent Scan | [services/tool-access-and-integration/snyk-agent-scan.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/snyk-agent-scan.md) |
 | ToolHive | [services/tool-access-and-integration/toolhive.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/toolhive.md) |
 | Toolhouse | [services/tool-access-and-integration/toolhouse.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/toolhouse.md) |

--- a/docs/index.md
+++ b/docs/index.md
@@ -87,12 +87,12 @@ Recommended flow for agents: start with `skill.md` for quick discovery, switch t
 | # | Category | Services | Description |
 |---|---|---|---|
 | 1 | [Communication](#1-communication-services) | 10 | Give agents a communication identity on the internet |
-| 2 | [Browser & Web Execution](#2-browser--web-execution-services) | 19 | Remote browser and web data extraction for agents |
-| 3 | [Tool Access & Integration](#3-tool-access--integration-services) | 13 | Runtime tool discovery, auth, and execution |
+| 2 | [Browser & Web Execution](#2-browser--web-execution-services) | 20 | Remote browser and web data extraction for agents |
+| 3 | [Tool Access & Integration](#3-tool-access--integration-services) | 14 | Runtime tool discovery, auth, and execution |
 | 4 | [Oversight & Approval](#4-oversight--approval-services) | 1 | Human-in-the-loop approval and escalation |
 | 5 | [Commerce & Payments](#5-commerce--payment-services) | 7 | Agent-native wallets, identity, and transactions |
 | 6 | [Agent Runtime & Infrastructure](#6-agent-runtime--infrastructure-services) | 23 | Execution, session isolation, secrets, and gateway |
-| 7 | [Memory & State](#7-memory--state-services) | 11 | Persistent agent memory across sessions |
+| 7 | [Memory & State](#7-memory--state-services) | 12 | Persistent agent memory across sessions |
 | 8 | [Search & Web Intelligence](#8-search--web-intelligence-services) | 6 | LLM-optimized web search and content retrieval |
 | 9 | [Code Execution](#9-code-execution-services) | 7 | Secure sandboxes for AI-generated code |
 | 10 | [Observability & Tracing](#10-observability--tracing-services) | 8 | Agent trajectory tracing and evaluation |
@@ -154,6 +154,7 @@ Recommended flow for agents: start with `skill.md` for quick discovery, switch t
 | [Olostep](services/browser-and-web-execution/olostep.md) [![⭐](https://img.shields.io/github/stars/olostep/olostep-mcp-server?style=social)](https://github.com/olostep/olostep-mcp-server) | Web data API for AI agents | Scrape · Search · Map · Crawl · Batch · Official MCP | ✅ | API key → [docs.olostep.com](https://docs.olostep.com) — `npx -y olostep-mcp` or remote `https://mcp.olostep.com/mcp` |
 | [Lightpanda](services/browser-and-web-execution/lightpanda.md) [![⭐](https://img.shields.io/github/stars/lightpanda-io/browser?style=social)](https://github.com/lightpanda-io/browser) | Headless browser for AI agents and automation | CDP · `fetch --dump markdown` · Built-in MCP (`lightpanda mcp`) | ✅ | [Install binary or Docker](https://github.com/lightpanda-io/browser#install) → `lightpanda serve` — [MCP guide](https://lightpanda.io/docs/open-source/guides/mcp-server) |
 | [Vessel Browser](services/browser-and-web-execution/vessel-browser.md) [![⭐](https://img.shields.io/github/stars/unmodeled-tyler/vessel-browser?style=social)](https://github.com/unmodeled-tyler/vessel-browser) | Built from the ground-up for agents — durable state, action undo, MCP control, BYOK | Named durable sessions · Action undo · Checkpoints · Agent-editable bookmarks · MCP | ✅ | `npm install -g vessel-browser` then `vessel-browser --mcp` (or Linux AppImage) |
+| [CamoFox Browser](services/browser-and-web-execution/camofox.md) [![⭐](https://img.shields.io/github/stars/jo-inc/camofox-browser?style=social)](https://github.com/jo-inc/camofox-browser) | Stealth headless browser for AI agents | Stealth sessions · Server/CLI control · Credential-safe profiles · Screenshots/extraction | ⚠️ | `npm install -g camofox-browser` then start the browser server |
 
 ---
 
@@ -180,6 +181,7 @@ Recommended flow for agents: start with `skill.md` for quick discovery, switch t
 | [ToolHive](services/tool-access-and-integration/toolhive.md) [![⭐](https://img.shields.io/github/stars/stacklok/toolhive-studio?style=social)](https://github.com/stacklok/toolhive-studio) | Run any MCP server securely, instantly, anywhere | MCP server discovery/deploy/manage · secure container runtime | ✅ | [toolhive.dev](https://toolhive.dev/) |
 | [Obot](services/tool-access-and-integration/obot.md) [![⭐](https://img.shields.io/github/stars/obot-platform/obot?style=social)](https://github.com/obot-platform/obot) | Complete MCP Platform — Hosting, Registry, Gateway, Chat Client | Hosted MCP servers · Registry · Gateway · OAuth 2.1 · RBAC | ✅ | `helm install obot obot/obot` (or Docker) — [obot.ai](https://obot.ai) |
 | [The Stall](https://github.com/thebrierfox/the-stall) [![⭐](https://img.shields.io/github/stars/thebrierfox/the-stall?style=social)](https://github.com/thebrierfox/the-stall) | 209 pay-per-call AI data capabilities via x402 MCP | Stocks/ETFs · DeFi/on-chain · Polymarket · Crypto · Global macro · Options | ✅ | POST `https://the-stall.intuitek.ai/mcp` — [the-stall.intuitek.ai](https://the-stall.intuitek.ai) · USDC on Base, no API key |
+| [Snyk Agent Scan](services/tool-access-and-integration/snyk-agent-scan.md) [![⭐](https://img.shields.io/github/stars/snyk/agent-scan?style=social)](https://github.com/snyk/agent-scan) | Security scanner for AI agents, MCP servers and agent skills | Agent component inventory · MCP inspection · Prompt/tool risk detection · CI gates | ✅ | `uvx snyk-agent-scan@latest scan` |
 
 ---
 
@@ -268,6 +270,7 @@ Recommended flow for agents: start with `skill.md` for quick discovery, switch t
 | [LycheeMem](services/memory-and-state/lycheemem.md) [![⭐](https://img.shields.io/github/stars/LycheeMem/LycheeMem?style=social)](https://github.com/LycheeMem/LycheeMem) | Compact memory framework for LLM agents | Working/semantic/procedural stores · Token-budget compression · HTTP MCP · OpenClaw plugin | ✅ | Clone repo → `pip install -e ".[dev]"` → `python main.py` — MCP at `http://localhost:8000/mcp` |
 | [MemMachine](services/memory-and-state/memmachine.md) [![⭐](https://img.shields.io/github/stars/MemMachine/MemMachine?style=social)](https://github.com/MemMachine/MemMachine) | Universal memory layer for AI Agents | Episodic graph · Profile SQL · Working memory · LangChain/CrewAI adapters | ⚠️ | `pip install memmachine` then `Memory().add(messages, agent_id=...)` |
 | [Cognee](services/memory-and-state/cognee.md) [![⭐](https://img.shields.io/github/stars/topoteretes/cognee?style=social)](https://github.com/topoteretes/cognee) | Memory control plane for AI agents — managed world model | Auto ontology · 28+ connectors · Per-agent permissions · MCP server | ✅ | `pip install cognee` → `cognee.add(docs)` → `cognee.cognify()` → `cognee.search(...)` |
+| [Hindsight](services/memory-and-state/hindsight.md) [![⭐](https://img.shields.io/github/stars/vectorize-io/hindsight?style=social)](https://github.com/vectorize-io/hindsight) | Agent Memory That Learns | `retain()` · `recall()` · `reflect()` · Dedicated memory banks | ⚠️ | `pip install hindsight-ai` then use retain/recall/reflect in the agent loop |
 
 ---
 

--- a/services/browser-and-web-execution/README.md
+++ b/services/browser-and-web-execution/README.md
@@ -34,6 +34,7 @@ The web was designed for humans sitting in front of browsers. AI agents that nee
 | [Playwright MCP](playwright-mcp.md) [![⭐](https://img.shields.io/github/stars/microsoft/playwright-mcp?style=social)](https://github.com/microsoft/playwright-mcp) | Playwright MCP server | MCP (stdio/HTTP), npm package, Docker image | ✅ |
 | [Apify](apify.md) [![⭐](https://img.shields.io/github/stars/apify/crawlee?style=social)](https://github.com/apify/crawlee) | Real-time web data for AI — Actor marketplace & API | REST API v2, JS/Python clients, webhooks, schedules | ⚠️ |
 | [Vessel Browser](vessel-browser.md) [![⭐](https://img.shields.io/github/stars/unmodeled-tyler/vessel-browser?style=social)](https://github.com/unmodeled-tyler/vessel-browser) | Built from the ground-up for agents — durable state, action undo, MCP control, BYOK | MCP (stdio), npm CLI, AppImage (Linux/Windows) | ✅ |
+| [CamoFox Browser](camofox.md) [![⭐](https://img.shields.io/github/stars/jo-inc/camofox-browser?style=social)](https://github.com/jo-inc/camofox-browser) | Stealth headless browser for AI agents | CLI/server automation, browser profiles, screenshots/extraction | ⚠️ |
 
 
 

--- a/services/browser-and-web-execution/camofox.md
+++ b/services/browser-and-web-execution/camofox.md
@@ -1,0 +1,129 @@
+# CamoFox Browser
+
+> **"Stealth headless browser for AI agents — bypass Cloudflare, bot detection, and anti-scraping."**
+
+| | |
+|---|---|
+| **Website** | https://github.com/jo-inc/camofox-browser |
+| **Docs** | https://github.com/jo-inc/camofox-browser |
+| **GitHub** | https://github.com/jo-inc/camofox-browser |
+| **Stars** | [![GitHub Stars](https://img.shields.io/github/stars/jo-inc/camofox-browser?style=social)](https://github.com/jo-inc/camofox-browser) |
+| **Classification** | `agent-native` |
+| **Category** | [Browser & Web Execution Services](README.md) |
+| **License** | MIT |
+
+---
+
+## Official Website
+
+https://github.com/jo-inc/camofox-browser
+
+---
+
+## Official Repo
+
+https://github.com/jo-inc/camofox-browser
+
+---
+
+## How to Use (Agent Onboarding)
+
+```bash
+npm install -g camofox-browser
+camofox-browser --help
+```
+
+Run the browser server, connect an agent via its REST/automation surface, and use isolated browser sessions for sites that block ordinary headless browsers.
+
+---
+
+## Agent Skills
+
+**Status:** ⚠️ No official portable Agent Skill package found.
+
+---
+
+## MCP
+
+**Status:** ⚠️ No official MCP server found in the main repository at time of listing.
+
+---
+
+## What It Does
+
+CamoFox Browser is an anti-detection browser server for AI-driven web automation. It wraps a stealth browser runtime with a server/CLI interface so agents can open pages, maintain sessions, capture screenshots, extract content, and complete web tasks without exposing raw credentials or relying on a human-operated browser window.
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | The official repository describes it as a stealth headless browser for AI agents. |
+| **Agent-specific primitive** | Agent-facing browser sessions, structured command output, tab/page control, screenshots, and content extraction. |
+| **Autonomy-compatible control plane** | An agent can start the server and drive browsing actions programmatically without per-click human approval. |
+| **M2M integration surface** | CLI/server automation surface designed for coding agents and LLM-powered automation. |
+| **Identity / delegation** | Browser profiles and credential injection patterns let a host delegate web access to the browser without putting secrets directly in the LLM transcript. |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **Stealth browser session** | Headless browser context hardened against common bot-detection signals. |
+| **Server/CLI control** | Non-interactive browser lifecycle and navigation from scripts or agents. |
+| **Credential-safe profiles** | Keep credentials in browser-side profiles instead of exposing them to the agent text stream. |
+| **Screenshots and extraction** | Return visual or text artifacts to the agent for reasoning and follow-up actions. |
+
+---
+
+## Autonomy Model
+
+1. Agent starts or connects to the CamoFox Browser server.
+2. Agent opens a page or reuses an authenticated profile.
+3. Agent navigates, observes page state, extracts information, and submits actions.
+4. Browser-side profiles and automation boundaries constrain delegated access.
+
+---
+
+## Identity and Delegation Model
+
+- Browser profiles represent delegated web identity.
+- Credentials can be injected into the browser runtime while remaining outside the LLM context.
+- Sessions can be separated per task, site, or agent to reduce cross-run leakage.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| CLI | Install and operate browser sessions from terminal workflows |
+| Browser server | Programmatic browser automation endpoint for agents |
+| Playwright/Puppeteer-style ecosystem | Designed as a drop-in automation browser for existing agent stacks |
+
+---
+
+## Human-in-the-Loop Support
+
+Optional. Humans can create or refresh browser profiles, but agents can run normal browsing loops autonomously once the runtime is available.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **Plain headless Chrome** | Commonly fingerprinted and blocked; does not provide agent-specific credential-safety guidance. |
+| **Manual browser** | Requires a human to operate the session. |
+| **Generic scraping library** | Lacks full browser state, screenshots, and authenticated session delegation. |
+
+---
+
+## Use Cases
+
+- Coding agents that need to inspect authenticated web apps safely
+- Research agents navigating sites that block standard headless browsers
+- QA agents exercising web flows with screenshots and stateful sessions
+- Data agents extracting dynamic pages requiring JavaScript execution

--- a/services/memory-and-state/README.md
+++ b/services/memory-and-state/README.md
@@ -35,6 +35,7 @@ Agent-native memory services solve this by providing:
 | [LycheeMem](lycheemem.md) | Compact memory framework for LLM agents | REST API, HTTP MCP, OpenClaw plugin | ✅ |
 | [MemMachine](memmachine.md) [![⭐](https://img.shields.io/github/stars/MemMachine/MemMachine?style=social)](https://github.com/MemMachine/MemMachine) | Universal memory layer — episodic graph + profile SQL + working memory | Python SDK, LangChain/CrewAI adapters, REST API | ⚠️ |
 | [Cognee](cognee.md) [![⭐](https://img.shields.io/github/stars/topoteretes/cognee?style=social)](https://github.com/topoteretes/cognee) | Memory control plane for AI agents — managed world model with auto ontology | Python SDK, 28+ connectors, MCP server, framework adapters | ✅ |
+| [Hindsight](hindsight.md) [![⭐](https://img.shields.io/github/stars/vectorize-io/hindsight?style=social)](https://github.com/vectorize-io/hindsight) | Agent Memory That Learns | Python SDK, open-source memory service, cookbook examples | ⚠️ |
 
 
 

--- a/services/memory-and-state/hindsight.md
+++ b/services/memory-and-state/hindsight.md
@@ -1,0 +1,132 @@
+# Hindsight
+
+> **"Agent Memory That Learns."**
+
+| | |
+|---|---|
+| **Website** | https://hindsight.vectorize.io |
+| **Docs** | https://hindsight.vectorize.io |
+| **GitHub** | https://github.com/vectorize-io/hindsight |
+| **Stars** | [![GitHub Stars](https://img.shields.io/github/stars/vectorize-io/hindsight?style=social)](https://github.com/vectorize-io/hindsight) |
+| **Classification** | `agent-native` |
+| **Category** | [Memory & State Services](README.md) |
+| **License** | Apache-2.0 |
+
+---
+
+## Official Website
+
+https://hindsight.vectorize.io
+
+---
+
+## Official Repo
+
+https://github.com/vectorize-io/hindsight
+
+---
+
+## How to Use (Agent Onboarding)
+
+```bash
+pip install hindsight-ai
+```
+
+Then wire the memory client into an agent loop so the agent can `retain()`, `recall()`, and `reflect()` against its dedicated memory bank.
+
+Docs: https://hindsight.vectorize.io
+
+---
+
+## Agent Skills
+
+**Status:** ⚠️ No official portable Agent Skill package found.
+
+---
+
+## MCP
+
+**Status:** ⚠️ No official MCP server found in the main repository at time of listing.
+
+---
+
+## What It Does
+
+Hindsight is an open-source memory system for AI agents that focuses on learning from experience rather than only replaying conversation history. Agents store observations and experiences, retrieve relevant memories, and run reflection to produce higher-level lessons that can change future behavior.
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | The official docs describe Hindsight as a memory system designed specifically for AI agents, and the repo tagline is "Agent Memory That Learns." |
+| **Agent-specific primitive** | `retain()`, `recall()`, and `reflect()` are agent-memory lifecycle operations rather than generic vector CRUD. |
+| **Autonomy-compatible control plane** | Agents can write, search, and consolidate memories during execution without a human curating each record. |
+| **M2M integration surface** | Python package and open-source service components for direct programmatic integration. |
+| **Identity / delegation** | Agents operate against dedicated memory banks; applications can isolate memory by agent, user, or deployment context. |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **Retain** | Store facts, observations, and experiences from an agent run. |
+| **Recall** | Retrieve relevant prior memories for the current task or context. |
+| **Reflect** | Consolidate lower-level memories into lessons, preferences, or strategies. |
+| **Dedicated memory bank** | Keep an agent's long-term learning state separate from transient context windows. |
+
+---
+
+## Autonomy Model
+
+1. Agent records useful run outcomes with `retain()`.
+2. Before or during future tasks, the agent calls `recall()` for relevant context.
+3. Periodically, the agent calls `reflect()` to distill durable lessons.
+4. The agent injects the recalled or reflected memory into planning and execution.
+
+No per-memory human confirmation is required for normal operation.
+
+---
+
+## Identity and Delegation Model
+
+- Memory can be scoped to an agent or application-defined actor.
+- Dedicated memory banks separate one agent's learned behavior from another's.
+- Host applications remain responsible for mapping users, agents, and tenants to memory namespaces.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| Python SDK | Agent memory operations such as retain, recall, and reflect |
+| Open-source server/library | Self-hostable components from the official repository |
+| Cookbook examples | Framework integration examples in the Hindsight ecosystem |
+
+---
+
+## Human-in-the-Loop Support
+
+Optional. Humans can inspect or reset memory as an operational control, but ordinary retention, recall, and reflection are agent-driven.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **Vector database** | Stores embeddings but does not decide what an agent should learn or reflect on. |
+| **Conversation buffer** | Replays raw history instead of producing durable behavioral learning. |
+| **RAG pipeline** | Retrieves documents, but does not provide agent experience retention and reflection primitives. |
+
+---
+
+## Use Cases
+
+- Long-running personal assistants that improve from prior interactions
+- Coding agents that remember project-specific lessons and recurring failure modes
+- Research agents that retain observations across experiments
+- Support agents that learn account-specific preferences and resolutions

--- a/services/tool-access-and-integration/README.md
+++ b/services/tool-access-and-integration/README.md
@@ -29,6 +29,7 @@ Agent-native tool access services solve all three problems with primitives that 
 | [MCP Toolbox for Databases](google-mcp-toolbox.md) [![⭐](https://img.shields.io/github/stars/googleapis/mcp-toolbox?style=social)](https://github.com/googleapis/mcp-toolbox) | MCP server connecting agents to enterprise databases | `@toolbox-sdk/server`, prebuilt packs, multi-language SDKs, IAM, OTEL | ✅ |
 | [ToolHive](toolhive.md) [![⭐](https://img.shields.io/github/stars/stacklok/toolhive-studio?style=social)](https://github.com/stacklok/toolhive-studio) | Run any MCP server securely, instantly, anywhere | MCP server discovery/deploy/manage · secure container runtime | ✅ |
 | [Obot](obot.md) [![⭐](https://img.shields.io/github/stars/obot-platform/obot?style=social)](https://github.com/obot-platform/obot) | Complete MCP Platform — Hosting, Registry, Gateway, Chat Client | MCP (Streamable HTTP), REST admin API, OAuth 2.1, Helm chart | ✅ |
+| [Snyk Agent Scan](snyk-agent-scan.md) [![⭐](https://img.shields.io/github/stars/snyk/agent-scan?style=social)](https://github.com/snyk/agent-scan) | Security scanner for AI agents, MCP servers and agent skills | CLI, MCP config inspection, CI scan output | ✅ |
 
 
 

--- a/services/tool-access-and-integration/snyk-agent-scan.md
+++ b/services/tool-access-and-integration/snyk-agent-scan.md
@@ -1,0 +1,130 @@
+# Snyk Agent Scan
+
+> **"Security scanner for AI agents, MCP servers and agent skills."**
+
+| | |
+|---|---|
+| **Website** | https://github.com/snyk/agent-scan |
+| **Docs** | https://github.com/snyk/agent-scan |
+| **GitHub** | https://github.com/snyk/agent-scan |
+| **Stars** | [![GitHub Stars](https://img.shields.io/github/stars/snyk/agent-scan?style=social)](https://github.com/snyk/agent-scan) |
+| **Classification** | `agent-native` |
+| **Category** | [Tool Access & Integration Services](README.md) |
+| **License** | Apache-2.0 |
+
+---
+
+## Official Website
+
+https://github.com/snyk/agent-scan
+
+---
+
+## Official Repo
+
+https://github.com/snyk/agent-scan
+
+---
+
+## How to Use (Agent Onboarding)
+
+```bash
+uvx snyk-agent-scan@latest scan
+```
+
+Run against discovered local agent components or pass explicit MCP configuration files to inspect and scan tool descriptions, prompts, resources, and skills.
+
+---
+
+## Agent Skills
+
+**Status:** ⚠️ No official Agent Skill package found; the product scans Agent Skills as first-class artifacts.
+
+---
+
+## MCP
+
+**Status:** ✅ MCP-aware scanner.
+
+Snyk Agent Scan discovers and inspects MCP configurations and MCP servers, then checks the resulting tools, prompts, and resources for agent-specific risks.
+
+---
+
+## What It Does
+
+Snyk Agent Scan inventories local AI-agent components such as harnesses, MCP servers, and skills, then scans them for threats including prompt injection, tool poisoning, tool shadowing, toxic flows, malware payloads, unsafe credential handling, and hardcoded secrets.
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | The official repository positions it as a security scanner for AI agents, MCP servers, and agent skills. |
+| **Agent-specific primitive** | Scans MCP tools/prompts/resources and Agent Skills for risks that only exist in agent tool chains. |
+| **Autonomy-compatible control plane** | Can run non-interactively in CI or agent setup flows before tools are exposed to autonomous agents. |
+| **M2M integration surface** | CLI built for scripted scans of MCP configs and local agent environments. |
+| **Identity / delegation** | Helps enforce which tools and skills are safe to delegate to an agent by producing attributable findings. |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **Agent component inventory** | Finds local harnesses, MCP servers, and skills. |
+| **MCP inspection** | Connects to MCP servers to read exposed tools, prompts, and resources. |
+| **Risk detection** | Flags prompt injection, tool poisoning, tool shadowing, toxic flows, malware payloads, and credential risks. |
+| **CI-friendly scan output** | Run scans before publishing or enabling agent tool bundles. |
+
+---
+
+## Autonomy Model
+
+1. Agent platform or CI invokes `snyk-agent-scan` against local/discovered configs.
+2. Scanner inspects agent components and MCP tool metadata.
+3. Findings are used to block, quarantine, or approve tool exposure.
+4. Approved tools can then be delegated to agents without per-call human review.
+
+---
+
+## Identity and Delegation Model
+
+- Scan results document which tools, skills, or servers were inspected.
+- Teams can use findings to decide which delegated capabilities are safe for each agent environment.
+- The scanner does not replace runtime auth; it validates the artifacts that will be delegated.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| CLI | `snyk-agent-scan scan`, `inspect`, and related commands |
+| MCP awareness | Reads MCP server configurations and metadata |
+| CI/script usage | Non-interactive scans for build and deployment pipelines |
+
+---
+
+## Human-in-the-Loop Support
+
+Recommended for review of critical findings, but normal scans can be automated and used as policy gates before agents receive tool access.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **Traditional SAST** | Does not inspect MCP tool descriptions, prompts, skills, or tool-call semantics. |
+| **Dependency scanner** | Finds vulnerable packages, not prompt-level or tool-shadowing attacks. |
+| **Manual MCP review** | Does not scale across dynamic agent environments and CI pipelines. |
+
+---
+
+## Use Cases
+
+- Preflight scanning before installing MCP servers for coding agents
+- CI checks for published Agent Skills
+- Security review of local agent harness configurations
+- Inventory of agent tool surfaces across developer machines


### PR DESCRIPTION
### Motivation
- Expand the catalog with recent, high-signal agent-native projects that meet the repo's five criteria and are widely discussed or highly starred. 
- Surface agent-first tooling for browser automation, memory, and security scanning so agents and integrators can discover ready-to-use primitives.
- Keep the GitHub Pages docs and category indexes in sync with the new entries so site consumers see updated counts and listings.

### Description
- Added three new service pages: `services/browser-and-web-execution/camofox.md` (CamoFox Browser), `services/memory-and-state/hindsight.md` (Hindsight), and `services/tool-access-and-integration/snyk-agent-scan.md` (Snyk Agent Scan). 
- Updated root README and per-category README files to increment service counts and insert catalog rows for the three new services. 
- Regenerated the GitHub Pages documentation under `docs/` so the category pages and `docs/index.md` reflect the additions.

### Testing
- Ran the documentation build and validation command `bash scripts/build-github-pages.sh && git diff --quiet -- docs/index.md docs/categories` and the generated docs matched the committed `docs/` outputs (build reported OG image generation skipped but completed successfully). 
- Confirmed the generated category pages include the new entries by checking `docs/categories/*` diffs, and the validation step completed without error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a300f6117e8832ea6769298529690b0)