### PR TITLE
[New Service] OutreachAgent

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Recommended flow for agents: start with `skill.md` for quick discovery, switch t
 
 | # | Category | Services | Description |
 |---|---|---|---|
-| 1 | [Communication](#1-communication-services) | 11 | Give agents a communication identity on the internet |
+| 1 | [Communication](#1-communication-services) | 12 | Give agents a communication identity on the internet |
 | 2 | [Browser & Web Execution](#2-browser--web-execution-services) | 22 | Remote browser and web data extraction for agents |
 | 3 | [Tool Access & Integration](#3-tool-access--integration-services) | 14 | Runtime tool discovery, auth, and execution |
 | 4 | [Oversight & Approval](#4-oversight--approval-services) | 3 | Human-in-the-loop approval and escalation |
@@ -119,6 +119,7 @@ Recommended flow for agents: start with `skill.md` for quick discovery, switch t
 | [Chimely](services/communication/chimely.md) [![⭐](https://img.shields.io/github/stars/dodopayments/chimely?style=social)](https://github.com/dodopayments/chimely) | Self-hostable in-app notification inbox | HTTP notification API · SSE hint plane · `<Inbox />` React component | ⚠️ | Use the HTTP API from https://chimely.dev docs to deliver in-app notifications |
 | [mails.dev](services/communication/mails-dev.md) | Email for AI Agents | @mails.dev mailbox · Send/inbox · wait-for-code · Full-text search | ⚠️ | Read https://mails.dev/skill.md and follow the instructions |
 | [OpenMail](services/communication/openmail.md) | Email API for AI agents | One inbox per agent · Webhook/WebSocket inbound · RAG-ready attachment parsing | ⚠️ | `npm install -g @openmail/cli` → `openmail setup` — [docs.openmail.sh](https://docs.openmail.sh/quickstart) |
+| [OutreachAgent](services/communication/outreachagent.md) | The Cold Outbound Engine for AI Agents | Agent inboxes · Reply-aware workflows · Send limits/approvals · Signed webhooks | ⚠️ | `npm install @outreachagent/sdk-ts` or use REST API at `https://api.outreachagent.dev/v1` |
 | [MailboxKit](services/communication/mailboxkit.md) | Email infrastructure for AI agents | Per-agent address · REST v1 · Inbound webhooks · URL Onboarding | ⚠️ | Read https://mailboxkit.com/skill.md and follow the instructions |
 | [Agents Mail](services/communication/agents-mail.md) | Email for AI Agents | Agent registration · Inbox lifecycle · Send/reply API · URL Onboarding | ⚠️ | Read https://agentsmail.org/skill.md and follow the instructions |
 | [MCP Agent Mail](services/communication/mcp-agent-mail.md) [![⭐](https://img.shields.io/github/stars/Dicklesworthstone/mcp_agent_mail?style=social)](https://github.com/Dicklesworthstone/mcp_agent_mail) | Async coordination layer for AI coding agents | Agent identity · Inbox/outbox · Thread search · Advisory file reservations | ✅ | `uvx mcp_agent_mail` then connect MCP client and call `register_agent`/`send_message` |

--- a/docs/categories/communication.md
+++ b/docs/categories/communication.md
@@ -14,9 +14,11 @@ permalink: /categories/communication/
 | AgentMail | [services/communication/agentmail.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/communication/agentmail.md) |
 | Agents Mail | [services/communication/agents-mail.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/communication/agents-mail.md) |
 | ATXP Email | [services/communication/atxp-email.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/communication/atxp-email.md) |
+| Chimely | [services/communication/chimely.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/communication/chimely.md) |
 | MailboxKit | [services/communication/mailboxkit.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/communication/mailboxkit.md) |
 | mails.dev | [services/communication/mails-dev.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/communication/mails-dev.md) |
 | MCP Agent Mail | [services/communication/mcp-agent-mail.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/communication/mcp-agent-mail.md) |
 | MCP Agent Mail (Rust) | [services/communication/mcp-agent-mail-rust.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/communication/mcp-agent-mail-rust.md) |
 | Novu | [services/communication/novu.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/communication/novu.md) |
 | OpenMail | [services/communication/openmail.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/communication/openmail.md) |
+| OutreachAgent | [services/communication/outreachagent.md](https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/communication/outreachagent.md) |

--- a/docs/index.md
+++ b/docs/index.md
@@ -90,7 +90,7 @@ Recommended flow for agents: start with `skill.md` for quick discovery, switch t
 
 | # | Category | Services | Description |
 |---|---|---|---|
-| 1 | [Communication](#1-communication-services) | 10 | Give agents a communication identity on the internet |
+| 1 | [Communication](#1-communication-services) | 12 | Give agents a communication identity on the internet |
 | 2 | [Browser & Web Execution](#2-browser--web-execution-services) | 22 | Remote browser and web data extraction for agents |
 | 3 | [Tool Access & Integration](#3-tool-access--integration-services) | 14 | Runtime tool discovery, auth, and execution |
 | 4 | [Oversight & Approval](#4-oversight--approval-services) | 3 | Human-in-the-loop approval and escalation |
@@ -121,8 +121,10 @@ Recommended flow for agents: start with `skill.md` for quick discovery, switch t
 | [ATXP Email](services/communication/atxp-email.md) [![⭐](https://img.shields.io/github/stars/atxp-dev/atxp?style=social)](https://github.com/atxp-dev/atxp) | Email for AI agents | Per-agent inbox · CLI/API provisioning · Verification-code workflow | ⚠️ | Read https://atxp.email/ and follow the docs to create an agent inbox via CLI/API |
 | [AgentMail](services/communication/agentmail.md) | Email for AI agents | Agent inbox · Threaded conversation · Webhook on inbound mail · Semantic search | ✅ | `pip install agentmail` then `POST /inboxes` |
 | [Novu](services/communication/novu.md) [![⭐](https://img.shields.io/github/stars/novuhq/novu?style=social)](https://github.com/novuhq/novu) | Notification infrastructure with Agent Toolkit | Workflow-as-tool · Cross-channel delivery · HITL notification flow | ✅ | `npx skills add novuhq/skills` |
+| [Chimely](services/communication/chimely.md) [![⭐](https://img.shields.io/github/stars/dodopayments/chimely?style=social)](https://github.com/dodopayments/chimely) | Self-hostable in-app notification inbox | HTTP notification API · SSE hint plane · `<Inbox />` React component | ⚠️ | Use the HTTP API from https://chimely.dev docs to deliver in-app notifications |
 | [mails.dev](services/communication/mails-dev.md) | Email for AI Agents | @mails.dev mailbox · Send/inbox · wait-for-code · Full-text search | ⚠️ | Read https://mails.dev/skill.md and follow the instructions |
 | [OpenMail](services/communication/openmail.md) | Email API for AI agents | One inbox per agent · Webhook/WebSocket inbound · RAG-ready attachment parsing | ⚠️ | `npm install -g @openmail/cli` → `openmail setup` — [docs.openmail.sh](https://docs.openmail.sh/quickstart) |
+| [OutreachAgent](services/communication/outreachagent.md) | The Cold Outbound Engine for AI Agents | Agent inboxes · Reply-aware workflows · Send limits/approvals · Signed webhooks | ⚠️ | `npm install @outreachagent/sdk-ts` or use REST API at `https://api.outreachagent.dev/v1` |
 | [MailboxKit](services/communication/mailboxkit.md) | Email infrastructure for AI agents | Per-agent address · REST v1 · Inbound webhooks · URL Onboarding | ⚠️ | Read https://mailboxkit.com/skill.md and follow the instructions |
 | [Agents Mail](services/communication/agents-mail.md) | Email for AI Agents | Agent registration · Inbox lifecycle · Send/reply API · URL Onboarding | ⚠️ | Read https://agentsmail.org/skill.md and follow the instructions |
 | [MCP Agent Mail](services/communication/mcp-agent-mail.md) [![⭐](https://img.shields.io/github/stars/Dicklesworthstone/mcp_agent_mail?style=social)](https://github.com/Dicklesworthstone/mcp_agent_mail) | Async coordination layer for AI coding agents | Agent identity · Inbox/outbox · Thread search · Advisory file reservations | ✅ | `uvx mcp_agent_mail` then connect MCP client and call `register_agent`/`send_message` |

--- a/services/communication/README.md
+++ b/services/communication/README.md
@@ -16,6 +16,7 @@ Human communication infrastructure (Gmail, Outlook, Slack) was built around the 
 | [Chimely](chimely.md) [![⭐](https://img.shields.io/github/stars/dodopayments/chimely?style=social)](https://github.com/dodopayments/chimely) | Self-hostable in-app notification inbox | HTTP API, Server-Sent Events, React `<Inbox />`, self-hosted Rust + Postgres + Redis | ⚠️ |
 | [mails.dev](mails-dev.md) | Email for AI Agents | CLI, REST API, TypeScript SDK | ⚠️ |
 | [OpenMail](openmail.md) | Email API for AI agents | REST API, WebSocket, Webhooks, CLI (`@openmail/cli`) | ⚠️ |
+| [OutreachAgent](outreachagent.md) | The Cold Outbound Engine for AI Agents | REST API, TypeScript/Python SDKs, Webhooks, MCP documented (`@outreachagent/mcp`) | ⚠️ |
 | [MailboxKit](mailboxkit.md) | Email infrastructure for AI agents | REST API v1, Webhooks, URL Onboarding (`skill.md`) | ⚠️ |
 | [Agents Mail](agents-mail.md) | Email for AI Agents | REST API, URL Onboarding (`skill.md`), `.well-known/agent.json` discovery | ⚠️ |
 | [MCP Agent Mail](mcp-agent-mail.md) | Async coordination layer for AI coding agents | MCP tools/resources, FastMCP, Git + SQLite | ✅ |

--- a/services/communication/outreachagent.md
+++ b/services/communication/outreachagent.md
@@ -1,0 +1,181 @@
+# OutreachAgent
+
+> **"The Cold Outbound Engine for AI Agents."**
+
+| | |
+|---|---|
+| **Website** | https://outreachagent.dev/ |
+| **Docs** | https://outreachagent.dev/docs/introduction |
+| **GitHub** | Not public; OpenAPI spec: https://api.outreachagent.dev/v1/openapi.json |
+| **Classification** | `agent-native` |
+| **Category** | [Communication Services](README.md) |
+| **Funding / Compliance** | Free tier available; built-in opt-out, pacing, warmup, bounce/complaint thresholds, and approval policies |
+
+---
+
+## Official Website
+
+https://outreachagent.dev/
+
+---
+
+## Official Repo
+
+Not public. The public machine-readable API surface is the OpenAPI 3.1 specification:
+
+https://api.outreachagent.dev/v1/openapi.json
+
+---
+
+## How to Use (Agent Onboarding)
+
+**The quickest path for an agent to start using this service.**
+
+```bash
+npm install @outreachagent/sdk-ts
+# or
+pip install outreachagent
+```
+
+Then create an API key in OutreachAgent, set `OUTREACHAGENT_API_KEY`, and use the REST API, SDK, or MCP server to create an inbox, define a workflow, enroll contacts, and receive signed webhook events for replies.
+
+For MCP-compatible clients:
+
+```json
+{
+  "mcpServers": {
+    "outreachagent": {
+      "command": "npx",
+      "args": ["@outreachagent/mcp"],
+      "env": {
+        "OUTREACHAGENT_API_KEY": "rm_live_..."
+      }
+    }
+  }
+}
+```
+
+Agent-facing quick reference: https://outreachagent.dev/for-agents
+
+---
+
+## Agent Skills
+
+**Status:** ✅ Available
+
+```bash
+npx skills add https://github.com/pagefarms/cold-outreach-writer.git --skill cold-outreach-writer
+```
+
+| Skill | What It Teaches the Agent |
+|---|---|
+| `cold-outreach-writer` | Research a target, draft compressed human cold emails, design follow-up angles, and hand off copy to OutreachAgent templates and workflows. |
+
+---
+
+## MCP
+
+**Status:** ⚠️ Documented, but package availability could not be independently verified from this environment.
+
+| Detail | Value |
+|---|---|
+| **MCP Package** | Package documented as `@outreachagent/mcp` |
+| **Transport** | stdio |
+| **Compatible Clients** | Cursor, Claude Desktop, and MCP-compatible clients |
+
+---
+
+## What It Does
+
+OutreachAgent is an API-first outbound email infrastructure platform for teams building AI agents. It lets external agent runtimes create and operate sending identities, compose or manage templates, run multi-step outbound workflows, and route replies or delivery events back into the agent loop.
+
+The service explicitly keeps prospecting, reasoning, copy generation, and next-step decisions in the caller's runtime while it handles inboxes, delivery state, workflows, waits, retries, webhooks, and operational visibility.
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | The homepage tagline is "The Cold Outbound Engine for AI Agents," and the docs say OutreachAgent is an API-first email infrastructure platform for teams building AI agents. Sources: https://outreachagent.dev/ and https://outreachagent.dev/docs/introduction |
+| **Agent-specific primitive** | Reply-aware outbound execution around agent-operated inboxes: workflow waits, retries, branches, exit-on-reply behavior, delivery events, queryable thread history, webhook routing, and deliverability guardrails. |
+| **Autonomy-compatible control plane** | Agents can create inboxes, contacts, templates, workflows, enrollments, webhook endpoints, domains, policies, approvals, send limits, and simulations through API/MCP surfaces rather than a required dashboard. |
+| **M2M integration surface** | REST API at `https://api.outreachagent.dev/v1`, OpenAPI 3.1, TypeScript and Python SDKs, signed webhooks, LLM context files, and MCP tools. |
+| **Identity / delegation** | Organizations are tenant boundaries; pods isolate environments; inboxes are email identities; named API keys delegate runtime access; policies, approvals, audit logs, workflow logs, and webhook delivery logs capture attributable external actions. |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **Organization** | Tenant and billing boundary for operators and runtime credentials. |
+| **Pod** | Regional or logical isolation unit for environments and data residency. |
+| **Inbox** | Email identity used by an agent runtime to send and receive messages. |
+| **Thread / Message** | Queryable conversation state that lets the runtime recover context across follow-ups. |
+| **Workflow / Enrollment** | Durable multi-step outbound sequence with waits, branches, retries, and execution logs. |
+| **Webhook endpoint / Event** | Signed event delivery for inbound replies, workflow state changes, bounces, unsubscribes, and retries. |
+| **Policy / Approval** | Governance controls that can allow, block, or require review before outbound actions. |
+| **Send limits / Metrics** | Pacing, warmup, deliverability thresholds, and summaries that constrain autonomous senders. |
+
+---
+
+## Autonomy Model
+
+1. The operator creates or delegates an API key to the agent runtime.
+2. The agent creates a pod and one or more inbox identities for outbound work.
+3. The agent creates contacts, verifies addresses, drafts templates, and defines a workflow with stop-on-reply exit criteria.
+4. The agent simulates and previews the workflow before sending, then publishes it when constraints pass.
+5. The agent enrolls contacts and monitors delivery, bounce, reply, unsubscribe, and approval events through signed webhooks or MCP tools.
+6. When a recipient replies or opts out, OutreachAgent updates thread/enrollment state and stops follow-ups according to the workflow policy.
+7. The agent queries thread history and metrics to decide the next action in its own runtime.
+
+---
+
+## Identity and Delegation Model
+
+- **Organization** models the human/team tenant boundary with billing and membership.
+- **Pod** separates runtime environments or regions under an organization.
+- **Inbox** is the agent-operated email identity; threads and messages are scoped under it.
+- **API keys** are named credentials that can be created and revoked for runtime delegation.
+- **Policies and approvals** constrain what the runtime may send automatically and when review is required.
+- **Audit logs, enrollment logs, webhook delivery logs, and metrics** preserve evidence of state changes and outbound execution.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| REST API | `https://api.outreachagent.dev/v1` |
+| OpenAPI | https://api.outreachagent.dev/v1/openapi.json |
+| TypeScript SDK | `npm install @outreachagent/sdk-ts` |
+| Python SDK | `pip install outreachagent` |
+| MCP | `npx @outreachagent/mcp` with `OUTREACHAGENT_API_KEY` |
+| Webhooks | Signed inbound and workflow event callbacks with retry/replay support |
+| LLM context | https://outreachagent.dev/llms-full.txt and https://outreachagent.dev/llms.txt |
+
+---
+
+## Human-in-the-Loop Support
+
+OutreachAgent supports policy outcomes that can allow, block, or require approval before sends. Approval requests can be inspected and resolved through the API or MCP layer, so humans can review high-risk outbound actions without becoming mandatory for every step. Simulations, template previews, test sends, metrics, and auto-pauses provide additional operator control before and during live campaigns.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **Gmail / Outlook APIs** | They are built around human mailboxes and OAuth consent, not high-volume programmatic inbox provisioning, reply-aware outbound workflows, or agent-specific pacing and governance. |
+| **Transactional email APIs** | They send messages well, but generally do not provide agent-owned inbox identities, durable follow-up state machines, stop-on-reply semantics, signed inbound routing, approval gates, workflow simulations, and per-workflow execution logs as one agent control plane. |
+| **Marketing automation tools** | They center human dashboard configuration and campaign management, while OutreachAgent exposes the operational loop to external runtimes through API, SDK, MCP, and webhooks. |
+
+---
+
+## Use Cases
+
+- **Agent SDR campaigns** — let an external prospecting/reasoning agent create contacts, templates, and multi-touch workflows while OutreachAgent handles pacing, delivery, and replies.
+- **Reply-aware follow-up** — stop a sequence automatically when a recipient replies, bounces, unsubscribes, or triggers a custom workflow event.
+- **Multi-inbox sender rotation** — provision and operate multiple sending identities with limits and warmup controls for safer autonomous outreach.
+- **Audited outbound automation** — combine approvals, logs, webhook replay, metrics, and simulations to make agent-driven email operations reviewable.


### PR DESCRIPTION
### Motivation
- Add OutreachAgent as a new agent-native communication service so the catalog includes an outbound email platform designed for autonomous agent workflows and to address issue #91.
- Provide a machine-readable service entry and onboarding guidance so agents can discover and integrate OutreachAgent via REST/SDK/MCP surfaces.
- Update the Communication category and generated docs so the public index and category pages reflect the new entry.

### Description
- Add `services/communication/outreachagent.md` with the full service-file format (Official Website, Official Repo/OpenAPI, How to Use, Agent Skills, MCP status, primitives, autonomy model, identity/delegation, protocol surface, HITL support, comparisons, and use cases). 
- Update `services/communication/README.md`, `README.md`, and `skill.md` to include OutreachAgent in the Communication category table and increment the service count. 
- Regenerate the site artifacts with `bash scripts/build-github-pages.sh` so `docs/index.md` and `docs/categories/communication.md` include the new service. 
- Mark MCP/SDK/package availability as documented in the entry but annotate that package lookups could not be verified from this environment. 

### Testing
- Ran `bash scripts/build-github-pages.sh`, which wrote `docs/index.md` and category pages and completed successfully while skipping Open Graph image generation due to an environment limitation. 
- Ran `git diff --check` (no diff-check errors reported) and validated the docs output changes to `docs/index.md` and `docs/categories/communication.md`. 
- Attempted `npm view @outreachagent/mcp version`, `npm view @outreachagent/sdk-ts version`, and `python3 -m pip index versions outreachagent`, which failed with registry/proxy `403 Forbidden`, so package/registry availability could not be independently verified from this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a61c306ffec832e812d1a6557c368c4)