### PR TITLE
Add Chimely

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Recommended flow for agents: start with `skill.md` for quick discovery, switch t
 
 | # | Category | Services | Description |
 |---|---|---|---|
-| 1 | [Communication](#1-communication-services) | 10 | Give agents a communication identity on the internet |
+| 1 | [Communication](#1-communication-services) | 11 | Give agents a communication identity on the internet |
 | 2 | [Browser & Web Execution](#2-browser--web-execution-services) | 22 | Remote browser and web data extraction for agents |
 | 3 | [Tool Access & Integration](#3-tool-access--integration-services) | 14 | Runtime tool discovery, auth, and execution |
 | 4 | [Oversight & Approval](#4-oversight--approval-services) | 3 | Human-in-the-loop approval and escalation |
@@ -116,6 +116,7 @@ Recommended flow for agents: start with `skill.md` for quick discovery, switch t
 | [ATXP Email](services/communication/atxp-email.md) [![⭐](https://img.shields.io/github/stars/atxp-dev/atxp?style=social)](https://github.com/atxp-dev/atxp) | Email for AI agents | Per-agent inbox · CLI/API provisioning · Verification-code workflow | ⚠️ | Read https://atxp.email/ and follow the docs to create an agent inbox via CLI/API |
 | [AgentMail](services/communication/agentmail.md) | Email for AI agents | Agent inbox · Threaded conversation · Webhook on inbound mail · Semantic search | ✅ | `pip install agentmail` then `POST /inboxes` |
 | [Novu](services/communication/novu.md) [![⭐](https://img.shields.io/github/stars/novuhq/novu?style=social)](https://github.com/novuhq/novu) | Notification infrastructure with Agent Toolkit | Workflow-as-tool · Cross-channel delivery · HITL notification flow | ✅ | `npx skills add novuhq/skills` |
+| [Chimely](services/communication/chimely.md) [![⭐](https://img.shields.io/github/stars/dodopayments/chimely?style=social)](https://github.com/dodopayments/chimely) | Self-hostable in-app notification inbox | HTTP notification API · SSE hint plane · `<Inbox />` React component | ⚠️ | Use the HTTP API from https://chimely.dev docs to deliver in-app notifications |
 | [mails.dev](services/communication/mails-dev.md) | Email for AI Agents | @mails.dev mailbox · Send/inbox · wait-for-code · Full-text search | ⚠️ | Read https://mails.dev/skill.md and follow the instructions |
 | [OpenMail](services/communication/openmail.md) | Email API for AI agents | One inbox per agent · Webhook/WebSocket inbound · RAG-ready attachment parsing | ⚠️ | `npm install -g @openmail/cli` → `openmail setup` — [docs.openmail.sh](https://docs.openmail.sh/quickstart) |
 | [MailboxKit](services/communication/mailboxkit.md) | Email infrastructure for AI agents | Per-agent address · REST v1 · Inbound webhooks · URL Onboarding | ⚠️ | Read https://mailboxkit.com/skill.md and follow the instructions |

--- a/services/communication/README.md
+++ b/services/communication/README.md
@@ -13,6 +13,7 @@ Human communication infrastructure (Gmail, Outlook, Slack) was built around the 
 | [ATXP Email](atxp-email.md) | Email for AI agents | CLI, API docs, per-agent inbox workflow | ⚠️ |
 | [AgentMail](agentmail.md) | Email for AI agents | REST, Python SDK, TypeScript SDK, Webhooks | ✅ |
 | [Novu](novu.md) | Open-source notification infrastructure with Agent Toolkit | Node SDK, Python SDK, REST API, Agent Skills | ✅ |
+| [Chimely](chimely.md) [![⭐](https://img.shields.io/github/stars/dodopayments/chimely?style=social)](https://github.com/dodopayments/chimely) | Self-hostable in-app notification inbox | HTTP API, Server-Sent Events, React `<Inbox />`, self-hosted Rust + Postgres + Redis | ⚠️ |
 | [mails.dev](mails-dev.md) | Email for AI Agents | CLI, REST API, TypeScript SDK | ⚠️ |
 | [OpenMail](openmail.md) | Email API for AI agents | REST API, WebSocket, Webhooks, CLI (`@openmail/cli`) | ⚠️ |
 | [MailboxKit](mailboxkit.md) | Email infrastructure for AI agents | REST API v1, Webhooks, URL Onboarding (`skill.md`) | ⚠️ |

--- a/services/communication/chimely.md
+++ b/services/communication/chimely.md
@@ -1,0 +1,150 @@
+# Chimely
+
+> **"Open-source, self-hostable in-app notification inbox infrastructure that agents can call through an HTTP API."**
+
+| | |
+|---|---|
+| **Website** | https://chimely.dev |
+| **Docs** | https://chimely.dev |
+| **GitHub** | https://github.com/dodopayments/chimely |
+| **Stars** | [![GitHub Stars](https://img.shields.io/github/stars/dodopayments/chimely?style=social)](https://github.com/dodopayments/chimely) |
+| **Classification** | `agent-native` |
+| **Category** | [Communication Services](README.md) |
+| **License** | AGPL-3.0 (server), MIT (SDKs) |
+| **Stars** | Not specified |
+
+---
+
+## Official Website
+
+https://chimely.dev
+
+---
+
+## Official Repo
+
+https://github.com/dodopayments/chimely — Core platform (open-source)
+
+---
+
+## Agent Skills
+
+**Status:** ⚠️ No dedicated Agent Skills listed
+
+Chimely is not a full agent toolkit. It is notification-inbox infrastructure with an HTTP notification API that agents can call to deliver in-app notifications to end users.
+
+| Skill | What It Teaches the Agent |
+|---|---|
+| HTTP notification API | Call Chimely's API to deliver in-app notifications to end users |
+
+**Compatibility:** Any agent runtime that can make HTTP API calls.
+
+---
+
+## MCP
+
+**Status:** ⚠️ Not listed
+
+Chimely's agent-facing surface is its HTTP API, not an MCP server.
+
+| Detail | Value |
+|---|---|
+| **MCP Docs** | Not listed |
+| **Transport** | HTTP API |
+| **Compatible Clients** | Any agent runtime that can call HTTP APIs |
+
+---
+
+## What It Does
+
+Chimely is open-source, self-hostable in-app notification inbox infrastructure built with Rust, Postgres, and Redis. It provides an HTTP API, a Server-Sent-Events hint plane, and a drop-in `<Inbox />` React component.
+
+Agents can call Chimely's HTTP notification API to deliver in-app notifications to end users. Chimely is a self-hosted alternative to Knock, Courier, MagicBell, and Novu.
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | The HTTP notification API can be called by AI agents to deliver in-app notifications to end users |
+| **Agent-specific primitive** | Agent-callable notification API backed by an in-app inbox for end users |
+| **Autonomy-compatible control plane** | Agents can deliver notifications through the API without operating a human-facing dashboard per notification |
+| **M2M integration surface** | HTTP API, Server-Sent-Events hint plane, and React `<Inbox />` component |
+| **Identity / delegation** | Notifications are delivered to end users through an application inbox rather than through a human mailbox proxy |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **HTTP Notification API** | Agents can call the API to deliver in-app notifications to end users |
+| **In-App Notification Inbox** | Self-hostable inbox infrastructure for application users |
+| **Server-Sent-Events Hint Plane** | Real-time hint plane for notification updates |
+| **Drop-In React Inbox** | `<Inbox />` React component for embedding the inbox in an application |
+| **Self-Hosted Runtime** | Rust service backed by Postgres and Redis |
+
+---
+
+## Autonomy Model
+
+```
+Agent needs to notify an end user
+    ↓
+Agent calls Chimely's HTTP notification API
+    ↓
+Chimely stores the notification in the in-app inbox
+    ↓
+Chimely emits a Server-Sent-Events hint
+    ↓
+The application shows the notification through <Inbox />
+```
+
+The agent does not need to own email, SMS, or push-channel delivery logic. Chimely provides the in-app notification inbox layer the application can host.
+
+---
+
+## Identity and Delegation Model
+
+- Notifications are addressed to end users inside the application
+- Chimely is not a human mailbox proxy or a separate agent identity provider
+- Agent delegation is through API access to the application's notification infrastructure
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| HTTP API | Notification API agents can call to deliver in-app notifications |
+| Server-Sent Events | Hint plane for notification updates |
+| React Component | Drop-in `<Inbox />` component |
+| Self-Hosting | Rust + Postgres + Redis |
+| Docs | https://chimely.dev |
+
+---
+
+## Human-in-the-Loop Support
+
+Chimely is not a full HITL workflow engine. It can deliver in-app notifications that an application may use for human-facing alerts, requests, or status updates.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **Raw notification table** | Agent must own inbox API behavior, real-time hints, and frontend inbox integration |
+| **Human mailbox** | Routes notifications through a human email account instead of an application inbox |
+| **Push-only transport** | Handles delivery hints but not a durable in-app notification inbox |
+| **Hosted notification SaaS only** | Does not provide the same self-hostable Rust + Postgres + Redis infrastructure |
+
+---
+
+## Use Cases
+
+- **Agent status updates** — agent writes task completion, failure, or progress notifications to an end user's in-app inbox
+- **In-app alerts** — agent delivers product alerts without owning email, SMS, or push-channel logic
+- **Approval prompts** — agent notifies a user that application-side approval or review is needed
+- **Self-hosted notification infrastructure** — teams run the notification inbox stack alongside their own application


### PR DESCRIPTION
Adds Chimely to Communication Services. Chimely is an open-source, self-hostable in-app notification inbox infrastructure (Rust + Postgres + Redis) with an HTTP API and a drop-in `<Inbox />` React component; agents can call its API to deliver in-app notifications. Self-hosted alternative to Knock, Courier, MagicBell, and Novu. Repo: https://github.com/dodopayments/chimely  Website: https://chimely.dev  License: AGPL-3.0.