### PR TITLE
[New Service] August OSS catalog additions

### DIFF
--- a/.skills/add-to-awesome-list/SKILL.md
+++ b/.skills/add-to-awesome-list/SKILL.md
@@ -9,7 +9,7 @@ license: CC0-1.0
 compatibility: Works with agents that can read repository files and browse official sources.
 metadata:
   repo: https://github.com/haoruilee/awesome-agent-native-services
-  catalog-version: "2026-08-18"
+  catalog-version: "2026-08-19"
 allowed-tools: WebSearch Read Bash
 ---
 

--- a/.skills/evaluate-agent-native/SKILL.md
+++ b/.skills/evaluate-agent-native/SKILL.md
@@ -8,7 +8,7 @@ license: CC0-1.0
 compatibility: Works with agents that can inspect official websites, repositories, and protocol documentation.
 metadata:
   repo: https://github.com/haoruilee/awesome-agent-native-services
-  catalog-version: "2026-08-18"
+  catalog-version: "2026-08-19"
 allowed-tools: WebSearch Read
 ---
 

--- a/.skills/find-agent-service/SKILL.md
+++ b/.skills/find-agent-service/SKILL.md
@@ -9,7 +9,7 @@ license: CC0-1.0
 compatibility: Works with any agent that can read markdown files and call web searches.
 metadata:
   repo: https://github.com/haoruilee/awesome-agent-native-services
-  catalog-version: "2026-08-18"
+  catalog-version: "2026-08-19"
 allowed-tools: WebSearch Read
 ---
 

--- a/.skills/install-agent-service/SKILL.md
+++ b/.skills/install-agent-service/SKILL.md
@@ -9,7 +9,7 @@ license: CC0-1.0
 compatibility: Works with Claude Code plugin skills and agents that can read SKILL.md.
 metadata:
   repo: https://github.com/haoruilee/awesome-agent-native-services
-  catalog-version: "2026-08-18"
+  catalog-version: "2026-08-19"
 allowed-tools: WebSearch Read Bash
 ---
 

--- a/README.md
+++ b/README.md
@@ -83,26 +83,26 @@ Recommended flow for agents: start with `skill.md` for quick discovery, switch t
 
 ## Categories
 
-**173 services across 16 categories.**
+**188 services across 16 categories.**
 
 | # | Category | Services | Description |
 |---|---|---|---|
-| 1 | [Communication](#1-communication-services) | 13 | Give agents a communication identity on the internet |
-| 2 | [Browser & Web Execution](#2-browser--web-execution-services) | 23 | Remote browser and web data extraction for agents |
-| 3 | [Tool Access & Integration](#3-tool-access--integration-services) | 15 | Runtime tool discovery, auth, and execution |
-| 4 | [Oversight & Approval](#4-oversight--approval-services) | 4 | Human-in-the-loop approval and escalation |
+| 1 | [Communication](#1-communication-services) | 15 | Give agents a communication identity on the internet |
+| 2 | [Browser & Web Execution](#2-browser--web-execution-services) | 24 | Remote browser and web data extraction for agents |
+| 3 | [Tool Access & Integration](#3-tool-access--integration-services) | 16 | Runtime tool discovery, auth, and execution |
+| 4 | [Oversight & Approval](#4-oversight--approval-services) | 5 | Human-in-the-loop approval and escalation |
 | 5 | [Commerce & Payments](#5-commerce--payment-services) | 9 | Agent-native wallets, identity, and transactions |
-| 6 | [Agent Runtime & Infrastructure](#6-agent-runtime--infrastructure-services) | 25 | Execution, session isolation, secrets, and gateway |
-| 7 | [Agent Harnesses & Operator Surfaces](#7-agent-harnesses--operator-surfaces) | 7 | Durable agent-loop control and live operator visibility |
-| 8 | [Memory & State](#8-memory--state-services) | 15 | Persistent agent memory across sessions |
-| 9 | [Search & Web Intelligence](#9-search--web-intelligence-services) | 8 | LLM-optimized web search and content retrieval |
+| 6 | [Agent Runtime & Infrastructure](#6-agent-runtime--infrastructure-services) | 27 | Execution, session isolation, secrets, and gateway |
+| 7 | [Agent Harnesses & Operator Surfaces](#7-agent-harnesses--operator-surfaces) | 9 | Durable agent-loop control and live operator visibility |
+| 8 | [Memory & State](#8-memory--state-services) | 17 | Persistent agent memory across sessions |
+| 9 | [Search & Web Intelligence](#9-search--web-intelligence-services) | 9 | LLM-optimized web search and content retrieval |
 | 10 | [Code Execution](#10-code-execution-services) | 10 | Secure sandboxes for AI-generated code |
 | 11 | [Observability & Tracing](#11-observability--tracing-services) | 11 | Agent trajectory tracing and evaluation |
 | 12 | [Durable Execution & Scheduling](#12-durable-execution--scheduling-services) | 7 | Fault-tolerant long-running agent workflows |
-| 13 | [Meeting & Conversation](#13-meeting--conversation-services) | 6 | Agent presence in voice and video meetings |
-| 14 | [Voice & Phone](#14-voice--phone-services) | 6 | Agent-controlled voice calls and phone infrastructure |
+| 13 | [Meeting & Conversation](#13-meeting--conversation-services) | 7 | Agent presence in voice and video meetings |
+| 14 | [Voice & Phone](#14-voice--phone-services) | 7 | Agent-controlled voice calls and phone infrastructure |
 | 15 | [LLM Gateway & Routing](#15-llm-gateway--routing-services) | 8 | Per-agent budget, routing, caching, and observability for LLM calls |
-| 16 | [Agent Social & Community](#16-agent-social--community-services) | 6 | Social networks where agents are first-class participants |
+| 16 | [Agent Social & Community](#16-agent-social--community-services) | 7 | Social networks where agents are first-class participants |
 
 ---
 
@@ -129,6 +129,8 @@ Recommended flow for agents: start with `skill.md` for quick discovery, switch t
 | [MCP Agent Mail (Rust)](services/communication/mcp-agent-mail-rust.md) [![⭐](https://img.shields.io/github/stars/Dicklesworthstone/mcp_agent_mail_rust?style=social)](https://github.com/Dicklesworthstone/mcp_agent_mail_rust) | It's like Gmail for your coding agents | 30+ MCP tools · 20+ resources · Git-backed archive · TUI/robot CLI | ✅ | `curl -fsSL \"https://raw.githubusercontent.com/Dicklesworthstone/mcp_agent_mail_rust/main/install.sh?$(date +%s)\" \| bash` then `am` |
 | [AgenticMail](services/communication/agenticmail.md) [![⭐](https://img.shields.io/github/stars/agenticmail/agenticmail?style=social)](https://github.com/agenticmail/agenticmail) | Email & SMS infrastructure for AI agents | Agent inbox + phone bundle · Stalwart self-host · Google Voice bridge · 75+ REST endpoints | ⚠️ | `git clone https://github.com/agenticmail/agenticmail && docker compose up -d` |
 | [Caspian](services/communication/caspian.md) [![⭐](https://img.shields.io/github/stars/TryCaspian/caspian-sdk?style=social)](https://github.com/TryCaspian/caspian-sdk) | One agent communication identity across human channels | Email/Slack/Discord/Telegram/SMS · normalized events · SDKs · webhooks | ⚠️ | Read https://api.trycaspianai.com/SKILL.md and follow it end to end |
+| [Atomic Mail](services/communication/atomic-mail.md) [![⭐](https://img.shields.io/github/stars/Atomic-Mail/atomic-mail-agentic?style=social)](https://github.com/Atomic-Mail/atomic-mail-agentic) | Not AI for your email. Email for your AI. | PoW inbox · JMAP · local/hosted MCP · AgentSkill | ✅ | Read https://atomicmail.ai and follow the instructions to create an inbox |
+| [AgentTeam Email](services/communication/agentteam-email.md) [![⭐](https://img.shields.io/github/stars/agentteamhq/agentteam-email?style=social)](https://github.com/agentteamhq/agentteam-email) | Open-source email infrastructure for AI agents | Per-agent mailbox · at-email CLI · draft review · Cloudflare routing | ⚠️ | `npx --yes @agentteamhq/email@latest` then `at-email agent connect` |
 
 ---
 
@@ -163,6 +165,7 @@ Recommended flow for agents: start with `skill.md` for quick discovery, switch t
 | [Vessel Browser](services/browser-and-web-execution/vessel-browser.md) [![⭐](https://img.shields.io/github/stars/unmodeled-tyler/vessel-browser?style=social)](https://github.com/unmodeled-tyler/vessel-browser) | Built from the ground-up for agents — durable state, action undo, MCP control, BYOK | Named durable sessions · Action undo · Checkpoints · Agent-editable bookmarks · MCP | ✅ | `npm install -g vessel-browser` then `vessel-browser --mcp` (or Linux AppImage) |
 | [CamoFox Browser](services/browser-and-web-execution/camofox.md) [![⭐](https://img.shields.io/github/stars/jo-inc/camofox-browser?style=social)](https://github.com/jo-inc/camofox-browser) | Stealth headless browser for AI agents | Stealth sessions · Server/CLI control · Credential-safe profiles · Screenshots/extraction | ⚠️ | `npm install -g camofox-browser` then start the browser server |
 | [Moli](services/browser-and-web-execution/moli.md) [![⭐](https://img.shields.io/github/stars/lexmount/moli?style=social)](https://github.com/lexmount/moli) | Structured-first browser engine for AI agents | Semantic tree · stable node IDs · CDP/WebDriver · screenshots · stdio MCP | ✅ | Build the Rust workspace, then run `moli fetch`, `moli serve`, or `moli mcp` |
+| [Kernel](services/browser-and-web-execution/kernel.md) [![⭐](https://img.shields.io/github/stars/kernel/kernel-images?style=social)](https://github.com/kernel/kernel-images) | you build agents. we give them the internet. | Sandboxed Chromium · managed auth · live view/replay · CLI + kernel-cli skill | ⚠️ | `brew install kernel/tap/kernel` or `npm install -g @onkernel/cli`, then `kernel browsers create -o json` |
 
 ---
 
@@ -191,6 +194,7 @@ Recommended flow for agents: start with `skill.md` for quick discovery, switch t
 | [Obot](services/tool-access-and-integration/obot.md) [![⭐](https://img.shields.io/github/stars/obot-platform/obot?style=social)](https://github.com/obot-platform/obot) | Complete MCP Platform — Hosting, Registry, Gateway, Chat Client | Hosted MCP servers · Registry · Gateway · OAuth 2.1 · RBAC | ✅ | `helm install obot obot/obot` (or Docker) — [obot.ai](https://obot.ai) |
 | [Snyk Agent Scan](services/tool-access-and-integration/snyk-agent-scan.md) [![⭐](https://img.shields.io/github/stars/snyk/agent-scan?style=social)](https://github.com/snyk/agent-scan) | Security scanner for AI agents, MCP servers and agent skills | Agent component inventory · MCP inspection · Prompt/tool risk detection · CI gates | ✅ | `uvx snyk-agent-scan@latest scan` |
 | [OpenChatCut](services/tool-access-and-integration/openchatcut.md) [![⭐](https://img.shields.io/github/stars/0xsline/OpenChatCut?style=social)](https://github.com/0xsline/OpenChatCut) | Local-first agent-native video editor with editable timelines | Agent Skill · Streamable HTTP MCP · isolated drafts · EditorCore tools | ✅ | `npx skills add 0xsline/OpenChatCut`, then ask the agent: `Set up OpenChatCut` |
+| [Toolport](services/tool-access-and-integration/toolport.md) [![⭐](https://img.shields.io/github/stars/tsouth89/toolport?style=social)](https://github.com/tsouth89/toolport) | Every tool. One port. | Lazy MCP meta-tools · per-client profiles · tool integrity · keychain secrets | ✅ | Install from [GitHub Releases](https://github.com/tsouth89/toolport/releases/latest), add servers, then connect each AI client to `toolport-gateway` |
 
 ---
 
@@ -206,6 +210,7 @@ Recommended flow for agents: start with `skill.md` for quick discovery, switch t
 | [Sondera Coding Agent Hooks](services/oversight-and-approval/sondera-coding-agent-hooks.md) [![⭐](https://img.shields.io/github/stars/sondera-ai/sondera-coding-agent-hooks?style=social)](https://github.com/sondera-ai/sondera-coding-agent-hooks) | A reference monitor for AI coding agents | Rust hooks · Cedar policies · shell/file/web interception | ⚠️ | Install hook binaries and Cedar policies |
 | [HumanLayer](services/oversight-and-approval/humanlayer.md) [![⭐](https://img.shields.io/github/stars/humanlayer/humanlayer?style=social)](https://github.com/humanlayer/humanlayer) | Human in the Loop for AI Agents | `@require_approval()` · Denial-feedback injection · Run/Call ID audit trail | ✅ | `pip install humanlayer` then decorate high-risk functions with `@hl.require_approval()` |
 | [Sallyport](services/oversight-and-approval/sallyport.md) [![⭐](https://img.shields.io/github/stars/OlegSotnikov/sallyport?style=social)](https://github.com/OlegSotnikov/sallyport) | Let your agent touch prod. Keep the keys. | MCP credential gate · HTTP/SSH execution · per-call approval · signed journal | ✅ | `brew install --cask olegsotnikov/tap/sallyport`, then add its `sp mcp` command to the agent |
+| [Preloop](services/oversight-and-approval/preloop.md) [![⭐](https://img.shields.io/github/stars/preloop/preloop?style=social)](https://github.com/preloop/preloop) | The Open Source Control Plane for AI Agents | MCP firewall · CEL approvals · model gateway budgets · session audit | ✅ | `curl -fsSL https://preloop.ai/install/cli \| sh` then `preloop signup` and `preloop agents discover` |
 
 ---
 
@@ -262,6 +267,8 @@ Recommended flow for agents: start with `skill.md` for quick discovery, switch t
 | [Modal](services/agent-runtime-and-infrastructure/modal.md) [![⭐](https://img.shields.io/github/stars/modal-labs/modal-client?style=social)](https://github.com/modal-labs/modal-client) | Serverless AI infra — GPUs, inference, sandboxes, batch | Elastic containers · Programmatic sandboxes · Sub-second cold start | ❌ | `pip install modal` → `modal setup` — [modal.com/docs](https://modal.com/docs) |
 | [Cyberdesk](services/agent-runtime-and-infrastructure/cyberdesk.md) [![⭐](https://img.shields.io/github/stars/cyberdesk-hq/cyberdesk?style=social)](https://github.com/cyberdesk-hq/cyberdesk) | Open source virtual desktops for AI agents | Desktop lifecycle API · computer actions · isolated sessions | ⚠️ | `pip install cyberdesk` — [docs.cyberdesk.io](https://docs.cyberdesk.io) |
 | [Polos](services/agent-runtime-and-infrastructure/polos.md) [![⭐](https://img.shields.io/github/stars/polos-dev/polos?style=social)](https://github.com/polos-dev/polos) | Open-source runtime for AI agents — sandbox + durable workflow + HITL | Docker/E2B sandbox · Durable steps with prompt cache · HTTP/cron/webhook/event triggers · Slack HITL | ⚠️ | `pip install polos` (or `npm install polos`) — see [README](https://github.com/polos-dev/polos) |
+| [Cloudflare Computer](services/agent-runtime-and-infrastructure/cloudflare-computer.md) [![⭐](https://img.shields.io/github/stars/cloudflare/computer?style=social)](https://github.com/cloudflare/computer) | Give your agent a computer | Durable Object workspace FS · runtime.exec backends · preview APIs | ⚠️ | `npm install @cloudflare/computer` then `withWorkspace` on a Durable Object — preview only |
+| [Agent Executor (AX)](services/agent-runtime-and-infrastructure/google-ax.md) [![⭐](https://img.shields.io/github/stars/google/ax?style=social)](https://github.com/google/ax) | An open source distributed agent runtime | Conversation resume · event log · isolated harnesses · `ax` CLI | ⚠️ | `go install github.com/google/ax/cmd/ax@latest` then `ax --input "…"` |
 
 ---
 
@@ -280,6 +287,8 @@ Recommended flow for agents: start with `skill.md` for quick discovery, switch t
 | [Agent QA](services/agent-harnesses-and-control-planes/agent-qa.md) [![⭐](https://img.shields.io/github/stars/vostride/agent-qa?style=social)](https://github.com/vostride/agent-qa) | The self-improving QA agent for software teams | Live run IDs · observe/plan/execute/verify · memory · queue cancel | ✅ | `npx agent-qa init` → `codex mcp add agent-qa -- agent-qa mcp` |
 | [Codex HUD (fwyc0573)](services/agent-harnesses-and-control-planes/codex-hud-fwyc0573.md) [![⭐](https://img.shields.io/github/stars/fwyc0573/codex-hud?style=social)](https://github.com/fwyc0573/codex-hud) | Real-time statusline HUD for OpenAI Codex CLI | Context/tools/subagents · multi-session view · attach/list/kill | ⚠️ | Clone [fwyc0573/codex-hud](https://github.com/fwyc0573/codex-hud), run `./bin/codex-hud-install`, then launch `codex` |
 | [Codex HUD (anhannin)](services/agent-harnesses-and-control-planes/codex-hud-anhannin.md) [![⭐](https://img.shields.io/github/stars/anhannin/codex-hud?style=social)](https://github.com/anhannin/codex-hud) | Patched Codex status line for usage and session state | Model/project/git · rollout session · 5-hour and 7-day usage windows | ⚠️ | Clone [anhannin/codex-hud](https://github.com/anhannin/codex-hud), review the patch/install script, then run `Codex-HUD/install.sh` |
+| [Claude HUD](services/agent-harnesses-and-control-planes/claude-hud.md) [![⭐](https://img.shields.io/github/stars/jarrodwatts/claude-hud?style=social)](https://github.com/jarrodwatts/claude-hud) | A Claude Code plugin that shows what's happening | Context/usage bars · tools · subagents · todos · statusline | ⚠️ | `/plugin marketplace add jarrodwatts/claude-hud` then `/plugin install claude-hud` and `/claude-hud:setup` |
+| [LoopX](services/agent-harnesses-and-control-planes/loopx.md) [![⭐](https://img.shields.io/github/stars/huangruiteng/loopx?style=social)](https://github.com/huangruiteng/loopx) | The open, provider-neutral, stateful control plane for long-horizon agents | Objectives · gates · todos/evidence · quota · claims/leases | ⚠️ | `python3 -m pip install --upgrade loopx` then `loopx workflow-skills --install` and `loopx connect` |
 
 ---
 
@@ -308,6 +317,8 @@ Recommended flow for agents: start with `skill.md` for quick discovery, switch t
 | [MemMachine](services/memory-and-state/memmachine.md) [![⭐](https://img.shields.io/github/stars/MemMachine/MemMachine?style=social)](https://github.com/MemMachine/MemMachine) | Universal memory layer for AI Agents | Episodic graph · Profile SQL · Working memory · LangChain/CrewAI adapters | ⚠️ | `pip install memmachine` then `Memory().add(messages, agent_id=...)` |
 | [Cognee](services/memory-and-state/cognee.md) [![⭐](https://img.shields.io/github/stars/topoteretes/cognee?style=social)](https://github.com/topoteretes/cognee) | Memory control plane for AI agents — managed world model | Auto ontology · 28+ connectors · Per-agent permissions · MCP server | ✅ | `pip install cognee` → `cognee.add(docs)` → `cognee.cognify()` → `cognee.search(...)` |
 | [Hindsight](services/memory-and-state/hindsight.md) [![⭐](https://img.shields.io/github/stars/vectorize-io/hindsight?style=social)](https://github.com/vectorize-io/hindsight) | Agent Memory That Learns | `retain()` · `recall()` · `reflect()` · Dedicated memory banks | ⚠️ | `pip install hindsight-ai` then use retain/recall/reflect in the agent loop |
+| [agentmemory](services/memory-and-state/agentmemory.md) [![⭐](https://img.shields.io/github/stars/rohitg00/agentmemory?style=social)](https://github.com/rohitg00/agentmemory) | Your coding agent remembers everything. No more re-explaining. | Shared memory server · MCP/hooks · 17 skills · INSTALL_FOR_AGENTS.md | ✅ | Read https://raw.githubusercontent.com/rohitg00/agentmemory/main/INSTALL_FOR_AGENTS.md and follow the instructions |
+| [TencentDB Agent Memory](services/memory-and-state/tencentdb-agent-memory.md) [![⭐](https://img.shields.io/github/stars/TencentCloud/TencentDB-Agent-Memory?style=social)](https://github.com/TencentCloud/TencentDB-Agent-Memory) | Agents remember,Humans innovate. | Symbolic Mermaid canvas · L0–L3 layering · OpenClaw/Hermes plugins | ⚠️ | `openclaw plugins install @tencentdb-agent-memory/memory-tencentdb` then enable `memory-tencentdb` |
 
 ---
 
@@ -327,6 +338,7 @@ Recommended flow for agents: start with `skill.md` for quick discovery, switch t
 | [Jina Reader](services/search-and-web-intelligence/jina-reader.md) [![⭐](https://img.shields.io/github/stars/jina-ai/reader?style=social)](https://github.com/jina-ai/reader) | URL and SERP as LLM-friendly text | `r.jina.ai` · `s.jina.ai` · MCP · PDF/images | ✅ | `curl "https://r.jina.ai/https://example.com"` — MCP: `mcp.jina.ai` |
 | [NotHumanSearch](services/search-and-web-intelligence/nothumansearch.md) | Agent-first search — the index of services designed for AI, not humans | `agentic_score` rank · `check_agent_readiness` · `verify_mcp` JSON-RPC probe · URL Onboarding | ✅ | Read https://nothumansearch.ai/llms.txt and follow the instructions — MCP: `https://nothumansearch.ai/mcp` |
 | [Linkup](services/search-and-web-intelligence/linkup.md) [![⭐](https://img.shields.io/github/stars/LinkupPlatform/linkup-python-sdk?style=social)](https://github.com/LinkupPlatform/linkup-python-sdk) | Search API for AI agents and LLM apps | LLM-oriented search · Structured retrieval · Citation-ready outputs | ⚠️ | API key via docs.linkup.so then call search endpoints via SDK/REST |
+| [Agent Search MCP](services/search-and-web-intelligence/agent-search-mcp.md) [![⭐](https://img.shields.io/github/stars/lennney/agent-search-mcp?style=social)](https://github.com/lennney/agent-search-mcp) | Free-first web search with inspectable evidence | Evidence packet · free-first policy · budgets · `fasm` CLI | ✅ | `npx -y agent-search-mcp` — optional `npx skills add lennney/agent-search-mcp --skill agent-search` |
 
 ---
 
@@ -405,6 +417,7 @@ Recommended flow for agents: start with `skill.md` for quick discovery, switch t
 | [Vexa](services/meeting-and-conversation/vexa.md) [![⭐](https://img.shields.io/github/stars/Vexa-ai/vexa?style=social)](https://github.com/Vexa-ai/vexa) | Open-source meeting transcription + interactive bot for Meet/Teams/Zoom | Bot lifecycle · WebSocket diarized transcript · In-meeting TTS/screen-share · MCP server (17 tools) · self-host | ✅ | `git clone https://github.com/Vexa-ai/vexa && docker compose up -d` — or hosted at [vexa.ai](https://vexa.ai) |
 | [Daily Agent Toolkit](services/meeting-and-conversation/daily-agent.md) [![⭐](https://img.shields.io/github/stars/daily-co/daily-python?style=social)](https://github.com/daily-co/daily-python) | Build realtime meeting agents on Daily | Programmatic room control · Media stream hooks · Bot orchestration | ⚠️ | `pip install daily-python` then integrate room/bot lifecycle APIs |
 | [Looped Meet](services/meeting-and-conversation/looped-meet.md) [![⭐](https://img.shields.io/github/stars/loopedautomation/meet?style=social)](https://github.com/loopedautomation/meet) | Dial your agent into your next meeting | Agent participant · LiveKit media · TTY WebSocket bridge · self-hosted room | ⚠️ | Clone [loopedautomation/meet](https://github.com/loopedautomation/meet), set the documented secrets, then `docker compose up` |
+| [AgentCall](services/meeting-and-conversation/agentcall.md) [![⭐](https://img.shields.io/github/stars/pattern-ai-labs/agentcall?style=social)](https://github.com/pattern-ai-labs/agentcall) | Your AI agent, in every meeting. | join-meeting skill · live TTS/transcript · screenshot/screenshare · Meet/Zoom/Teams | ⚠️ | `/plugin marketplace add pattern-ai-labs/agentcall` then `/plugin install join-meeting@agentcall` |
 
 ---
 
@@ -422,6 +435,7 @@ Recommended flow for agents: start with `skill.md` for quick discovery, switch t
 | [Stimm](services/voice-and-phone/stimm.md) [![⭐](https://img.shields.io/github/stars/stimm-ai/stimm?style=social)](https://github.com/stimm-ai/stimm) | Open-source voice agent platform — ultra-low latency over WebRTC | Dual-agent (fast + slow) · Optimistic VUI · BYO STT/LLM/TTS · WebRTC media plane | ⚠️ | `git clone https://github.com/stimm-ai/stimm` then follow README to wire providers |
 | [Pipecat](services/voice-and-phone/pipecat.md) [![⭐](https://img.shields.io/github/stars/pipecat-ai/pipecat?style=social)](https://github.com/pipecat-ai/pipecat) | Open-source framework for real-time voice AI agents | Realtime voice pipeline · In-call tool invocation · WebRTC/SIP adapters | ⚠️ | `pip install pipecat-ai` then compose STT/LLM/TTS + transport pipeline |
 | [Qwen Audio Agent](services/voice-and-phone/qwen-audio-agent.md) [![⭐](https://img.shields.io/github/stars/QwenAudio/qwen-audio-agent?style=social)](https://github.com/QwenAudio/qwen-audio-agent) | Realtime voice runtime that keeps agents talking, working, and present | Gateway · ACP backend · CLI/TUI/WebUI · realtime voice sessions | ⚠️ | `npm install -g qwen-audio-agent`, run `qwenaudio config`, then start `qwenaudio` |
+| [Patter](services/voice-and-phone/patter.md) [![⭐](https://img.shields.io/github/stars/PatterAI/Patter?style=social)](https://github.com/PatterAI/Patter) | The open-source SDK that gives your AI agent a phone number | Agent loop + PSTN · swap STT/TTS/realtime/carrier · Skills | ⚠️ | `npx skills add patterai/skills` then `npm install getpatter` or `pip install getpatter` |
 
 ---
 
@@ -458,6 +472,7 @@ Recommended flow for agents: start with `skill.md` for quick discovery, switch t
 | [MCP Verse](services/agent-social-network/mcpverse.md) | Open town square for autonomous MCP agents | Public rooms · Publications · Reputation · Rate limits (TiDi) | ✅ | ⚠️ Former website/docs are offline; wait for a verified official replacement |
 | [KinthAI](services/agent-social-network/kinthai.md) | Agent economy network — agents earn revenue, collaborate, and self-organize | Agent marketplace · Multi-agent orchestration · Persistent memory · A2A protocol · Revenue sharing | ❌ | Visit [agents.kinthai.ai](https://agents.kinthai.ai) — browse agents, hire, or deploy your own |
 | [Agent Chamber](services/agent-social-network/agent-chamber.md) [![⭐](https://img.shields.io/github/stars/LtyFantasy/agent-chamber?style=social)](https://github.com/LtyFantasy/agent-chamber) | Where AI agents meet, discuss, and get work done | Agent identity · rooms · missions · MCP/REST · Skills · Mission Control | ✅ | Clone [LtyFantasy/agent-chamber](https://github.com/LtyFantasy/agent-chamber), then run `./scripts/setup.sh` |
+| [AgentGram](services/agent-social-network/agentgram.md) [![⭐](https://img.shields.io/github/stars/agentgram/agentgram?style=social)](https://github.com/agentgram/agentgram) | The Open-Source Social Network for AI Agents | Agent register/post · API keys/Ed25519 · MCP · AX Score | ✅ | `pip install agentgram` then `AgentGram().agents.register(name='my-bot')` — MCP: `npx @agentgram/mcp-server` |
 
 ---
 

--- a/catalog.json
+++ b/catalog.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://lihaorui.com/awesome-agent-native-services/catalog.schema.json",
   "schema_version": "1.0.0",
-  "catalog_version": "2026-08-18",
-  "generated_at": "2026-08-18",
+  "catalog_version": "2026-08-19",
+  "generated_at": "2026-08-19",
   "license": "CC0-1.0",
   "source": {
     "repository": "https://github.com/haoruilee/awesome-agent-native-services",
@@ -11,7 +11,7 @@
     "service_directory": "services",
     "content_digest": {
       "algorithm": "sha256",
-      "value": "c11881b2e338df8041d7646e9f4eac0c3ec92c752a20372749d77f4f2a86db43",
+      "value": "414695665d51ecd39d640f5519d206566b775a824065983bfcf91544738baac1",
       "input_paths": [
         "README.md",
         "skill.md",
@@ -19,6 +19,8 @@
         "services/communication/agenticmail.md",
         "services/communication/agentmail.md",
         "services/communication/agents-mail.md",
+        "services/communication/agentteam-email.md",
+        "services/communication/atomic-mail.md",
         "services/communication/atxp-email.md",
         "services/communication/caspian.md",
         "services/communication/chimely.md",
@@ -44,6 +46,7 @@
         "services/browser-and-web-execution/crawl4ai.md",
         "services/browser-and-web-execution/firecrawl.md",
         "services/browser-and-web-execution/hyperbrowser.md",
+        "services/browser-and-web-execution/kernel.md",
         "services/browser-and-web-execution/lightpanda.md",
         "services/browser-and-web-execution/moli.md",
         "services/browser-and-web-execution/notte.md",
@@ -69,9 +72,11 @@
         "services/tool-access-and-integration/snyk-agent-scan.md",
         "services/tool-access-and-integration/toolhive.md",
         "services/tool-access-and-integration/toolhouse.md",
+        "services/tool-access-and-integration/toolport.md",
         "services/oversight-and-approval/README.md",
         "services/oversight-and-approval/cordum.md",
         "services/oversight-and-approval/humanlayer.md",
+        "services/oversight-and-approval/preloop.md",
         "services/oversight-and-approval/sallyport.md",
         "services/oversight-and-approval/sondera-coding-agent-hooks.md",
         "services/commerce-and-payments/README.md",
@@ -96,11 +101,13 @@
         "services/agent-runtime-and-infrastructure/claude-managed-agents.md",
         "services/agent-runtime-and-infrastructure/claude-peers.md",
         "services/agent-runtime-and-infrastructure/cloudflare-agents-sdk.md",
+        "services/agent-runtime-and-infrastructure/cloudflare-computer.md",
         "services/agent-runtime-and-infrastructure/codex-plugin-cc.md",
         "services/agent-runtime-and-infrastructure/cx.md",
         "services/agent-runtime-and-infrastructure/cyberdesk.md",
         "services/agent-runtime-and-infrastructure/db9.md",
         "services/agent-runtime-and-infrastructure/fiserv-agentos.md",
+        "services/agent-runtime-and-infrastructure/google-ax.md",
         "services/agent-runtime-and-infrastructure/infisical-agent-sentinel.md",
         "services/agent-runtime-and-infrastructure/letta.md",
         "services/agent-runtime-and-infrastructure/modal.md",
@@ -112,13 +119,16 @@
         "services/agent-runtime-and-infrastructure/vertex-ai-agent-engine.md",
         "services/agent-harnesses-and-control-planes/README.md",
         "services/agent-harnesses-and-control-planes/agent-qa.md",
+        "services/agent-harnesses-and-control-planes/claude-hud.md",
         "services/agent-harnesses-and-control-planes/codex-hud-anhannin.md",
         "services/agent-harnesses-and-control-planes/codex-hud-fwyc0573.md",
         "services/agent-harnesses-and-control-planes/longhorizon-harness.md",
+        "services/agent-harnesses-and-control-planes/loopx.md",
         "services/agent-harnesses-and-control-planes/oh-my-codex.md",
         "services/agent-harnesses-and-control-planes/qm.md",
         "services/agent-harnesses-and-control-planes/ruflo.md",
         "services/memory-and-state/README.md",
+        "services/memory-and-state/agentmemory.md",
         "services/memory-and-state/cognee.md",
         "services/memory-and-state/ensue.md",
         "services/memory-and-state/hindsight.md",
@@ -133,8 +143,10 @@
         "services/memory-and-state/memu.md",
         "services/memory-and-state/openviking.md",
         "services/memory-and-state/recall.md",
+        "services/memory-and-state/tencentdb-agent-memory.md",
         "services/memory-and-state/zep.md",
         "services/search-and-web-intelligence/README.md",
+        "services/search-and-web-intelligence/agent-search-mcp.md",
         "services/search-and-web-intelligence/contextx.md",
         "services/search-and-web-intelligence/exa.md",
         "services/search-and-web-intelligence/jina-deepsearch.md",
@@ -175,6 +187,7 @@
         "services/durable-execution-and-scheduling/restate.md",
         "services/durable-execution-and-scheduling/trigger-dev.md",
         "services/meeting-and-conversation/README.md",
+        "services/meeting-and-conversation/agentcall.md",
         "services/meeting-and-conversation/daily-agent.md",
         "services/meeting-and-conversation/looped-meet.md",
         "services/meeting-and-conversation/meeting-baas.md",
@@ -183,6 +196,7 @@
         "services/meeting-and-conversation/vexa.md",
         "services/voice-and-phone/README.md",
         "services/voice-and-phone/livekit-agents.md",
+        "services/voice-and-phone/patter.md",
         "services/voice-and-phone/pipecat.md",
         "services/voice-and-phone/qwen-audio-agent.md",
         "services/voice-and-phone/retell-ai.md",
@@ -199,6 +213,7 @@
         "services/llm-gateway-and-routing/sageroute.md",
         "services/agent-social-network/README.md",
         "services/agent-social-network/agent-chamber.md",
+        "services/agent-social-network/agentgram.md",
         "services/agent-social-network/kinthai.md",
         "services/agent-social-network/mcpverse.md",
         "services/agent-social-network/moltbook.md",
@@ -209,7 +224,7 @@
   },
   "counts": {
     "categories": 16,
-    "services": 173
+    "services": 188
   },
   "categories": [
     {
@@ -217,28 +232,28 @@
       "name": "Communication",
       "description": "Services that give AI agents a first-class communication identity on the internet — not a proxy to a human's mailbox or messaging account, but an identity the agent owns and operates autonomously.",
       "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/communication/README.md",
-      "service_count": 13
+      "service_count": 15
     },
     {
       "id": "browser-and-web-execution",
       "name": "Browser & Web Execution",
       "description": "Services that give AI agents a remote, managed browser runtime — so agents can navigate, interact with, and extract data from the web as an autonomous actor, without any human operating a browser on their behalf.",
       "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/browser-and-web-execution/README.md",
-      "service_count": 23
+      "service_count": 24
     },
     {
       "id": "tool-access-and-integration",
       "name": "Tool Access & Integration",
       "description": "Services that let AI agents discover, authenticate, and invoke external tools at runtime — without a human pre-configuring credentials or selecting which integrations to activate.",
       "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/README.md",
-      "service_count": 15
+      "service_count": 16
     },
     {
       "id": "oversight-and-approval",
       "name": "Oversight & Approval",
       "description": "Services that give AI agents a structured, programmatic way to request human approval before executing high-stakes actions — turning human oversight from an ad-hoc interruption into a first-class, auditable primitive.",
       "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/oversight-and-approval/README.md",
-      "service_count": 4
+      "service_count": 5
     },
     {
       "id": "commerce-and-payments",
@@ -252,28 +267,28 @@
       "name": "Agent Runtime & Infrastructure",
       "description": "Services that provide the secure deployment substrate, session isolation, secret management, identity, gateway, and observability required to run AI agents reliably in production — the \"operating system layer\" for autonomous agents.",
       "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/README.md",
-      "service_count": 25
+      "service_count": 27
     },
     {
       "id": "agent-harnesses-and-control-planes",
       "name": "Agent Harnesses & Operator Surfaces",
       "description": "Systems purpose-built around running agents: either harnesses that add durable work state, orchestration, verification, and policy, or operator surfaces that expose live agent state and bounded session controls.",
       "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/README.md",
-      "service_count": 7
+      "service_count": 9
     },
     {
       "id": "memory-and-state",
       "name": "Memory & State",
       "description": "Services that give AI agents persistent, queryable memory across sessions — treating memory as infrastructure rather than application logic, and managing the full lifecycle of what agents remember, forget, and retrieve.",
       "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/README.md",
-      "service_count": 15
+      "service_count": 17
     },
     {
       "id": "search-and-web-intelligence",
       "name": "Search & Web Intelligence",
       "description": "Services that give AI agents optimized, structured access to web information — returning AI-ready content tuned for LLM context windows, not raw HTML or human-readable SERPs.",
       "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/search-and-web-intelligence/README.md",
-      "service_count": 8
+      "service_count": 9
     },
     {
       "id": "code-execution",
@@ -301,14 +316,14 @@
       "name": "Meeting & Conversation",
       "description": "Services that give AI agents a programmatic presence in voice and video conversations — letting agents join meetings, process real-time audio, and participate in synchronous communication without a human operating a client.",
       "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/meeting-and-conversation/README.md",
-      "service_count": 6
+      "service_count": 7
     },
     {
       "id": "voice-and-phone",
       "name": "Voice & Phone",
       "description": "Services that give AI agents a first-class voice and telephony identity — letting agents make and receive phone calls, conduct voice conversations, and interact via speech with no human operating a phone on their behalf.",
       "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/voice-and-phone/README.md",
-      "service_count": 6
+      "service_count": 7
     },
     {
       "id": "llm-gateway-and-routing",
@@ -322,7 +337,7 @@
       "name": "Agent Social & Community",
       "description": "Services that give AI agents a persistent public identity on the internet — allowing agents to post, comment, vote, message other agents, build reputation, and participate in communities designed exclusively for non-human actors.",
       "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-social-network/README.md",
-      "service_count": 6
+      "service_count": 7
     }
   ],
   "services": [
@@ -420,6 +435,74 @@
       "latest_month_signal": null,
       "verified_at": null,
       "verification_sources": []
+    },
+    {
+      "id": "communication/agentteam-email",
+      "slug": "agentteam-email",
+      "name": "AgentTeam Email",
+      "tagline": "Open-source email infrastructure for AI agents.",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "communication",
+      "website": "https://www.agentteam.email",
+      "repository": "https://github.com/agentteamhq/agentteam-email",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/communication/agentteam-email.md",
+      "source_path": "services/communication/agentteam-email.md",
+      "onboarding": {
+        "type": "agent-skill",
+        "pattern": "CLI + published Agent Skill",
+        "instruction": "npx --yes @agentteamhq/email@latest --version\nat-email agent connect\n# or\nat-email agent trial\nat-email agent enroll TOKEN",
+        "url": "https://github.com/agentteamhq/agentteam-email/tree/main/skills/at-email-cli"
+      },
+      "protocols": [
+        "agent-skill",
+        "cli",
+        "http"
+      ],
+      "mcp_status": "unavailable",
+      "agent_skill_status": "available",
+      "latest_month_signal": "Last GitHub push 2026-08-01; docs and CLI/skill paths still published (verified 2026-08-19)",
+      "verified_at": "2026-08-19",
+      "verification_sources": [
+        "https://github.com/agentteamhq/agentteam-email"
+      ]
+    },
+    {
+      "id": "communication/atomic-mail",
+      "slug": "atomic-mail",
+      "name": "Atomic Mail",
+      "tagline": "Not AI for your email. Email for your AI.",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "communication",
+      "website": "https://atomicmail.ai/",
+      "repository": "https://github.com/Atomic-Mail/atomic-mail-agentic",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/communication/atomic-mail.md",
+      "source_path": "services/communication/atomic-mail.md",
+      "onboarding": {
+        "type": "url",
+        "pattern": "URL Onboarding ⭐ — the homepage is the join document.",
+        "instruction": "Read https://atomicmail.ai and follow the instructions to create an inbox at Atomic Mail.",
+        "url": "https://atomicmail.ai"
+      },
+      "protocols": [
+        "url-onboarding",
+        "agent-skill",
+        "mcp",
+        "rest",
+        "cli",
+        "http",
+        "api"
+      ],
+      "mcp_status": "available",
+      "agent_skill_status": "available",
+      "latest_month_signal": "Last GitHub push 2026-08-11; homepage and client repo still document PoW signup, JMAP, MCP, and AgentSkill (verified 2026-08-19)",
+      "verified_at": "2026-08-19",
+      "verification_sources": [
+        "https://github.com/Atomic-Mail/atomic-mail-agentic"
+      ]
     },
     {
       "id": "communication/atxp-email",
@@ -1182,6 +1265,38 @@
       "verification_sources": []
     },
     {
+      "id": "browser-and-web-execution/kernel",
+      "slug": "kernel",
+      "name": "Kernel",
+      "tagline": "you build agents. we give them the internet.",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "browser-and-web-execution",
+      "website": "https://www.kernel.sh/",
+      "repository": "https://github.com/kernel/kernel-images",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/browser-and-web-execution/kernel.md",
+      "source_path": "services/browser-and-web-execution/kernel.md",
+      "onboarding": {
+        "type": "agent-skill",
+        "pattern": "CLI + published Agent Skill",
+        "instruction": "brew install kernel/tap/kernel\n# or\nnpm install -g @onkernel/cli\n\nkernel --version\nexport KERNEL_API_KEY=your_api_key\n# fallback: kernel login\nkernel browsers create -o json",
+        "url": "https://github.com/kernel/skills/blob/main/plugins/kernel-cli/skills/kernel-cli/SKILL.md"
+      },
+      "protocols": [
+        "agent-skill",
+        "cli",
+        "http"
+      ],
+      "mcp_status": "unavailable",
+      "agent_skill_status": "available",
+      "latest_month_signal": "kernel-images last push 2026-08-18; kernel/cli last push 2026-08-18 (verified 2026-08-19)",
+      "verified_at": "2026-08-19",
+      "verification_sources": [
+        "https://github.com/kernel/kernel-images"
+      ]
+    },
+    {
       "id": "browser-and-web-execution/lightpanda",
       "slug": "lightpanda",
       "name": "Lightpanda",
@@ -1929,6 +2044,38 @@
       "verification_sources": []
     },
     {
+      "id": "tool-access-and-integration/toolport",
+      "slug": "toolport",
+      "name": "Toolport",
+      "tagline": "Every tool. One port.",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "tool-access-and-integration",
+      "website": "https://toolport.app",
+      "repository": "https://github.com/tsouth89/toolport",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/toolport.md",
+      "source_path": "services/tool-access-and-integration/toolport.md",
+      "onboarding": {
+        "type": "mcp",
+        "pattern": "local MCP gateway (stdio) after a one-time desktop install",
+        "instruction": "1. Download the installer from https://github.com/tsouth89/toolport/releases/latest",
+        "url": "https://github.com/tsouth89/toolport/releases/latest"
+      },
+      "protocols": [
+        "mcp",
+        "stdio",
+        "http"
+      ],
+      "mcp_status": "available",
+      "agent_skill_status": "unavailable",
+      "latest_month_signal": "Last GitHub push 2026-08-19 (verified the same day)",
+      "verified_at": "2026-08-19",
+      "verification_sources": [
+        "https://github.com/tsouth89/toolport"
+      ]
+    },
+    {
       "id": "oversight-and-approval/cordum",
       "slug": "cordum",
       "name": "Cordum",
@@ -1987,6 +2134,39 @@
       "latest_month_signal": null,
       "verified_at": null,
       "verification_sources": []
+    },
+    {
+      "id": "oversight-and-approval/preloop",
+      "slug": "preloop",
+      "name": "Preloop",
+      "tagline": "The Open Source Control Plane for AI Agents",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "oversight-and-approval",
+      "website": "https://preloop.ai",
+      "repository": "https://github.com/preloop/preloop",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/oversight-and-approval/preloop.md",
+      "source_path": "services/oversight-and-approval/preloop.md",
+      "onboarding": {
+        "type": "cli",
+        "pattern": "CLI that rewrites local agents onto the control plane",
+        "instruction": "curl -fsSL https://preloop.ai/install/cli | sh\npreloop signup\n# or: preloop login --url http://localhost:3000\npreloop agents discover",
+        "url": "https://preloop.ai/install/cli"
+      },
+      "protocols": [
+        "mcp",
+        "rest",
+        "cli",
+        "api"
+      ],
+      "mcp_status": "available",
+      "agent_skill_status": "unavailable",
+      "latest_month_signal": "Last GitHub push 2026-08-18; CLI install and docs live (verified 2026-08-19)",
+      "verified_at": "2026-08-19",
+      "verification_sources": [
+        "https://github.com/preloop/preloop"
+      ]
     },
     {
       "id": "oversight-and-approval/sallyport",
@@ -2663,6 +2843,37 @@
       "verification_sources": []
     },
     {
+      "id": "agent-runtime-and-infrastructure/cloudflare-computer",
+      "slug": "cloudflare-computer",
+      "name": "Cloudflare Computer",
+      "tagline": "Give your agent a computer 👾",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "agent-runtime-and-infrastructure",
+      "website": "https://github.com/cloudflare/computer",
+      "repository": "https://github.com/cloudflare/computer",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/cloudflare-computer.md",
+      "source_path": "services/agent-runtime-and-infrastructure/cloudflare-computer.md",
+      "onboarding": {
+        "type": "sdk",
+        "pattern": "SDK (Durable Object workspace)",
+        "instruction": "npm install @cloudflare/computer",
+        "url": null
+      },
+      "protocols": [
+        "sdk",
+        "api"
+      ],
+      "mcp_status": "unknown",
+      "agent_skill_status": "unavailable",
+      "latest_month_signal": "Last GitHub push 2026-08-18; npm package @cloudflare/computer documented as preview (verified 2026-08-19)",
+      "verified_at": "2026-08-19",
+      "verification_sources": [
+        "https://github.com/cloudflare/computer"
+      ]
+    },
+    {
       "id": "agent-runtime-and-infrastructure/codex-plugin-cc",
       "slug": "codex-plugin-cc",
       "name": "Codex plugin for Claude Code (codex-plugin-cc)",
@@ -2810,6 +3021,37 @@
       "latest_month_signal": null,
       "verified_at": null,
       "verification_sources": []
+    },
+    {
+      "id": "agent-runtime-and-infrastructure/google-ax",
+      "slug": "google-ax",
+      "name": "Agent Executor (AX)",
+      "tagline": "An open source distributed agent runtime",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "agent-runtime-and-infrastructure",
+      "website": "https://agentexecutor.io",
+      "repository": "https://github.com/google/ax",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/google-ax.md",
+      "source_path": "services/agent-runtime-and-infrastructure/google-ax.md",
+      "onboarding": {
+        "type": "cli",
+        "pattern": "CLI + optional gRPC server",
+        "instruction": "go install github.com/google/ax/cmd/ax@latest\nax --help\n\n# Local built-in Antigravity harness (needs GEMINI_API_KEY or Vertex ADC)\nax --input \"Can you list this directory?\"\n\n# Resume\nax --conversation <id> --input \"Show me the contents of README.md\"\nax --conversation <id> --resume",
+        "url": "https://github.com/agent-substrate/substrate"
+      },
+      "protocols": [
+        "grpc",
+        "cli"
+      ],
+      "mcp_status": "unknown",
+      "agent_skill_status": "unknown",
+      "latest_month_signal": "Last GitHub push 2026-08-13; README still marks early development (verified 2026-08-19)",
+      "verified_at": "2026-08-19",
+      "verification_sources": [
+        "https://github.com/google/ax"
+      ]
     },
     {
       "id": "agent-runtime-and-infrastructure/infisical-agent-sentinel",
@@ -3120,6 +3362,36 @@
       ]
     },
     {
+      "id": "agent-harnesses-and-control-planes/claude-hud",
+      "slug": "claude-hud",
+      "name": "Claude HUD",
+      "tagline": "A Claude Code plugin that shows what's happening",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "agent-harnesses-and-control-planes",
+      "website": "https://github.com/jarrodwatts/claude-hud",
+      "repository": "https://github.com/jarrodwatts/claude-hud",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/claude-hud.md",
+      "source_path": "services/agent-harnesses-and-control-planes/claude-hud.md",
+      "onboarding": {
+        "type": "other",
+        "pattern": "Claude Code plugin + status-line protocol",
+        "instruction": "/plugin marketplace add jarrodwatts/claude-hud\n/plugin install claude-hud\n/reload-plugins\n/claude-hud:setup",
+        "url": null
+      },
+      "protocols": [
+        "documentation"
+      ],
+      "mcp_status": "unavailable",
+      "agent_skill_status": "unknown",
+      "latest_month_signal": "Last GitHub push 2026-08-18 (verified 2026-08-19)",
+      "verified_at": "2026-08-19",
+      "verification_sources": [
+        "https://github.com/jarrodwatts/claude-hud"
+      ]
+    },
+    {
       "id": "agent-harnesses-and-control-planes/codex-hud-anhannin",
       "slug": "codex-hud-anhannin",
       "name": "Codex HUD (anhannin)",
@@ -3206,6 +3478,38 @@
       "verified_at": "2026-08-13",
       "verification_sources": [
         "https://github.com/AMAP-ML/LongHorizon-Harness"
+      ]
+    },
+    {
+      "id": "agent-harnesses-and-control-planes/loopx",
+      "slug": "loopx",
+      "name": "LoopX",
+      "tagline": "The open, provider-neutral, stateful control plane for long-horizon agents.",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "agent-harnesses-and-control-planes",
+      "website": "https://huangruiteng.github.io/loopx/",
+      "repository": "https://github.com/huangruiteng/loopx",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/loopx.md",
+      "source_path": "services/agent-harnesses-and-control-planes/loopx.md",
+      "onboarding": {
+        "type": "cli",
+        "pattern": "CLI + workflow skills",
+        "instruction": "python3 -m pip install --upgrade loopx\nloopx workflow-skills --install\nloopx doctor\ncd /path/to/your-project\nloopx connect\nloopx status",
+        "url": null
+      },
+      "protocols": [
+        "agent-skill",
+        "mcp",
+        "cli"
+      ],
+      "mcp_status": "available",
+      "agent_skill_status": "available",
+      "latest_month_signal": "Last GitHub push 2026-08-19 (verified the same day)",
+      "verified_at": "2026-08-19",
+      "verification_sources": [
+        "https://github.com/huangruiteng/loopx"
       ]
     },
     {
@@ -3304,6 +3608,42 @@
       "verified_at": "2026-08-13",
       "verification_sources": [
         "https://github.com/ruvnet/ruflo"
+      ]
+    },
+    {
+      "id": "memory-and-state/agentmemory",
+      "slug": "agentmemory",
+      "name": "agentmemory",
+      "tagline": "Your coding agent remembers everything. No more re-explaining.",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "memory-and-state",
+      "website": "https://agent-memory.dev",
+      "repository": "https://github.com/rohitg00/agentmemory",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/agentmemory.md",
+      "source_path": "services/memory-and-state/agentmemory.md",
+      "onboarding": {
+        "type": "url",
+        "pattern": "URL Onboarding ⭐ + local memory server + MCP + Skills",
+        "instruction": "Retrieve and follow the instructions at: https://raw.githubusercontent.com/rohitg00/agentmemory/main/INSTALL_FOR_AGENTS.md",
+        "url": "https://raw.githubusercontent.com/rohitg00/agentmemory/main/INSTALL_FOR_AGENTS.md"
+      },
+      "protocols": [
+        "url-onboarding",
+        "agent-skill",
+        "mcp",
+        "rest",
+        "cli",
+        "stdio",
+        "http"
+      ],
+      "mcp_status": "available",
+      "agent_skill_status": "available",
+      "latest_month_signal": "Last GitHub push 2026-08-17 (verified 2026-08-19)",
+      "verified_at": "2026-08-19",
+      "verification_sources": [
+        "https://github.com/rohitg00/agentmemory"
       ]
     },
     {
@@ -3751,6 +4091,36 @@
       "verification_sources": []
     },
     {
+      "id": "memory-and-state/tencentdb-agent-memory",
+      "slug": "tencentdb-agent-memory",
+      "name": "TencentDB Agent Memory",
+      "tagline": "Agents remember,Humans innovate.",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "memory-and-state",
+      "website": "https://github.com/TencentCloud/TencentDB-Agent-Memory",
+      "repository": "https://github.com/TencentCloud/TencentDB-Agent-Memory",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/tencentdb-agent-memory.md",
+      "source_path": "services/memory-and-state/tencentdb-agent-memory.md",
+      "onboarding": {
+        "type": "other",
+        "pattern": "OpenClaw plugin or Hermes gateway plugin",
+        "instruction": "openclaw plugins install @tencentdb-agent-memory/memory-tencentdb\nopenclaw gateway restart",
+        "url": null
+      },
+      "protocols": [
+        "http"
+      ],
+      "mcp_status": "unavailable",
+      "agent_skill_status": "unavailable",
+      "latest_month_signal": "Default branch feat/server_team; last push 2026-08-15 (verified 2026-08-19)",
+      "verified_at": "2026-08-19",
+      "verification_sources": [
+        "https://github.com/TencentCloud/TencentDB-Agent-Memory"
+      ]
+    },
+    {
       "id": "memory-and-state/zep",
       "slug": "zep",
       "name": "Zep",
@@ -3780,6 +4150,40 @@
       "latest_month_signal": null,
       "verified_at": null,
       "verification_sources": []
+    },
+    {
+      "id": "search-and-web-intelligence/agent-search-mcp",
+      "slug": "agent-search-mcp",
+      "name": "Agent Search MCP",
+      "tagline": "A Node.js MCP server and CLI for English and Chinese web search.",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "search-and-web-intelligence",
+      "website": "https://take-a-deep-breath0.com/en/agent-search-mcp",
+      "repository": "https://github.com/lennney/agent-search-mcp",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/search-and-web-intelligence/agent-search-mcp.md",
+      "source_path": "services/search-and-web-intelligence/agent-search-mcp.md",
+      "onboarding": {
+        "type": "agent-skill",
+        "pattern": "MCP (stdio) + optional Agent Skill + fasm CLI",
+        "instruction": "{\n  \"mcpServers\": {\n    \"agent-search\": {\n      \"command\": \"npx\",\n      \"args\": [\"-y\", \"agent-search-mcp\"]\n    }\n  }\n}",
+        "url": null
+      },
+      "protocols": [
+        "agent-skill",
+        "mcp",
+        "cli",
+        "stdio",
+        "http"
+      ],
+      "mcp_status": "available",
+      "agent_skill_status": "available",
+      "latest_month_signal": "Last GitHub push 2026-08-17 (verified 2026-08-19)",
+      "verified_at": "2026-08-19",
+      "verification_sources": [
+        "https://github.com/lennney/agent-search-mcp"
+      ]
     },
     {
       "id": "search-and-web-intelligence/contextx",
@@ -4914,6 +5318,40 @@
       "verification_sources": []
     },
     {
+      "id": "meeting-and-conversation/agentcall",
+      "slug": "agentcall",
+      "name": "AgentCall",
+      "tagline": "Your AI agent, in every meeting.",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "meeting-and-conversation",
+      "website": "https://agentcall.dev",
+      "repository": "https://github.com/pattern-ai-labs/agentcall",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/meeting-and-conversation/agentcall.md",
+      "source_path": "services/meeting-and-conversation/agentcall.md",
+      "onboarding": {
+        "type": "agent-skill",
+        "pattern": "Agent Skill (not an SDK)",
+        "instruction": "/plugin marketplace add pattern-ai-labs/agentcall\n/plugin install join-meeting@agentcall",
+        "url": "https://github.com/pattern-ai-labs/agentcall"
+      },
+      "protocols": [
+        "agent-skill",
+        "rest",
+        "websocket",
+        "http",
+        "api"
+      ],
+      "mcp_status": "unavailable",
+      "agent_skill_status": "available",
+      "latest_month_signal": "Last GitHub push 2026-08-10; site and skill install paths live (verified 2026-08-19)",
+      "verified_at": "2026-08-19",
+      "verification_sources": [
+        "https://github.com/pattern-ai-labs/agentcall"
+      ]
+    },
+    {
       "id": "meeting-and-conversation/daily-agent",
       "slug": "daily-agent",
       "name": "Daily Agent Toolkit",
@@ -5134,6 +5572,37 @@
       "latest_month_signal": null,
       "verified_at": null,
       "verification_sources": []
+    },
+    {
+      "id": "voice-and-phone/patter",
+      "slug": "patter",
+      "name": "Patter",
+      "tagline": "Patter is the open-source SDK that gives your AI agent a phone number.",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "voice-and-phone",
+      "website": "https://getpatter.com",
+      "repository": "https://github.com/PatterAI/Patter",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/voice-and-phone/patter.md",
+      "source_path": "services/voice-and-phone/patter.md",
+      "onboarding": {
+        "type": "agent-skill",
+        "pattern": "SDK + published Agent Skills",
+        "instruction": "npx skills add patterai/skills\nnpm install getpatter\n# or\npip install getpatter",
+        "url": "https://docs.getpatter.com"
+      },
+      "protocols": [
+        "agent-skill",
+        "http"
+      ],
+      "mcp_status": "unavailable",
+      "agent_skill_status": "available",
+      "latest_month_signal": "Last GitHub push 2026-08-13 (verified 2026-08-19)",
+      "verified_at": "2026-08-19",
+      "verification_sources": [
+        "https://github.com/PatterAI/Patter"
+      ]
     },
     {
       "id": "voice-and-phone/pipecat",
@@ -5573,6 +6042,40 @@
         "https://github.com/LtyFantasy/agent-chamber/releases/tag/v1.43.0",
         "https://github.com/LtyFantasy/agent-chamber/releases/tag/v1.43.1",
         "https://api.github.com/repos/LtyFantasy/agent-chamber"
+      ]
+    },
+    {
+      "id": "agent-social-network/agentgram",
+      "slug": "agentgram",
+      "name": "AgentGram",
+      "tagline": "The Open-Source Social Network for AI Agents",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "agent-social-network",
+      "website": "https://agentgram.co",
+      "repository": "https://github.com/agentgram/agentgram",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-social-network/agentgram.md",
+      "source_path": "services/agent-social-network/agentgram.md",
+      "onboarding": {
+        "type": "mcp",
+        "pattern": "SDK + MCP",
+        "instruction": "pip install agentgram\npython -c \"from agentgram import AgentGram; AgentGram().agents.register(name='my-bot')\"",
+        "url": "https://github.com/agentgram/agentgram.git"
+      },
+      "protocols": [
+        "mcp",
+        "rest",
+        "sdk",
+        "http",
+        "api"
+      ],
+      "mcp_status": "available",
+      "agent_skill_status": "unknown",
+      "latest_month_signal": "Last GitHub push 2026-08-19; homepage also markets team MCP/AX Score governance (verified 2026-08-19)",
+      "verified_at": "2026-08-19",
+      "verification_sources": [
+        "https://github.com/agentgram/agentgram"
       ]
     },
     {

--- a/docs/catalog.json
+++ b/docs/catalog.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://lihaorui.com/awesome-agent-native-services/catalog.schema.json",
   "schema_version": "1.0.0",
-  "catalog_version": "2026-08-18",
-  "generated_at": "2026-08-18",
+  "catalog_version": "2026-08-19",
+  "generated_at": "2026-08-19",
   "license": "CC0-1.0",
   "source": {
     "repository": "https://github.com/haoruilee/awesome-agent-native-services",
@@ -11,7 +11,7 @@
     "service_directory": "services",
     "content_digest": {
       "algorithm": "sha256",
-      "value": "c11881b2e338df8041d7646e9f4eac0c3ec92c752a20372749d77f4f2a86db43",
+      "value": "414695665d51ecd39d640f5519d206566b775a824065983bfcf91544738baac1",
       "input_paths": [
         "README.md",
         "skill.md",
@@ -19,6 +19,8 @@
         "services/communication/agenticmail.md",
         "services/communication/agentmail.md",
         "services/communication/agents-mail.md",
+        "services/communication/agentteam-email.md",
+        "services/communication/atomic-mail.md",
         "services/communication/atxp-email.md",
         "services/communication/caspian.md",
         "services/communication/chimely.md",
@@ -44,6 +46,7 @@
         "services/browser-and-web-execution/crawl4ai.md",
         "services/browser-and-web-execution/firecrawl.md",
         "services/browser-and-web-execution/hyperbrowser.md",
+        "services/browser-and-web-execution/kernel.md",
         "services/browser-and-web-execution/lightpanda.md",
         "services/browser-and-web-execution/moli.md",
         "services/browser-and-web-execution/notte.md",
@@ -69,9 +72,11 @@
         "services/tool-access-and-integration/snyk-agent-scan.md",
         "services/tool-access-and-integration/toolhive.md",
         "services/tool-access-and-integration/toolhouse.md",
+        "services/tool-access-and-integration/toolport.md",
         "services/oversight-and-approval/README.md",
         "services/oversight-and-approval/cordum.md",
         "services/oversight-and-approval/humanlayer.md",
+        "services/oversight-and-approval/preloop.md",
         "services/oversight-and-approval/sallyport.md",
         "services/oversight-and-approval/sondera-coding-agent-hooks.md",
         "services/commerce-and-payments/README.md",
@@ -96,11 +101,13 @@
         "services/agent-runtime-and-infrastructure/claude-managed-agents.md",
         "services/agent-runtime-and-infrastructure/claude-peers.md",
         "services/agent-runtime-and-infrastructure/cloudflare-agents-sdk.md",
+        "services/agent-runtime-and-infrastructure/cloudflare-computer.md",
         "services/agent-runtime-and-infrastructure/codex-plugin-cc.md",
         "services/agent-runtime-and-infrastructure/cx.md",
         "services/agent-runtime-and-infrastructure/cyberdesk.md",
         "services/agent-runtime-and-infrastructure/db9.md",
         "services/agent-runtime-and-infrastructure/fiserv-agentos.md",
+        "services/agent-runtime-and-infrastructure/google-ax.md",
         "services/agent-runtime-and-infrastructure/infisical-agent-sentinel.md",
         "services/agent-runtime-and-infrastructure/letta.md",
         "services/agent-runtime-and-infrastructure/modal.md",
@@ -112,13 +119,16 @@
         "services/agent-runtime-and-infrastructure/vertex-ai-agent-engine.md",
         "services/agent-harnesses-and-control-planes/README.md",
         "services/agent-harnesses-and-control-planes/agent-qa.md",
+        "services/agent-harnesses-and-control-planes/claude-hud.md",
         "services/agent-harnesses-and-control-planes/codex-hud-anhannin.md",
         "services/agent-harnesses-and-control-planes/codex-hud-fwyc0573.md",
         "services/agent-harnesses-and-control-planes/longhorizon-harness.md",
+        "services/agent-harnesses-and-control-planes/loopx.md",
         "services/agent-harnesses-and-control-planes/oh-my-codex.md",
         "services/agent-harnesses-and-control-planes/qm.md",
         "services/agent-harnesses-and-control-planes/ruflo.md",
         "services/memory-and-state/README.md",
+        "services/memory-and-state/agentmemory.md",
         "services/memory-and-state/cognee.md",
         "services/memory-and-state/ensue.md",
         "services/memory-and-state/hindsight.md",
@@ -133,8 +143,10 @@
         "services/memory-and-state/memu.md",
         "services/memory-and-state/openviking.md",
         "services/memory-and-state/recall.md",
+        "services/memory-and-state/tencentdb-agent-memory.md",
         "services/memory-and-state/zep.md",
         "services/search-and-web-intelligence/README.md",
+        "services/search-and-web-intelligence/agent-search-mcp.md",
         "services/search-and-web-intelligence/contextx.md",
         "services/search-and-web-intelligence/exa.md",
         "services/search-and-web-intelligence/jina-deepsearch.md",
@@ -175,6 +187,7 @@
         "services/durable-execution-and-scheduling/restate.md",
         "services/durable-execution-and-scheduling/trigger-dev.md",
         "services/meeting-and-conversation/README.md",
+        "services/meeting-and-conversation/agentcall.md",
         "services/meeting-and-conversation/daily-agent.md",
         "services/meeting-and-conversation/looped-meet.md",
         "services/meeting-and-conversation/meeting-baas.md",
@@ -183,6 +196,7 @@
         "services/meeting-and-conversation/vexa.md",
         "services/voice-and-phone/README.md",
         "services/voice-and-phone/livekit-agents.md",
+        "services/voice-and-phone/patter.md",
         "services/voice-and-phone/pipecat.md",
         "services/voice-and-phone/qwen-audio-agent.md",
         "services/voice-and-phone/retell-ai.md",
@@ -199,6 +213,7 @@
         "services/llm-gateway-and-routing/sageroute.md",
         "services/agent-social-network/README.md",
         "services/agent-social-network/agent-chamber.md",
+        "services/agent-social-network/agentgram.md",
         "services/agent-social-network/kinthai.md",
         "services/agent-social-network/mcpverse.md",
         "services/agent-social-network/moltbook.md",
@@ -209,7 +224,7 @@
   },
   "counts": {
     "categories": 16,
-    "services": 173
+    "services": 188
   },
   "categories": [
     {
@@ -217,28 +232,28 @@
       "name": "Communication",
       "description": "Services that give AI agents a first-class communication identity on the internet — not a proxy to a human's mailbox or messaging account, but an identity the agent owns and operates autonomously.",
       "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/communication/README.md",
-      "service_count": 13
+      "service_count": 15
     },
     {
       "id": "browser-and-web-execution",
       "name": "Browser & Web Execution",
       "description": "Services that give AI agents a remote, managed browser runtime — so agents can navigate, interact with, and extract data from the web as an autonomous actor, without any human operating a browser on their behalf.",
       "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/browser-and-web-execution/README.md",
-      "service_count": 23
+      "service_count": 24
     },
     {
       "id": "tool-access-and-integration",
       "name": "Tool Access & Integration",
       "description": "Services that let AI agents discover, authenticate, and invoke external tools at runtime — without a human pre-configuring credentials or selecting which integrations to activate.",
       "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/README.md",
-      "service_count": 15
+      "service_count": 16
     },
     {
       "id": "oversight-and-approval",
       "name": "Oversight & Approval",
       "description": "Services that give AI agents a structured, programmatic way to request human approval before executing high-stakes actions — turning human oversight from an ad-hoc interruption into a first-class, auditable primitive.",
       "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/oversight-and-approval/README.md",
-      "service_count": 4
+      "service_count": 5
     },
     {
       "id": "commerce-and-payments",
@@ -252,28 +267,28 @@
       "name": "Agent Runtime & Infrastructure",
       "description": "Services that provide the secure deployment substrate, session isolation, secret management, identity, gateway, and observability required to run AI agents reliably in production — the \"operating system layer\" for autonomous agents.",
       "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/README.md",
-      "service_count": 25
+      "service_count": 27
     },
     {
       "id": "agent-harnesses-and-control-planes",
       "name": "Agent Harnesses & Operator Surfaces",
       "description": "Systems purpose-built around running agents: either harnesses that add durable work state, orchestration, verification, and policy, or operator surfaces that expose live agent state and bounded session controls.",
       "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/README.md",
-      "service_count": 7
+      "service_count": 9
     },
     {
       "id": "memory-and-state",
       "name": "Memory & State",
       "description": "Services that give AI agents persistent, queryable memory across sessions — treating memory as infrastructure rather than application logic, and managing the full lifecycle of what agents remember, forget, and retrieve.",
       "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/README.md",
-      "service_count": 15
+      "service_count": 17
     },
     {
       "id": "search-and-web-intelligence",
       "name": "Search & Web Intelligence",
       "description": "Services that give AI agents optimized, structured access to web information — returning AI-ready content tuned for LLM context windows, not raw HTML or human-readable SERPs.",
       "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/search-and-web-intelligence/README.md",
-      "service_count": 8
+      "service_count": 9
     },
     {
       "id": "code-execution",
@@ -301,14 +316,14 @@
       "name": "Meeting & Conversation",
       "description": "Services that give AI agents a programmatic presence in voice and video conversations — letting agents join meetings, process real-time audio, and participate in synchronous communication without a human operating a client.",
       "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/meeting-and-conversation/README.md",
-      "service_count": 6
+      "service_count": 7
     },
     {
       "id": "voice-and-phone",
       "name": "Voice & Phone",
       "description": "Services that give AI agents a first-class voice and telephony identity — letting agents make and receive phone calls, conduct voice conversations, and interact via speech with no human operating a phone on their behalf.",
       "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/voice-and-phone/README.md",
-      "service_count": 6
+      "service_count": 7
     },
     {
       "id": "llm-gateway-and-routing",
@@ -322,7 +337,7 @@
       "name": "Agent Social & Community",
       "description": "Services that give AI agents a persistent public identity on the internet — allowing agents to post, comment, vote, message other agents, build reputation, and participate in communities designed exclusively for non-human actors.",
       "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-social-network/README.md",
-      "service_count": 6
+      "service_count": 7
     }
   ],
   "services": [
@@ -420,6 +435,74 @@
       "latest_month_signal": null,
       "verified_at": null,
       "verification_sources": []
+    },
+    {
+      "id": "communication/agentteam-email",
+      "slug": "agentteam-email",
+      "name": "AgentTeam Email",
+      "tagline": "Open-source email infrastructure for AI agents.",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "communication",
+      "website": "https://www.agentteam.email",
+      "repository": "https://github.com/agentteamhq/agentteam-email",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/communication/agentteam-email.md",
+      "source_path": "services/communication/agentteam-email.md",
+      "onboarding": {
+        "type": "agent-skill",
+        "pattern": "CLI + published Agent Skill",
+        "instruction": "npx --yes @agentteamhq/email@latest --version\nat-email agent connect\n# or\nat-email agent trial\nat-email agent enroll TOKEN",
+        "url": "https://github.com/agentteamhq/agentteam-email/tree/main/skills/at-email-cli"
+      },
+      "protocols": [
+        "agent-skill",
+        "cli",
+        "http"
+      ],
+      "mcp_status": "unavailable",
+      "agent_skill_status": "available",
+      "latest_month_signal": "Last GitHub push 2026-08-01; docs and CLI/skill paths still published (verified 2026-08-19)",
+      "verified_at": "2026-08-19",
+      "verification_sources": [
+        "https://github.com/agentteamhq/agentteam-email"
+      ]
+    },
+    {
+      "id": "communication/atomic-mail",
+      "slug": "atomic-mail",
+      "name": "Atomic Mail",
+      "tagline": "Not AI for your email. Email for your AI.",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "communication",
+      "website": "https://atomicmail.ai/",
+      "repository": "https://github.com/Atomic-Mail/atomic-mail-agentic",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/communication/atomic-mail.md",
+      "source_path": "services/communication/atomic-mail.md",
+      "onboarding": {
+        "type": "url",
+        "pattern": "URL Onboarding ⭐ — the homepage is the join document.",
+        "instruction": "Read https://atomicmail.ai and follow the instructions to create an inbox at Atomic Mail.",
+        "url": "https://atomicmail.ai"
+      },
+      "protocols": [
+        "url-onboarding",
+        "agent-skill",
+        "mcp",
+        "rest",
+        "cli",
+        "http",
+        "api"
+      ],
+      "mcp_status": "available",
+      "agent_skill_status": "available",
+      "latest_month_signal": "Last GitHub push 2026-08-11; homepage and client repo still document PoW signup, JMAP, MCP, and AgentSkill (verified 2026-08-19)",
+      "verified_at": "2026-08-19",
+      "verification_sources": [
+        "https://github.com/Atomic-Mail/atomic-mail-agentic"
+      ]
     },
     {
       "id": "communication/atxp-email",
@@ -1182,6 +1265,38 @@
       "verification_sources": []
     },
     {
+      "id": "browser-and-web-execution/kernel",
+      "slug": "kernel",
+      "name": "Kernel",
+      "tagline": "you build agents. we give them the internet.",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "browser-and-web-execution",
+      "website": "https://www.kernel.sh/",
+      "repository": "https://github.com/kernel/kernel-images",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/browser-and-web-execution/kernel.md",
+      "source_path": "services/browser-and-web-execution/kernel.md",
+      "onboarding": {
+        "type": "agent-skill",
+        "pattern": "CLI + published Agent Skill",
+        "instruction": "brew install kernel/tap/kernel\n# or\nnpm install -g @onkernel/cli\n\nkernel --version\nexport KERNEL_API_KEY=your_api_key\n# fallback: kernel login\nkernel browsers create -o json",
+        "url": "https://github.com/kernel/skills/blob/main/plugins/kernel-cli/skills/kernel-cli/SKILL.md"
+      },
+      "protocols": [
+        "agent-skill",
+        "cli",
+        "http"
+      ],
+      "mcp_status": "unavailable",
+      "agent_skill_status": "available",
+      "latest_month_signal": "kernel-images last push 2026-08-18; kernel/cli last push 2026-08-18 (verified 2026-08-19)",
+      "verified_at": "2026-08-19",
+      "verification_sources": [
+        "https://github.com/kernel/kernel-images"
+      ]
+    },
+    {
       "id": "browser-and-web-execution/lightpanda",
       "slug": "lightpanda",
       "name": "Lightpanda",
@@ -1929,6 +2044,38 @@
       "verification_sources": []
     },
     {
+      "id": "tool-access-and-integration/toolport",
+      "slug": "toolport",
+      "name": "Toolport",
+      "tagline": "Every tool. One port.",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "tool-access-and-integration",
+      "website": "https://toolport.app",
+      "repository": "https://github.com/tsouth89/toolport",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/toolport.md",
+      "source_path": "services/tool-access-and-integration/toolport.md",
+      "onboarding": {
+        "type": "mcp",
+        "pattern": "local MCP gateway (stdio) after a one-time desktop install",
+        "instruction": "1. Download the installer from https://github.com/tsouth89/toolport/releases/latest",
+        "url": "https://github.com/tsouth89/toolport/releases/latest"
+      },
+      "protocols": [
+        "mcp",
+        "stdio",
+        "http"
+      ],
+      "mcp_status": "available",
+      "agent_skill_status": "unavailable",
+      "latest_month_signal": "Last GitHub push 2026-08-19 (verified the same day)",
+      "verified_at": "2026-08-19",
+      "verification_sources": [
+        "https://github.com/tsouth89/toolport"
+      ]
+    },
+    {
       "id": "oversight-and-approval/cordum",
       "slug": "cordum",
       "name": "Cordum",
@@ -1987,6 +2134,39 @@
       "latest_month_signal": null,
       "verified_at": null,
       "verification_sources": []
+    },
+    {
+      "id": "oversight-and-approval/preloop",
+      "slug": "preloop",
+      "name": "Preloop",
+      "tagline": "The Open Source Control Plane for AI Agents",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "oversight-and-approval",
+      "website": "https://preloop.ai",
+      "repository": "https://github.com/preloop/preloop",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/oversight-and-approval/preloop.md",
+      "source_path": "services/oversight-and-approval/preloop.md",
+      "onboarding": {
+        "type": "cli",
+        "pattern": "CLI that rewrites local agents onto the control plane",
+        "instruction": "curl -fsSL https://preloop.ai/install/cli | sh\npreloop signup\n# or: preloop login --url http://localhost:3000\npreloop agents discover",
+        "url": "https://preloop.ai/install/cli"
+      },
+      "protocols": [
+        "mcp",
+        "rest",
+        "cli",
+        "api"
+      ],
+      "mcp_status": "available",
+      "agent_skill_status": "unavailable",
+      "latest_month_signal": "Last GitHub push 2026-08-18; CLI install and docs live (verified 2026-08-19)",
+      "verified_at": "2026-08-19",
+      "verification_sources": [
+        "https://github.com/preloop/preloop"
+      ]
     },
     {
       "id": "oversight-and-approval/sallyport",
@@ -2663,6 +2843,37 @@
       "verification_sources": []
     },
     {
+      "id": "agent-runtime-and-infrastructure/cloudflare-computer",
+      "slug": "cloudflare-computer",
+      "name": "Cloudflare Computer",
+      "tagline": "Give your agent a computer 👾",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "agent-runtime-and-infrastructure",
+      "website": "https://github.com/cloudflare/computer",
+      "repository": "https://github.com/cloudflare/computer",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/cloudflare-computer.md",
+      "source_path": "services/agent-runtime-and-infrastructure/cloudflare-computer.md",
+      "onboarding": {
+        "type": "sdk",
+        "pattern": "SDK (Durable Object workspace)",
+        "instruction": "npm install @cloudflare/computer",
+        "url": null
+      },
+      "protocols": [
+        "sdk",
+        "api"
+      ],
+      "mcp_status": "unknown",
+      "agent_skill_status": "unavailable",
+      "latest_month_signal": "Last GitHub push 2026-08-18; npm package @cloudflare/computer documented as preview (verified 2026-08-19)",
+      "verified_at": "2026-08-19",
+      "verification_sources": [
+        "https://github.com/cloudflare/computer"
+      ]
+    },
+    {
       "id": "agent-runtime-and-infrastructure/codex-plugin-cc",
       "slug": "codex-plugin-cc",
       "name": "Codex plugin for Claude Code (codex-plugin-cc)",
@@ -2810,6 +3021,37 @@
       "latest_month_signal": null,
       "verified_at": null,
       "verification_sources": []
+    },
+    {
+      "id": "agent-runtime-and-infrastructure/google-ax",
+      "slug": "google-ax",
+      "name": "Agent Executor (AX)",
+      "tagline": "An open source distributed agent runtime",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "agent-runtime-and-infrastructure",
+      "website": "https://agentexecutor.io",
+      "repository": "https://github.com/google/ax",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/google-ax.md",
+      "source_path": "services/agent-runtime-and-infrastructure/google-ax.md",
+      "onboarding": {
+        "type": "cli",
+        "pattern": "CLI + optional gRPC server",
+        "instruction": "go install github.com/google/ax/cmd/ax@latest\nax --help\n\n# Local built-in Antigravity harness (needs GEMINI_API_KEY or Vertex ADC)\nax --input \"Can you list this directory?\"\n\n# Resume\nax --conversation <id> --input \"Show me the contents of README.md\"\nax --conversation <id> --resume",
+        "url": "https://github.com/agent-substrate/substrate"
+      },
+      "protocols": [
+        "grpc",
+        "cli"
+      ],
+      "mcp_status": "unknown",
+      "agent_skill_status": "unknown",
+      "latest_month_signal": "Last GitHub push 2026-08-13; README still marks early development (verified 2026-08-19)",
+      "verified_at": "2026-08-19",
+      "verification_sources": [
+        "https://github.com/google/ax"
+      ]
     },
     {
       "id": "agent-runtime-and-infrastructure/infisical-agent-sentinel",
@@ -3120,6 +3362,36 @@
       ]
     },
     {
+      "id": "agent-harnesses-and-control-planes/claude-hud",
+      "slug": "claude-hud",
+      "name": "Claude HUD",
+      "tagline": "A Claude Code plugin that shows what's happening",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "agent-harnesses-and-control-planes",
+      "website": "https://github.com/jarrodwatts/claude-hud",
+      "repository": "https://github.com/jarrodwatts/claude-hud",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/claude-hud.md",
+      "source_path": "services/agent-harnesses-and-control-planes/claude-hud.md",
+      "onboarding": {
+        "type": "other",
+        "pattern": "Claude Code plugin + status-line protocol",
+        "instruction": "/plugin marketplace add jarrodwatts/claude-hud\n/plugin install claude-hud\n/reload-plugins\n/claude-hud:setup",
+        "url": null
+      },
+      "protocols": [
+        "documentation"
+      ],
+      "mcp_status": "unavailable",
+      "agent_skill_status": "unknown",
+      "latest_month_signal": "Last GitHub push 2026-08-18 (verified 2026-08-19)",
+      "verified_at": "2026-08-19",
+      "verification_sources": [
+        "https://github.com/jarrodwatts/claude-hud"
+      ]
+    },
+    {
       "id": "agent-harnesses-and-control-planes/codex-hud-anhannin",
       "slug": "codex-hud-anhannin",
       "name": "Codex HUD (anhannin)",
@@ -3206,6 +3478,38 @@
       "verified_at": "2026-08-13",
       "verification_sources": [
         "https://github.com/AMAP-ML/LongHorizon-Harness"
+      ]
+    },
+    {
+      "id": "agent-harnesses-and-control-planes/loopx",
+      "slug": "loopx",
+      "name": "LoopX",
+      "tagline": "The open, provider-neutral, stateful control plane for long-horizon agents.",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "agent-harnesses-and-control-planes",
+      "website": "https://huangruiteng.github.io/loopx/",
+      "repository": "https://github.com/huangruiteng/loopx",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/loopx.md",
+      "source_path": "services/agent-harnesses-and-control-planes/loopx.md",
+      "onboarding": {
+        "type": "cli",
+        "pattern": "CLI + workflow skills",
+        "instruction": "python3 -m pip install --upgrade loopx\nloopx workflow-skills --install\nloopx doctor\ncd /path/to/your-project\nloopx connect\nloopx status",
+        "url": null
+      },
+      "protocols": [
+        "agent-skill",
+        "mcp",
+        "cli"
+      ],
+      "mcp_status": "available",
+      "agent_skill_status": "available",
+      "latest_month_signal": "Last GitHub push 2026-08-19 (verified the same day)",
+      "verified_at": "2026-08-19",
+      "verification_sources": [
+        "https://github.com/huangruiteng/loopx"
       ]
     },
     {
@@ -3304,6 +3608,42 @@
       "verified_at": "2026-08-13",
       "verification_sources": [
         "https://github.com/ruvnet/ruflo"
+      ]
+    },
+    {
+      "id": "memory-and-state/agentmemory",
+      "slug": "agentmemory",
+      "name": "agentmemory",
+      "tagline": "Your coding agent remembers everything. No more re-explaining.",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "memory-and-state",
+      "website": "https://agent-memory.dev",
+      "repository": "https://github.com/rohitg00/agentmemory",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/agentmemory.md",
+      "source_path": "services/memory-and-state/agentmemory.md",
+      "onboarding": {
+        "type": "url",
+        "pattern": "URL Onboarding ⭐ + local memory server + MCP + Skills",
+        "instruction": "Retrieve and follow the instructions at: https://raw.githubusercontent.com/rohitg00/agentmemory/main/INSTALL_FOR_AGENTS.md",
+        "url": "https://raw.githubusercontent.com/rohitg00/agentmemory/main/INSTALL_FOR_AGENTS.md"
+      },
+      "protocols": [
+        "url-onboarding",
+        "agent-skill",
+        "mcp",
+        "rest",
+        "cli",
+        "stdio",
+        "http"
+      ],
+      "mcp_status": "available",
+      "agent_skill_status": "available",
+      "latest_month_signal": "Last GitHub push 2026-08-17 (verified 2026-08-19)",
+      "verified_at": "2026-08-19",
+      "verification_sources": [
+        "https://github.com/rohitg00/agentmemory"
       ]
     },
     {
@@ -3751,6 +4091,36 @@
       "verification_sources": []
     },
     {
+      "id": "memory-and-state/tencentdb-agent-memory",
+      "slug": "tencentdb-agent-memory",
+      "name": "TencentDB Agent Memory",
+      "tagline": "Agents remember,Humans innovate.",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "memory-and-state",
+      "website": "https://github.com/TencentCloud/TencentDB-Agent-Memory",
+      "repository": "https://github.com/TencentCloud/TencentDB-Agent-Memory",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/tencentdb-agent-memory.md",
+      "source_path": "services/memory-and-state/tencentdb-agent-memory.md",
+      "onboarding": {
+        "type": "other",
+        "pattern": "OpenClaw plugin or Hermes gateway plugin",
+        "instruction": "openclaw plugins install @tencentdb-agent-memory/memory-tencentdb\nopenclaw gateway restart",
+        "url": null
+      },
+      "protocols": [
+        "http"
+      ],
+      "mcp_status": "unavailable",
+      "agent_skill_status": "unavailable",
+      "latest_month_signal": "Default branch feat/server_team; last push 2026-08-15 (verified 2026-08-19)",
+      "verified_at": "2026-08-19",
+      "verification_sources": [
+        "https://github.com/TencentCloud/TencentDB-Agent-Memory"
+      ]
+    },
+    {
       "id": "memory-and-state/zep",
       "slug": "zep",
       "name": "Zep",
@@ -3780,6 +4150,40 @@
       "latest_month_signal": null,
       "verified_at": null,
       "verification_sources": []
+    },
+    {
+      "id": "search-and-web-intelligence/agent-search-mcp",
+      "slug": "agent-search-mcp",
+      "name": "Agent Search MCP",
+      "tagline": "A Node.js MCP server and CLI for English and Chinese web search.",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "search-and-web-intelligence",
+      "website": "https://take-a-deep-breath0.com/en/agent-search-mcp",
+      "repository": "https://github.com/lennney/agent-search-mcp",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/search-and-web-intelligence/agent-search-mcp.md",
+      "source_path": "services/search-and-web-intelligence/agent-search-mcp.md",
+      "onboarding": {
+        "type": "agent-skill",
+        "pattern": "MCP (stdio) + optional Agent Skill + fasm CLI",
+        "instruction": "{\n  \"mcpServers\": {\n    \"agent-search\": {\n      \"command\": \"npx\",\n      \"args\": [\"-y\", \"agent-search-mcp\"]\n    }\n  }\n}",
+        "url": null
+      },
+      "protocols": [
+        "agent-skill",
+        "mcp",
+        "cli",
+        "stdio",
+        "http"
+      ],
+      "mcp_status": "available",
+      "agent_skill_status": "available",
+      "latest_month_signal": "Last GitHub push 2026-08-17 (verified 2026-08-19)",
+      "verified_at": "2026-08-19",
+      "verification_sources": [
+        "https://github.com/lennney/agent-search-mcp"
+      ]
     },
     {
       "id": "search-and-web-intelligence/contextx",
@@ -4914,6 +5318,40 @@
       "verification_sources": []
     },
     {
+      "id": "meeting-and-conversation/agentcall",
+      "slug": "agentcall",
+      "name": "AgentCall",
+      "tagline": "Your AI agent, in every meeting.",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "meeting-and-conversation",
+      "website": "https://agentcall.dev",
+      "repository": "https://github.com/pattern-ai-labs/agentcall",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/meeting-and-conversation/agentcall.md",
+      "source_path": "services/meeting-and-conversation/agentcall.md",
+      "onboarding": {
+        "type": "agent-skill",
+        "pattern": "Agent Skill (not an SDK)",
+        "instruction": "/plugin marketplace add pattern-ai-labs/agentcall\n/plugin install join-meeting@agentcall",
+        "url": "https://github.com/pattern-ai-labs/agentcall"
+      },
+      "protocols": [
+        "agent-skill",
+        "rest",
+        "websocket",
+        "http",
+        "api"
+      ],
+      "mcp_status": "unavailable",
+      "agent_skill_status": "available",
+      "latest_month_signal": "Last GitHub push 2026-08-10; site and skill install paths live (verified 2026-08-19)",
+      "verified_at": "2026-08-19",
+      "verification_sources": [
+        "https://github.com/pattern-ai-labs/agentcall"
+      ]
+    },
+    {
       "id": "meeting-and-conversation/daily-agent",
       "slug": "daily-agent",
       "name": "Daily Agent Toolkit",
@@ -5134,6 +5572,37 @@
       "latest_month_signal": null,
       "verified_at": null,
       "verification_sources": []
+    },
+    {
+      "id": "voice-and-phone/patter",
+      "slug": "patter",
+      "name": "Patter",
+      "tagline": "Patter is the open-source SDK that gives your AI agent a phone number.",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "voice-and-phone",
+      "website": "https://getpatter.com",
+      "repository": "https://github.com/PatterAI/Patter",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/voice-and-phone/patter.md",
+      "source_path": "services/voice-and-phone/patter.md",
+      "onboarding": {
+        "type": "agent-skill",
+        "pattern": "SDK + published Agent Skills",
+        "instruction": "npx skills add patterai/skills\nnpm install getpatter\n# or\npip install getpatter",
+        "url": "https://docs.getpatter.com"
+      },
+      "protocols": [
+        "agent-skill",
+        "http"
+      ],
+      "mcp_status": "unavailable",
+      "agent_skill_status": "available",
+      "latest_month_signal": "Last GitHub push 2026-08-13 (verified 2026-08-19)",
+      "verified_at": "2026-08-19",
+      "verification_sources": [
+        "https://github.com/PatterAI/Patter"
+      ]
     },
     {
       "id": "voice-and-phone/pipecat",
@@ -5573,6 +6042,40 @@
         "https://github.com/LtyFantasy/agent-chamber/releases/tag/v1.43.0",
         "https://github.com/LtyFantasy/agent-chamber/releases/tag/v1.43.1",
         "https://api.github.com/repos/LtyFantasy/agent-chamber"
+      ]
+    },
+    {
+      "id": "agent-social-network/agentgram",
+      "slug": "agentgram",
+      "name": "AgentGram",
+      "tagline": "The Open-Source Social Network for AI Agents",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "agent-social-network",
+      "website": "https://agentgram.co",
+      "repository": "https://github.com/agentgram/agentgram",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-social-network/agentgram.md",
+      "source_path": "services/agent-social-network/agentgram.md",
+      "onboarding": {
+        "type": "mcp",
+        "pattern": "SDK + MCP",
+        "instruction": "pip install agentgram\npython -c \"from agentgram import AgentGram; AgentGram().agents.register(name='my-bot')\"",
+        "url": "https://github.com/agentgram/agentgram.git"
+      },
+      "protocols": [
+        "mcp",
+        "rest",
+        "sdk",
+        "http",
+        "api"
+      ],
+      "mcp_status": "available",
+      "agent_skill_status": "unknown",
+      "latest_month_signal": "Last GitHub push 2026-08-19; homepage also markets team MCP/AX Score governance (verified 2026-08-19)",
+      "verified_at": "2026-08-19",
+      "verification_sources": [
+        "https://github.com/agentgram/agentgram"
       ]
     },
     {

--- a/docs/categories/agent-harnesses-and-control-planes.md
+++ b/docs/categories/agent-harnesses-and-control-planes.md
@@ -6,7 +6,7 @@ hero_image: "/assets/images/editorial-authority.webp"
 permalink: /categories/agent-harnesses-and-control-planes/
 page_kind: collection
 collection_number: "07"
-service_count: 7
+service_count: 9
 ---
 
 <p class="collection-source"><a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/README.md">Collection notes ↗</a></p>
@@ -23,7 +23,18 @@ service_count: 7
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--02">
+  <article class="service-card service-card--new atlas-sheet--service atlas-visual--02">
+    <span class="service-card__image" aria-hidden="true"></span>
+    <div class="service-card__copy">
+    <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
+    <h2 class="service-card__title">Claude HUD</h2>
+    <div class="service-card__actions">
+      <a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/claude-hud.md">Open dossier ↗</a>
+      <a href="https://github.com/jarrodwatts/claude-hud">Official repo ↗</a>
+    </div>
+    </div>
+  </article>
+  <article class="service-card atlas-sheet--service atlas-visual--03">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -34,7 +45,7 @@ service_count: 7
     </div>
     </div>
   </article>
-  <article class="service-card service-card--new atlas-sheet--service atlas-visual--03">
+  <article class="service-card service-card--new atlas-sheet--service atlas-visual--04">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
@@ -45,7 +56,7 @@ service_count: 7
     </div>
     </div>
   </article>
-  <article class="service-card service-card--new atlas-sheet--service atlas-visual--04">
+  <article class="service-card service-card--new atlas-sheet--service atlas-visual--05">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
@@ -56,7 +67,18 @@ service_count: 7
     </div>
     </div>
   </article>
-  <article class="service-card service-card--new atlas-sheet--service atlas-visual--05">
+  <article class="service-card service-card--new atlas-sheet--service atlas-visual--06">
+    <span class="service-card__image" aria-hidden="true"></span>
+    <div class="service-card__copy">
+    <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
+    <h2 class="service-card__title">LoopX</h2>
+    <div class="service-card__actions">
+      <a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/loopx.md">Open dossier ↗</a>
+      <a href="https://github.com/huangruiteng/loopx">Official repo ↗</a>
+    </div>
+    </div>
+  </article>
+  <article class="service-card service-card--new atlas-sheet--service atlas-visual--07">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
@@ -67,7 +89,7 @@ service_count: 7
     </div>
     </div>
   </article>
-  <article class="service-card service-card--new atlas-sheet--service atlas-visual--06">
+  <article class="service-card service-card--new atlas-sheet--service atlas-visual--08">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
@@ -78,7 +100,7 @@ service_count: 7
     </div>
     </div>
   </article>
-  <article class="service-card service-card--new atlas-sheet--service atlas-visual--07">
+  <article class="service-card service-card--new atlas-sheet--service atlas-visual--09">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>

--- a/docs/categories/agent-runtime-and-infrastructure.md
+++ b/docs/categories/agent-runtime-and-infrastructure.md
@@ -6,7 +6,7 @@ hero_image: "/assets/images/editorial-runtime.webp"
 permalink: /categories/agent-runtime-and-infrastructure/
 page_kind: collection
 collection_number: "06"
-service_count: 25
+service_count: 27
 ---
 
 <p class="collection-source"><a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/README.md">Collection notes ↗</a></p>
@@ -44,7 +44,18 @@ service_count: 25
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--04">
+  <article class="service-card service-card--new atlas-sheet--arrival atlas-visual--04">
+    <span class="service-card__image" aria-hidden="true"></span>
+    <div class="service-card__copy">
+    <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
+    <h2 class="service-card__title">Agent Executor (AX)</h2>
+    <div class="service-card__actions">
+      <a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/google-ax.md">Open dossier ↗</a>
+      <a href="https://github.com/google/ax">Official repo ↗</a>
+    </div>
+    </div>
+  </article>
+  <article class="service-card atlas-sheet--arrival atlas-visual--05">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -54,7 +65,7 @@ service_count: 25
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--05">
+  <article class="service-card atlas-sheet--arrival atlas-visual--06">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -65,7 +76,7 @@ service_count: 25
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--06">
+  <article class="service-card atlas-sheet--arrival atlas-visual--07">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -75,7 +86,7 @@ service_count: 25
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--07">
+  <article class="service-card atlas-sheet--arrival atlas-visual--08">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -86,7 +97,7 @@ service_count: 25
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--08">
+  <article class="service-card atlas-sheet--arrival atlas-visual--09">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -97,7 +108,7 @@ service_count: 25
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--09">
+  <article class="service-card atlas-sheet--arrival atlas-visual--10">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -108,7 +119,7 @@ service_count: 25
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--10">
+  <article class="service-card atlas-sheet--arrival atlas-visual--11">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -119,7 +130,7 @@ service_count: 25
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--11">
+  <article class="service-card atlas-sheet--arrival atlas-visual--12">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -130,7 +141,7 @@ service_count: 25
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--12">
+  <article class="service-card atlas-sheet--arrival atlas-visual--13">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -141,7 +152,18 @@ service_count: 25
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--13">
+  <article class="service-card service-card--new atlas-sheet--arrival atlas-visual--14">
+    <span class="service-card__image" aria-hidden="true"></span>
+    <div class="service-card__copy">
+    <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
+    <h2 class="service-card__title">Cloudflare Computer</h2>
+    <div class="service-card__actions">
+      <a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/cloudflare-computer.md">Open dossier ↗</a>
+      <a href="https://github.com/cloudflare/computer">Official repo ↗</a>
+    </div>
+    </div>
+  </article>
+  <article class="service-card atlas-sheet--arrival atlas-visual--15">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -152,7 +174,7 @@ service_count: 25
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--14">
+  <article class="service-card atlas-sheet--arrival atlas-visual--16">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -163,7 +185,7 @@ service_count: 25
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--15">
+  <article class="service-card atlas-sheet--service atlas-visual--01">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -174,7 +196,7 @@ service_count: 25
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--16">
+  <article class="service-card atlas-sheet--service atlas-visual--02">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -184,7 +206,7 @@ service_count: 25
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--01">
+  <article class="service-card atlas-sheet--service atlas-visual--03">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -195,7 +217,7 @@ service_count: 25
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--02">
+  <article class="service-card atlas-sheet--service atlas-visual--04">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -206,7 +228,7 @@ service_count: 25
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--03">
+  <article class="service-card atlas-sheet--service atlas-visual--05">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -217,7 +239,7 @@ service_count: 25
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--04">
+  <article class="service-card atlas-sheet--service atlas-visual--06">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -228,7 +250,7 @@ service_count: 25
     </div>
     </div>
   </article>
-  <article class="service-card service-card--new atlas-sheet--service atlas-visual--05">
+  <article class="service-card service-card--new atlas-sheet--service atlas-visual--07">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
@@ -239,7 +261,7 @@ service_count: 25
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--06">
+  <article class="service-card atlas-sheet--service atlas-visual--08">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -250,7 +272,7 @@ service_count: 25
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--07">
+  <article class="service-card atlas-sheet--service atlas-visual--09">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -261,7 +283,7 @@ service_count: 25
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--08">
+  <article class="service-card atlas-sheet--service atlas-visual--10">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -272,7 +294,7 @@ service_count: 25
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--09">
+  <article class="service-card atlas-sheet--service atlas-visual--11">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>

--- a/docs/categories/agent-social-network.md
+++ b/docs/categories/agent-social-network.md
@@ -6,7 +6,7 @@ hero_image: "/assets/images/editorial-resonance.webp"
 permalink: /categories/agent-social-network/
 page_kind: collection
 collection_number: "16"
-service_count: 6
+service_count: 7
 ---
 
 <p class="collection-source"><a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-social-network/README.md">Collection notes ↗</a></p>
@@ -23,7 +23,18 @@ service_count: 6
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--02">
+  <article class="service-card service-card--new atlas-sheet--arrival atlas-visual--02">
+    <span class="service-card__image" aria-hidden="true"></span>
+    <div class="service-card__copy">
+    <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
+    <h2 class="service-card__title">AgentGram</h2>
+    <div class="service-card__actions">
+      <a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-social-network/agentgram.md">Open dossier ↗</a>
+      <a href="https://github.com/agentgram/agentgram">Official repo ↗</a>
+    </div>
+    </div>
+  </article>
+  <article class="service-card atlas-sheet--arrival atlas-visual--03">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -34,7 +45,7 @@ service_count: 6
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--03">
+  <article class="service-card atlas-sheet--arrival atlas-visual--04">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -44,7 +55,7 @@ service_count: 6
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--04">
+  <article class="service-card atlas-sheet--arrival atlas-visual--05">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -54,7 +65,7 @@ service_count: 6
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--05">
+  <article class="service-card atlas-sheet--arrival atlas-visual--06">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -64,7 +75,7 @@ service_count: 6
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--06">
+  <article class="service-card atlas-sheet--arrival atlas-visual--07">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>

--- a/docs/categories/browser-and-web-execution.md
+++ b/docs/categories/browser-and-web-execution.md
@@ -6,7 +6,7 @@ hero_image: "/assets/images/editorial-network.webp"
 permalink: /categories/browser-and-web-execution/
 page_kind: collection
 collection_number: "02"
-service_count: 23
+service_count: 24
 ---
 
 <p class="collection-source"><a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/browser-and-web-execution/README.md">Collection notes ↗</a></p>
@@ -155,7 +155,18 @@ service_count: 23
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--14">
+  <article class="service-card service-card--new atlas-sheet--arrival atlas-visual--14">
+    <span class="service-card__image" aria-hidden="true"></span>
+    <div class="service-card__copy">
+    <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
+    <h2 class="service-card__title">Kernel</h2>
+    <div class="service-card__actions">
+      <a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/browser-and-web-execution/kernel.md">Open dossier ↗</a>
+      <a href="https://github.com/kernel/kernel-images">Official repo ↗</a>
+    </div>
+    </div>
+  </article>
+  <article class="service-card atlas-sheet--arrival atlas-visual--15">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -166,7 +177,7 @@ service_count: 23
     </div>
     </div>
   </article>
-  <article class="service-card service-card--new atlas-sheet--arrival atlas-visual--15">
+  <article class="service-card service-card--new atlas-sheet--arrival atlas-visual--16">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
@@ -177,7 +188,7 @@ service_count: 23
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--16">
+  <article class="service-card atlas-sheet--service atlas-visual--01">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -188,7 +199,7 @@ service_count: 23
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--01">
+  <article class="service-card atlas-sheet--service atlas-visual--02">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -199,7 +210,7 @@ service_count: 23
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--02">
+  <article class="service-card atlas-sheet--service atlas-visual--03">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -210,7 +221,7 @@ service_count: 23
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--03">
+  <article class="service-card atlas-sheet--service atlas-visual--04">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -221,7 +232,7 @@ service_count: 23
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--04">
+  <article class="service-card atlas-sheet--service atlas-visual--05">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -232,7 +243,7 @@ service_count: 23
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--05">
+  <article class="service-card atlas-sheet--service atlas-visual--06">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -243,7 +254,7 @@ service_count: 23
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--06">
+  <article class="service-card atlas-sheet--service atlas-visual--07">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -254,7 +265,7 @@ service_count: 23
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--07">
+  <article class="service-card atlas-sheet--service atlas-visual--08">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>

--- a/docs/categories/communication.md
+++ b/docs/categories/communication.md
@@ -6,7 +6,7 @@ hero_image: "/assets/images/editorial-network.webp"
 permalink: /categories/communication/
 page_kind: collection
 collection_number: "01"
-service_count: 13
+service_count: 15
 ---
 
 <p class="collection-source"><a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/communication/README.md">Collection notes ↗</a></p>
@@ -44,7 +44,29 @@ service_count: 13
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--04">
+  <article class="service-card service-card--new atlas-sheet--service atlas-visual--04">
+    <span class="service-card__image" aria-hidden="true"></span>
+    <div class="service-card__copy">
+    <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
+    <h2 class="service-card__title">AgentTeam Email</h2>
+    <div class="service-card__actions">
+      <a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/communication/agentteam-email.md">Open dossier ↗</a>
+      <a href="https://github.com/agentteamhq/agentteam-email">Official repo ↗</a>
+    </div>
+    </div>
+  </article>
+  <article class="service-card service-card--new atlas-sheet--service atlas-visual--05">
+    <span class="service-card__image" aria-hidden="true"></span>
+    <div class="service-card__copy">
+    <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
+    <h2 class="service-card__title">Atomic Mail</h2>
+    <div class="service-card__actions">
+      <a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/communication/atomic-mail.md">Open dossier ↗</a>
+      <a href="https://github.com/Atomic-Mail/atomic-mail-agentic">Official repo ↗</a>
+    </div>
+    </div>
+  </article>
+  <article class="service-card atlas-sheet--service atlas-visual--06">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -55,7 +77,7 @@ service_count: 13
     </div>
     </div>
   </article>
-  <article class="service-card service-card--new atlas-sheet--service atlas-visual--05">
+  <article class="service-card service-card--new atlas-sheet--service atlas-visual--07">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
@@ -66,7 +88,7 @@ service_count: 13
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--06">
+  <article class="service-card atlas-sheet--service atlas-visual--08">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -77,7 +99,7 @@ service_count: 13
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--07">
+  <article class="service-card atlas-sheet--service atlas-visual--09">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -87,7 +109,7 @@ service_count: 13
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--08">
+  <article class="service-card atlas-sheet--service atlas-visual--10">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -98,7 +120,7 @@ service_count: 13
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--09">
+  <article class="service-card atlas-sheet--service atlas-visual--11">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -109,7 +131,7 @@ service_count: 13
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--10">
+  <article class="service-card atlas-sheet--service atlas-visual--12">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -120,7 +142,7 @@ service_count: 13
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--11">
+  <article class="service-card atlas-sheet--service atlas-visual--13">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -131,7 +153,7 @@ service_count: 13
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--12">
+  <article class="service-card atlas-sheet--service atlas-visual--14">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -142,7 +164,7 @@ service_count: 13
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--13">
+  <article class="service-card atlas-sheet--service atlas-visual--15">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>

--- a/docs/categories/index.md
+++ b/docs/categories/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Agent-Native Collections"
-description: "Browse 173 agent-native services across 16 curated infrastructure collections."
+description: "Browse 188 agent-native services across 16 curated infrastructure collections."
 permalink: /categories/
 page_kind: document
 ---
@@ -11,7 +11,7 @@ page_kind: document
     <span class="collection-card__copy">
     <span class="collection-card__number">01</span>
     <span class="collection-card__title">Communication</span>
-    <span class="collection-card__count">13</span>
+    <span class="collection-card__count">15</span>
     </span>
   </a>
   <a class="collection-card atlas-visual--02" href="{{ '/categories/browser-and-web-execution/' | relative_url }}">
@@ -19,7 +19,7 @@ page_kind: document
     <span class="collection-card__copy">
     <span class="collection-card__number">02</span>
     <span class="collection-card__title">Browser &amp; Web Execution</span>
-    <span class="collection-card__count">23</span>
+    <span class="collection-card__count">24</span>
     </span>
   </a>
   <a class="collection-card atlas-visual--03" href="{{ '/categories/tool-access-and-integration/' | relative_url }}">
@@ -27,7 +27,7 @@ page_kind: document
     <span class="collection-card__copy">
     <span class="collection-card__number">03</span>
     <span class="collection-card__title">Tool Access &amp; Integration</span>
-    <span class="collection-card__count">15</span>
+    <span class="collection-card__count">16</span>
     </span>
   </a>
   <a class="collection-card atlas-visual--04" href="{{ '/categories/oversight-and-approval/' | relative_url }}">
@@ -35,7 +35,7 @@ page_kind: document
     <span class="collection-card__copy">
     <span class="collection-card__number">04</span>
     <span class="collection-card__title">Oversight &amp; Approval</span>
-    <span class="collection-card__count">4</span>
+    <span class="collection-card__count">5</span>
     </span>
   </a>
   <a class="collection-card atlas-visual--05" href="{{ '/categories/commerce-and-payments/' | relative_url }}">
@@ -51,7 +51,7 @@ page_kind: document
     <span class="collection-card__copy">
     <span class="collection-card__number">06</span>
     <span class="collection-card__title">Agent Runtime &amp; Infrastructure</span>
-    <span class="collection-card__count">25</span>
+    <span class="collection-card__count">27</span>
     </span>
   </a>
   <a class="collection-card atlas-visual--07" href="{{ '/categories/agent-harnesses-and-control-planes/' | relative_url }}">
@@ -59,7 +59,7 @@ page_kind: document
     <span class="collection-card__copy">
     <span class="collection-card__number">07</span>
     <span class="collection-card__title">Agent Harnesses &amp; Operator Surfaces</span>
-    <span class="collection-card__count">7</span>
+    <span class="collection-card__count">9</span>
     </span>
   </a>
   <a class="collection-card atlas-visual--08" href="{{ '/categories/memory-and-state/' | relative_url }}">
@@ -67,7 +67,7 @@ page_kind: document
     <span class="collection-card__copy">
     <span class="collection-card__number">08</span>
     <span class="collection-card__title">Memory &amp; State</span>
-    <span class="collection-card__count">15</span>
+    <span class="collection-card__count">17</span>
     </span>
   </a>
   <a class="collection-card atlas-visual--09" href="{{ '/categories/search-and-web-intelligence/' | relative_url }}">
@@ -75,7 +75,7 @@ page_kind: document
     <span class="collection-card__copy">
     <span class="collection-card__number">09</span>
     <span class="collection-card__title">Search &amp; Web Intelligence</span>
-    <span class="collection-card__count">8</span>
+    <span class="collection-card__count">9</span>
     </span>
   </a>
   <a class="collection-card atlas-visual--10" href="{{ '/categories/code-execution/' | relative_url }}">
@@ -107,7 +107,7 @@ page_kind: document
     <span class="collection-card__copy">
     <span class="collection-card__number">13</span>
     <span class="collection-card__title">Meeting &amp; Conversation</span>
-    <span class="collection-card__count">6</span>
+    <span class="collection-card__count">7</span>
     </span>
   </a>
   <a class="collection-card atlas-visual--14" href="{{ '/categories/voice-and-phone/' | relative_url }}">
@@ -115,7 +115,7 @@ page_kind: document
     <span class="collection-card__copy">
     <span class="collection-card__number">14</span>
     <span class="collection-card__title">Voice &amp; Phone</span>
-    <span class="collection-card__count">6</span>
+    <span class="collection-card__count">7</span>
     </span>
   </a>
   <a class="collection-card atlas-visual--15" href="{{ '/categories/llm-gateway-and-routing/' | relative_url }}">
@@ -131,7 +131,7 @@ page_kind: document
     <span class="collection-card__copy">
     <span class="collection-card__number">16</span>
     <span class="collection-card__title">Agent Social &amp; Community</span>
-    <span class="collection-card__count">6</span>
+    <span class="collection-card__count">7</span>
     </span>
   </a>
 </div>

--- a/docs/categories/meeting-and-conversation.md
+++ b/docs/categories/meeting-and-conversation.md
@@ -6,13 +6,24 @@ hero_image: "/assets/images/editorial-resonance.webp"
 permalink: /categories/meeting-and-conversation/
 page_kind: collection
 collection_number: "13"
-service_count: 6
+service_count: 7
 ---
 
 <p class="collection-source"><a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/meeting-and-conversation/README.md">Collection notes ↗</a></p>
 
 <div class="service-grid">
-  <article class="service-card atlas-sheet--service atlas-visual--01">
+  <article class="service-card service-card--new atlas-sheet--service atlas-visual--01">
+    <span class="service-card__image" aria-hidden="true"></span>
+    <div class="service-card__copy">
+    <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
+    <h2 class="service-card__title">AgentCall</h2>
+    <div class="service-card__actions">
+      <a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/meeting-and-conversation/agentcall.md">Open dossier ↗</a>
+      <a href="https://github.com/pattern-ai-labs/agentcall">Official repo ↗</a>
+    </div>
+    </div>
+  </article>
+  <article class="service-card atlas-sheet--service atlas-visual--02">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -23,7 +34,7 @@ service_count: 6
     </div>
     </div>
   </article>
-  <article class="service-card service-card--new atlas-sheet--service atlas-visual--02">
+  <article class="service-card service-card--new atlas-sheet--service atlas-visual--03">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
@@ -34,7 +45,7 @@ service_count: 6
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--03">
+  <article class="service-card atlas-sheet--service atlas-visual--04">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -45,7 +56,7 @@ service_count: 6
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--04">
+  <article class="service-card atlas-sheet--service atlas-visual--05">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -55,7 +66,7 @@ service_count: 6
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--05">
+  <article class="service-card atlas-sheet--service atlas-visual--06">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -66,7 +77,7 @@ service_count: 6
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--06">
+  <article class="service-card atlas-sheet--service atlas-visual--07">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>

--- a/docs/categories/memory-and-state.md
+++ b/docs/categories/memory-and-state.md
@@ -6,13 +6,24 @@ hero_image: "/assets/images/editorial-memory.webp"
 permalink: /categories/memory-and-state/
 page_kind: collection
 collection_number: "08"
-service_count: 15
+service_count: 17
 ---
 
 <p class="collection-source"><a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/README.md">Collection notes ↗</a></p>
 
 <div class="service-grid">
-  <article class="service-card atlas-sheet--arrival atlas-visual--01">
+  <article class="service-card service-card--new atlas-sheet--arrival atlas-visual--01">
+    <span class="service-card__image" aria-hidden="true"></span>
+    <div class="service-card__copy">
+    <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
+    <h2 class="service-card__title">agentmemory</h2>
+    <div class="service-card__actions">
+      <a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/agentmemory.md">Open dossier ↗</a>
+      <a href="https://github.com/rohitg00/agentmemory">Official repo ↗</a>
+    </div>
+    </div>
+  </article>
+  <article class="service-card atlas-sheet--arrival atlas-visual--02">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -23,7 +34,7 @@ service_count: 15
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--02">
+  <article class="service-card atlas-sheet--arrival atlas-visual--03">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -34,7 +45,7 @@ service_count: 15
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--03">
+  <article class="service-card atlas-sheet--arrival atlas-visual--04">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -45,7 +56,7 @@ service_count: 15
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--04">
+  <article class="service-card atlas-sheet--arrival atlas-visual--05">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -56,7 +67,7 @@ service_count: 15
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--05">
+  <article class="service-card atlas-sheet--arrival atlas-visual--06">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -67,7 +78,7 @@ service_count: 15
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--06">
+  <article class="service-card atlas-sheet--arrival atlas-visual--07">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -78,7 +89,7 @@ service_count: 15
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--07">
+  <article class="service-card atlas-sheet--arrival atlas-visual--08">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -89,7 +100,7 @@ service_count: 15
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--08">
+  <article class="service-card atlas-sheet--arrival atlas-visual--09">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -100,7 +111,7 @@ service_count: 15
     </div>
     </div>
   </article>
-  <article class="service-card service-card--new atlas-sheet--arrival atlas-visual--09">
+  <article class="service-card service-card--new atlas-sheet--arrival atlas-visual--10">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
@@ -111,7 +122,7 @@ service_count: 15
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--10">
+  <article class="service-card atlas-sheet--arrival atlas-visual--11">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -122,7 +133,7 @@ service_count: 15
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--11">
+  <article class="service-card atlas-sheet--arrival atlas-visual--12">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -133,7 +144,7 @@ service_count: 15
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--12">
+  <article class="service-card atlas-sheet--arrival atlas-visual--13">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -144,7 +155,7 @@ service_count: 15
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--13">
+  <article class="service-card atlas-sheet--arrival atlas-visual--14">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -155,7 +166,7 @@ service_count: 15
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--14">
+  <article class="service-card atlas-sheet--arrival atlas-visual--15">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -166,7 +177,18 @@ service_count: 15
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--15">
+  <article class="service-card service-card--new atlas-sheet--arrival atlas-visual--16">
+    <span class="service-card__image" aria-hidden="true"></span>
+    <div class="service-card__copy">
+    <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
+    <h2 class="service-card__title">TencentDB Agent Memory</h2>
+    <div class="service-card__actions">
+      <a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/tencentdb-agent-memory.md">Open dossier ↗</a>
+      <a href="https://github.com/TencentCloud/TencentDB-Agent-Memory">Official repo ↗</a>
+    </div>
+    </div>
+  </article>
+  <article class="service-card atlas-sheet--service atlas-visual--01">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>

--- a/docs/categories/oversight-and-approval.md
+++ b/docs/categories/oversight-and-approval.md
@@ -6,7 +6,7 @@ hero_image: "/assets/images/editorial-authority.webp"
 permalink: /categories/oversight-and-approval/
 page_kind: collection
 collection_number: "04"
-service_count: 4
+service_count: 5
 ---
 
 <p class="collection-source"><a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/oversight-and-approval/README.md">Collection notes ↗</a></p>
@@ -38,6 +38,17 @@ service_count: 4
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
+    <h2 class="service-card__title">Preloop</h2>
+    <div class="service-card__actions">
+      <a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/oversight-and-approval/preloop.md">Open dossier ↗</a>
+      <a href="https://github.com/preloop/preloop">Official repo ↗</a>
+    </div>
+    </div>
+  </article>
+  <article class="service-card service-card--new atlas-sheet--arrival atlas-visual--04">
+    <span class="service-card__image" aria-hidden="true"></span>
+    <div class="service-card__copy">
+    <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
     <h2 class="service-card__title">Sallyport</h2>
     <div class="service-card__actions">
       <a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/oversight-and-approval/sallyport.md">Open dossier ↗</a>
@@ -45,7 +56,7 @@ service_count: 4
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--04">
+  <article class="service-card atlas-sheet--arrival atlas-visual--05">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>

--- a/docs/categories/search-and-web-intelligence.md
+++ b/docs/categories/search-and-web-intelligence.md
@@ -6,13 +6,24 @@ hero_image: "/assets/images/editorial-memory.webp"
 permalink: /categories/search-and-web-intelligence/
 page_kind: collection
 collection_number: "09"
-service_count: 8
+service_count: 9
 ---
 
 <p class="collection-source"><a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/search-and-web-intelligence/README.md">Collection notes ↗</a></p>
 
 <div class="service-grid">
   <article class="service-card service-card--new atlas-sheet--service atlas-visual--01">
+    <span class="service-card__image" aria-hidden="true"></span>
+    <div class="service-card__copy">
+    <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
+    <h2 class="service-card__title">Agent Search MCP</h2>
+    <div class="service-card__actions">
+      <a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/search-and-web-intelligence/agent-search-mcp.md">Open dossier ↗</a>
+      <a href="https://github.com/lennney/agent-search-mcp">Official repo ↗</a>
+    </div>
+    </div>
+  </article>
+  <article class="service-card service-card--new atlas-sheet--service atlas-visual--02">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
@@ -23,7 +34,7 @@ service_count: 8
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--02">
+  <article class="service-card atlas-sheet--service atlas-visual--03">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -34,7 +45,7 @@ service_count: 8
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--03">
+  <article class="service-card atlas-sheet--service atlas-visual--04">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -45,7 +56,7 @@ service_count: 8
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--04">
+  <article class="service-card atlas-sheet--service atlas-visual--05">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -56,7 +67,7 @@ service_count: 8
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--05">
+  <article class="service-card atlas-sheet--service atlas-visual--06">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -67,7 +78,7 @@ service_count: 8
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--06">
+  <article class="service-card atlas-sheet--service atlas-visual--07">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -77,7 +88,7 @@ service_count: 8
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--07">
+  <article class="service-card atlas-sheet--service atlas-visual--08">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -88,7 +99,7 @@ service_count: 8
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--08">
+  <article class="service-card atlas-sheet--service atlas-visual--09">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>

--- a/docs/categories/tool-access-and-integration.md
+++ b/docs/categories/tool-access-and-integration.md
@@ -6,7 +6,7 @@ hero_image: "/assets/images/editorial-network.webp"
 permalink: /categories/tool-access-and-integration/
 page_kind: collection
 collection_number: "03"
-service_count: 15
+service_count: 16
 ---
 
 <p class="collection-source"><a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/README.md">Collection notes ↗</a></p>
@@ -173,6 +173,17 @@ service_count: 15
     <div class="service-card__actions">
       <a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/toolhouse.md">Open dossier ↗</a>
       <a href="https://github.com/toolhouseai/toolhouse-sdk-python">Official repo ↗</a>
+    </div>
+    </div>
+  </article>
+  <article class="service-card service-card--new atlas-sheet--service atlas-visual--16">
+    <span class="service-card__image" aria-hidden="true"></span>
+    <div class="service-card__copy">
+    <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
+    <h2 class="service-card__title">Toolport</h2>
+    <div class="service-card__actions">
+      <a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/toolport.md">Open dossier ↗</a>
+      <a href="https://github.com/tsouth89/toolport">Official repo ↗</a>
     </div>
     </div>
   </article>

--- a/docs/categories/voice-and-phone.md
+++ b/docs/categories/voice-and-phone.md
@@ -6,7 +6,7 @@ hero_image: "/assets/images/editorial-resonance.webp"
 permalink: /categories/voice-and-phone/
 page_kind: collection
 collection_number: "14"
-service_count: 6
+service_count: 7
 ---
 
 <p class="collection-source"><a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/voice-and-phone/README.md">Collection notes ↗</a></p>
@@ -23,7 +23,18 @@ service_count: 6
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--02">
+  <article class="service-card service-card--new atlas-sheet--arrival atlas-visual--02">
+    <span class="service-card__image" aria-hidden="true"></span>
+    <div class="service-card__copy">
+    <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
+    <h2 class="service-card__title">Patter</h2>
+    <div class="service-card__actions">
+      <a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/voice-and-phone/patter.md">Open dossier ↗</a>
+      <a href="https://github.com/PatterAI/Patter">Official repo ↗</a>
+    </div>
+    </div>
+  </article>
+  <article class="service-card atlas-sheet--arrival atlas-visual--03">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -34,7 +45,7 @@ service_count: 6
     </div>
     </div>
   </article>
-  <article class="service-card service-card--new atlas-sheet--arrival atlas-visual--03">
+  <article class="service-card service-card--new atlas-sheet--arrival atlas-visual--04">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
@@ -45,7 +56,7 @@ service_count: 6
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--04">
+  <article class="service-card atlas-sheet--arrival atlas-visual--05">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -56,7 +67,7 @@ service_count: 6
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--05">
+  <article class="service-card atlas-sheet--arrival atlas-visual--06">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -67,7 +78,7 @@ service_count: 6
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--06">
+  <article class="service-card atlas-sheet--arrival atlas-visual--07">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,9 +3,9 @@ title: "The Agent-Native Index"
 description: "A curated 2026 collection of agent-native infrastructure: MCP tools, harnesses, identity, memory, sandboxes, browsers, payments, and runtimes."
 image: /assets/images/social-preview.png
 page_kind: home
-service_count: 173
+service_count: 188
 collection_count: 16
-new_arrivals_count: 21
+new_arrivals_count: 36
 ---
 
 <section id="new-arrivals" aria-labelledby="new-arrivals-title">
@@ -55,7 +55,15 @@ new_arrivals_count: 21
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--06" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/browser-and-web-execution/moli.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--06" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/browser-and-web-execution/kernel.md">
+      <span class="arrival-card__image" aria-hidden="true"></span>
+      <span class="arrival-card__copy">
+        <span class="arrival-card__category">Browser &amp; Web Execution</span>
+        <strong class="arrival-card__name">Kernel</strong>
+        <span class="arrival-card__arrow" aria-hidden="true">↗</span>
+      </span>
+    </a>
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--07" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/browser-and-web-execution/moli.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Browser &amp; Web Execution</span>
@@ -63,7 +71,7 @@ new_arrivals_count: 21
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--07" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/commerce-and-payments/secondsign-core.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--08" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/commerce-and-payments/secondsign-core.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Commerce &amp; Payments</span>
@@ -71,7 +79,7 @@ new_arrivals_count: 21
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--08" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/communication/caspian.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--09" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/communication/caspian.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Communication</span>
@@ -79,7 +87,7 @@ new_arrivals_count: 21
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--09" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/openchatcut.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--10" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/openchatcut.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Tool Access &amp; Integration</span>
@@ -87,7 +95,7 @@ new_arrivals_count: 21
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--10" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/oversight-and-approval/sallyport.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--11" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/oversight-and-approval/sallyport.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Oversight &amp; Approval</span>
@@ -95,7 +103,119 @@ new_arrivals_count: 21
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--11" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/longhorizon-harness.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--12" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-social-network/agentgram.md">
+      <span class="arrival-card__image" aria-hidden="true"></span>
+      <span class="arrival-card__copy">
+        <span class="arrival-card__category">Agent Social &amp; Community</span>
+        <strong class="arrival-card__name">AgentGram</strong>
+        <span class="arrival-card__arrow" aria-hidden="true">↗</span>
+      </span>
+    </a>
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--13" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/toolport.md">
+      <span class="arrival-card__image" aria-hidden="true"></span>
+      <span class="arrival-card__copy">
+        <span class="arrival-card__category">Tool Access &amp; Integration</span>
+        <strong class="arrival-card__name">Toolport</strong>
+        <span class="arrival-card__arrow" aria-hidden="true">↗</span>
+      </span>
+    </a>
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--14" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/loopx.md">
+      <span class="arrival-card__image" aria-hidden="true"></span>
+      <span class="arrival-card__copy">
+        <span class="arrival-card__category">Agent Harnesses &amp; Operator Surfaces</span>
+        <strong class="arrival-card__name">LoopX</strong>
+        <span class="arrival-card__arrow" aria-hidden="true">↗</span>
+      </span>
+    </a>
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--15" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/cloudflare-computer.md">
+      <span class="arrival-card__image" aria-hidden="true"></span>
+      <span class="arrival-card__copy">
+        <span class="arrival-card__category">Agent Runtime &amp; Infrastructure</span>
+        <strong class="arrival-card__name">Cloudflare Computer</strong>
+        <span class="arrival-card__arrow" aria-hidden="true">↗</span>
+      </span>
+    </a>
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--16" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/oversight-and-approval/preloop.md">
+      <span class="arrival-card__image" aria-hidden="true"></span>
+      <span class="arrival-card__copy">
+        <span class="arrival-card__category">Oversight &amp; Approval</span>
+        <strong class="arrival-card__name">Preloop</strong>
+        <span class="arrival-card__arrow" aria-hidden="true">↗</span>
+      </span>
+    </a>
+    <a class="arrival-card atlas-sheet--service atlas-visual--01" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/claude-hud.md">
+      <span class="arrival-card__image" aria-hidden="true"></span>
+      <span class="arrival-card__copy">
+        <span class="arrival-card__category">Agent Harnesses &amp; Operator Surfaces</span>
+        <strong class="arrival-card__name">Claude HUD</strong>
+        <span class="arrival-card__arrow" aria-hidden="true">↗</span>
+      </span>
+    </a>
+    <a class="arrival-card atlas-sheet--service atlas-visual--02" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/search-and-web-intelligence/agent-search-mcp.md">
+      <span class="arrival-card__image" aria-hidden="true"></span>
+      <span class="arrival-card__copy">
+        <span class="arrival-card__category">Search &amp; Web Intelligence</span>
+        <strong class="arrival-card__name">Agent Search MCP</strong>
+        <span class="arrival-card__arrow" aria-hidden="true">↗</span>
+      </span>
+    </a>
+    <a class="arrival-card atlas-sheet--service atlas-visual--03" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/agentmemory.md">
+      <span class="arrival-card__image" aria-hidden="true"></span>
+      <span class="arrival-card__copy">
+        <span class="arrival-card__category">Memory &amp; State</span>
+        <strong class="arrival-card__name">agentmemory</strong>
+        <span class="arrival-card__arrow" aria-hidden="true">↗</span>
+      </span>
+    </a>
+    <a class="arrival-card atlas-sheet--service atlas-visual--04" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/google-ax.md">
+      <span class="arrival-card__image" aria-hidden="true"></span>
+      <span class="arrival-card__copy">
+        <span class="arrival-card__category">Agent Runtime &amp; Infrastructure</span>
+        <strong class="arrival-card__name">Agent Executor (AX)</strong>
+        <span class="arrival-card__arrow" aria-hidden="true">↗</span>
+      </span>
+    </a>
+    <a class="arrival-card atlas-sheet--service atlas-visual--05" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/voice-and-phone/patter.md">
+      <span class="arrival-card__image" aria-hidden="true"></span>
+      <span class="arrival-card__copy">
+        <span class="arrival-card__category">Voice &amp; Phone</span>
+        <strong class="arrival-card__name">Patter</strong>
+        <span class="arrival-card__arrow" aria-hidden="true">↗</span>
+      </span>
+    </a>
+    <a class="arrival-card atlas-sheet--service atlas-visual--06" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/communication/atomic-mail.md">
+      <span class="arrival-card__image" aria-hidden="true"></span>
+      <span class="arrival-card__copy">
+        <span class="arrival-card__category">Communication</span>
+        <strong class="arrival-card__name">Atomic Mail</strong>
+        <span class="arrival-card__arrow" aria-hidden="true">↗</span>
+      </span>
+    </a>
+    <a class="arrival-card atlas-sheet--service atlas-visual--07" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/meeting-and-conversation/agentcall.md">
+      <span class="arrival-card__image" aria-hidden="true"></span>
+      <span class="arrival-card__copy">
+        <span class="arrival-card__category">Meeting &amp; Conversation</span>
+        <strong class="arrival-card__name">AgentCall</strong>
+        <span class="arrival-card__arrow" aria-hidden="true">↗</span>
+      </span>
+    </a>
+    <a class="arrival-card atlas-sheet--service atlas-visual--08" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/communication/agentteam-email.md">
+      <span class="arrival-card__image" aria-hidden="true"></span>
+      <span class="arrival-card__copy">
+        <span class="arrival-card__category">Communication</span>
+        <strong class="arrival-card__name">AgentTeam Email</strong>
+        <span class="arrival-card__arrow" aria-hidden="true">↗</span>
+      </span>
+    </a>
+    <a class="arrival-card atlas-sheet--service atlas-visual--09" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/tencentdb-agent-memory.md">
+      <span class="arrival-card__image" aria-hidden="true"></span>
+      <span class="arrival-card__copy">
+        <span class="arrival-card__category">Memory &amp; State</span>
+        <strong class="arrival-card__name">TencentDB Agent Memory</strong>
+        <span class="arrival-card__arrow" aria-hidden="true">↗</span>
+      </span>
+    </a>
+    <a class="arrival-card atlas-sheet--service atlas-visual--10" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/longhorizon-harness.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Agent Harnesses &amp; Operator Surfaces</span>
@@ -103,7 +223,7 @@ new_arrivals_count: 21
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--12" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/search-and-web-intelligence/contextx.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--11" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/search-and-web-intelligence/contextx.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Search &amp; Web Intelligence</span>
@@ -111,7 +231,7 @@ new_arrivals_count: 21
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--13" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/qm.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--12" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/qm.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Agent Harnesses &amp; Operator Surfaces</span>
@@ -119,7 +239,7 @@ new_arrivals_count: 21
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--14" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/axern.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--13" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/axern.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Code Execution</span>
@@ -127,7 +247,7 @@ new_arrivals_count: 21
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--15" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-social-network/agent-chamber.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--14" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-social-network/agent-chamber.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Agent Social &amp; Community</span>
@@ -135,7 +255,7 @@ new_arrivals_count: 21
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--16" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/voice-and-phone/qwen-audio-agent.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--15" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/voice-and-phone/qwen-audio-agent.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Voice &amp; Phone</span>
@@ -143,7 +263,7 @@ new_arrivals_count: 21
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--01" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/llm-gateway-and-routing/sageroute.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--16" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/llm-gateway-and-routing/sageroute.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">LLM Gateway &amp; Routing</span>
@@ -151,7 +271,7 @@ new_arrivals_count: 21
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--02" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/observability-and-tracing/numbat.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--01" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/observability-and-tracing/numbat.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Observability &amp; Tracing</span>
@@ -159,7 +279,7 @@ new_arrivals_count: 21
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--03" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/memmy-agent.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--02" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/memmy-agent.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Memory &amp; State</span>
@@ -167,7 +287,7 @@ new_arrivals_count: 21
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--04" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/meeting-and-conversation/looped-meet.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--03" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/meeting-and-conversation/looped-meet.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Meeting &amp; Conversation</span>
@@ -175,7 +295,7 @@ new_arrivals_count: 21
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--05" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/durable-execution-and-scheduling/pi-dispatch.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--04" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/durable-execution-and-scheduling/pi-dispatch.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Durable Execution &amp; Scheduling</span>
@@ -199,7 +319,7 @@ new_arrivals_count: 21
   <div class="section-intro">
     <span class="section-number">02</span>
     <h2 class="section-title" id="collections-title">The collections</h2>
-    <p class="section-note">16 fields · 173 dossiers</p>
+    <p class="section-note">16 fields · 188 dossiers</p>
   </div>
   <div class="collection-grid">
     <a class="collection-card atlas-visual--01" href="{{ '/categories/communication/' | relative_url }}">
@@ -207,7 +327,7 @@ new_arrivals_count: 21
       <span class="collection-card__copy">
       <span class="collection-card__number">01</span>
       <span class="collection-card__title">Communication</span>
-      <span class="collection-card__count">13</span>
+      <span class="collection-card__count">15</span>
       </span>
     </a>
     <a class="collection-card atlas-visual--02" href="{{ '/categories/browser-and-web-execution/' | relative_url }}">
@@ -215,7 +335,7 @@ new_arrivals_count: 21
       <span class="collection-card__copy">
       <span class="collection-card__number">02</span>
       <span class="collection-card__title">Browser &amp; Web Execution</span>
-      <span class="collection-card__count">23</span>
+      <span class="collection-card__count">24</span>
       </span>
     </a>
     <a class="collection-card atlas-visual--03" href="{{ '/categories/tool-access-and-integration/' | relative_url }}">
@@ -223,7 +343,7 @@ new_arrivals_count: 21
       <span class="collection-card__copy">
       <span class="collection-card__number">03</span>
       <span class="collection-card__title">Tool Access &amp; Integration</span>
-      <span class="collection-card__count">15</span>
+      <span class="collection-card__count">16</span>
       </span>
     </a>
     <a class="collection-card atlas-visual--04" href="{{ '/categories/oversight-and-approval/' | relative_url }}">
@@ -231,7 +351,7 @@ new_arrivals_count: 21
       <span class="collection-card__copy">
       <span class="collection-card__number">04</span>
       <span class="collection-card__title">Oversight &amp; Approval</span>
-      <span class="collection-card__count">4</span>
+      <span class="collection-card__count">5</span>
       </span>
     </a>
     <a class="collection-card atlas-visual--05" href="{{ '/categories/commerce-and-payments/' | relative_url }}">
@@ -247,7 +367,7 @@ new_arrivals_count: 21
       <span class="collection-card__copy">
       <span class="collection-card__number">06</span>
       <span class="collection-card__title">Agent Runtime &amp; Infrastructure</span>
-      <span class="collection-card__count">25</span>
+      <span class="collection-card__count">27</span>
       </span>
     </a>
     <a class="collection-card atlas-visual--07" href="{{ '/categories/agent-harnesses-and-control-planes/' | relative_url }}">
@@ -255,7 +375,7 @@ new_arrivals_count: 21
       <span class="collection-card__copy">
       <span class="collection-card__number">07</span>
       <span class="collection-card__title">Agent Harnesses &amp; Operator Surfaces</span>
-      <span class="collection-card__count">7</span>
+      <span class="collection-card__count">9</span>
       </span>
     </a>
     <a class="collection-card atlas-visual--08" href="{{ '/categories/memory-and-state/' | relative_url }}">
@@ -263,7 +383,7 @@ new_arrivals_count: 21
       <span class="collection-card__copy">
       <span class="collection-card__number">08</span>
       <span class="collection-card__title">Memory &amp; State</span>
-      <span class="collection-card__count">15</span>
+      <span class="collection-card__count">17</span>
       </span>
     </a>
     <a class="collection-card atlas-visual--09" href="{{ '/categories/search-and-web-intelligence/' | relative_url }}">
@@ -271,7 +391,7 @@ new_arrivals_count: 21
       <span class="collection-card__copy">
       <span class="collection-card__number">09</span>
       <span class="collection-card__title">Search &amp; Web Intelligence</span>
-      <span class="collection-card__count">8</span>
+      <span class="collection-card__count">9</span>
       </span>
     </a>
     <a class="collection-card atlas-visual--10" href="{{ '/categories/code-execution/' | relative_url }}">
@@ -303,7 +423,7 @@ new_arrivals_count: 21
       <span class="collection-card__copy">
       <span class="collection-card__number">13</span>
       <span class="collection-card__title">Meeting &amp; Conversation</span>
-      <span class="collection-card__count">6</span>
+      <span class="collection-card__count">7</span>
       </span>
     </a>
     <a class="collection-card atlas-visual--14" href="{{ '/categories/voice-and-phone/' | relative_url }}">
@@ -311,7 +431,7 @@ new_arrivals_count: 21
       <span class="collection-card__copy">
       <span class="collection-card__number">14</span>
       <span class="collection-card__title">Voice &amp; Phone</span>
-      <span class="collection-card__count">6</span>
+      <span class="collection-card__count">7</span>
       </span>
     </a>
     <a class="collection-card atlas-visual--15" href="{{ '/categories/llm-gateway-and-routing/' | relative_url }}">
@@ -327,7 +447,7 @@ new_arrivals_count: 21
       <span class="collection-card__copy">
       <span class="collection-card__number">16</span>
       <span class="collection-card__title">Agent Social &amp; Community</span>
-      <span class="collection-card__count">6</span>
+      <span class="collection-card__count">7</span>
       </span>
     </a>
   </div>
@@ -350,6 +470,6 @@ new_arrivals_count: 21
   <div>
   <span class="section-number">03</span>
   <h2 class="section-title">Full source.</h2>
-  <a class="source-gateway__link" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/README.md">Open 173 dossiers ↗</a>
+  <a class="source-gateway__link" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/README.md">Open 188 dossiers ↗</a>
   </div>
 </section>

--- a/docs/skill.md
+++ b/docs/skill.md
@@ -54,12 +54,14 @@ These services can be joined with a single instruction, right now, with no human
 | **mails.dev** | Email for agents: @mails.dev mailbox, send/inbox, wait-for-code | `Read https://mails.dev/skill.md and follow the instructions` |
 | **MailboxKit** | Agent email in one API — REST v1, webhooks, skill.md | `Read https://mailboxkit.com/skill.md and follow the instructions` |
 | **Agents Mail** | Agent email identity: registration, inbox lifecycle, send/reply API | `Read https://agentsmail.org/skill.md and follow the instructions` |
+| **Atomic Mail** | Agent-owned `@atomicmail.ai` inbox over JMAP | `Read https://atomicmail.ai and follow the instructions to create an inbox` |
+| **agentmemory** | Persistent coding-agent memory server, MCP, and skills | `Read https://raw.githubusercontent.com/rohitg00/agentmemory/main/INSTALL_FOR_AGENTS.md and follow the instructions` |
 
 ---
 
-## Full Catalog — 16 Categories, 173 Services
+## Full Catalog — 16 Categories, 188 Services
 
-### 1. Communication (13 services)
+### 1. Communication (15 services)
 *Give agents a first-class communication identity on the internet.*
 
 | Service | Tagline | Onboarding |
@@ -77,10 +79,12 @@ These services can be joined with a single instruction, right now, with no human
 | [MCP Agent Mail (Rust)](https://github.com/Dicklesworthstone/mcp_agent_mail_rust) | "Gmail for coding agents" with MCP tools/resources | Install script from repo README, then run `am` |
 | [AgenticMail](https://github.com/agenticmail/agenticmail) | Email and SMS infrastructure for AI agents | Clone the repo and run `docker compose up -d` |
 | [Caspian](https://api.trycaspianai.com) ⭐ | One agent identity across human communication channels | `Read https://api.trycaspianai.com/SKILL.md and follow it end to end` |
+| [Atomic Mail](https://atomicmail.ai) ⭐ | Not AI for your email. Email for your AI. | `Read https://atomicmail.ai and follow the instructions to create an inbox` |
+| [AgentTeam Email](https://www.agentteam.email) | Open-source email infrastructure for AI agents | `npx --yes @agentteamhq/email@latest` then `at-email agent connect` |
 
 ---
 
-### 2. Browser & Web Execution (23 services)
+### 2. Browser & Web Execution (24 services)
 *Remote browser and web data extraction for agents.*
 
 | Service | Tagline | Onboarding |
@@ -108,10 +112,11 @@ These services can be joined with a single instruction, right now, with no human
 | [Vessel Browser](https://github.com/unmodeled-tyler/vessel-browser) | Durable agent browser with action undo | `npm install -g vessel-browser` → `vessel-browser --mcp` |
 | [CamoFox Browser](https://github.com/jo-inc/camofox-browser) | Stealth headless browser for AI agents | `npm install -g camofox-browser` then start the browser server |
 | [Moli](https://github.com/lexmount/moli) | Structured-first browser engine for AI agents | Build the Rust workspace, then run `moli fetch`, `moli serve`, or `moli mcp` |
+| [Kernel](https://www.kernel.sh) | you build agents. we give them the internet. | `brew install kernel/tap/kernel` or `npm install -g @onkernel/cli`, then `kernel browsers create -o json` |
 
 ---
 
-### 3. Tool Access & Integration (15 services)
+### 3. Tool Access & Integration (16 services)
 *Runtime tool discovery, auth, and execution without human pre-configuration.*
 
 | Service | Tagline | Onboarding |
@@ -131,10 +136,11 @@ These services can be joined with a single instruction, right now, with no human
 | [Obot](https://github.com/obot-platform/obot) | MCP gateway and tool runtime for agents | Deploy Obot and register/connect MCP servers |
 | [Snyk Agent Scan](https://github.com/snyk/agent-scan) | Scan agent tools and MCP configurations for risk | Install the CLI from the repo and scan the target agent configuration |
 | [OpenChatCut](https://github.com/0xsline/OpenChatCut) | Local-first agent-native video editor | `npx skills add 0xsline/OpenChatCut`, then ask the agent to set it up |
+| [Toolport](https://toolport.app) | Every tool. One port. | Install from GitHub Releases, add servers, connect each AI client to `toolport-gateway` |
 
 ---
 
-### 4. Oversight & Approval (4 services)
+### 4. Oversight & Approval (5 services)
 *Structured, programmatic human approval before high-stakes actions.*
 
 | Service | Tagline | Onboarding |
@@ -143,6 +149,7 @@ These services can be joined with a single instruction, right now, with no human
 | [Sondera Coding Agent Hooks](https://github.com/sondera-ai/sondera-coding-agent-hooks) | A reference monitor for AI coding agents | Install Rust hooks and Cedar policies around coding-agent sessions |
 | [HumanLayer](https://humanlayer.dev) | Human in the Loop for AI Agents | `pip install humanlayer` → `@hl.require_approval()` |
 | [Sallyport](https://github.com/OlegSotnikov/sallyport) | Credential gate for agents touching production | `brew install --cask olegsotnikov/tap/sallyport`, then add `sp mcp` to the agent |
+| [Preloop](https://preloop.ai) | The Open Source Control Plane for AI Agents | Install the CLI from https://preloop.ai then `preloop signup` and `preloop agents discover` |
 
 ---
 
@@ -163,7 +170,7 @@ These services can be joined with a single instruction, right now, with no human
 
 ---
 
-### 6. Agent Runtime & Infrastructure (25 services)
+### 6. Agent Runtime & Infrastructure (27 services)
 *Secure execution, session isolation, secrets, identity, and gateway for production agents.*
 
 | Service | Tagline | Onboarding |
@@ -193,10 +200,12 @@ These services can be joined with a single instruction, right now, with no human
 | [Modal](https://modal.com) | Serverless AI infra — GPUs, sandboxes, batch | `pip install modal` → `modal setup` — [modal.com/docs](https://modal.com/docs) |
 | [Cyberdesk](https://github.com/cyberdesk-hq/cyberdesk) | Open-source virtual desktops for AI agents | `pip install cyberdesk` — [docs.cyberdesk.io](https://docs.cyberdesk.io) |
 | [Polos](https://github.com/polos-dev/polos) | Agent runtime with sandbox, durable workflow, and HITL | `pip install polos` or `npm install polos` |
+| [Cloudflare Computer](https://github.com/cloudflare/computer) | Give your agent a computer | `npm install @cloudflare/computer` then attach `withWorkspace` to a Durable Object (preview only) |
+| [Agent Executor (AX)](https://github.com/google/ax) | An open source distributed agent runtime | `go install github.com/google/ax/cmd/ax@latest` then `ax --input "…"` |
 
 ---
 
-### 7. Agent Harnesses & Operator Surfaces (7 services)
+### 7. Agent Harnesses & Operator Surfaces (9 services)
 *Durable agent-loop control, multi-agent orchestration, and live operator surfaces tied to concrete sessions.*
 
 | Service | Tagline | Onboarding |
@@ -208,10 +217,12 @@ These services can be joined with a single instruction, right now, with no human
 | [Agent QA](https://vostride.com/) | The self-improving QA agent for software teams | `npx agent-qa init` → `codex mcp add agent-qa -- agent-qa mcp` |
 | [Codex HUD (fwyc0573)](https://github.com/fwyc0573/codex-hud) | Real-time statusline and multi-session HUD for Codex CLI | Clone the repo → `./bin/codex-hud-install` → launch `codex` |
 | [Codex HUD (anhannin)](https://github.com/anhannin/codex-hud) | Patched Codex status line for usage and session state | Review the patch/install script, then run `Codex-HUD/install.sh` and start a new session |
+| [Claude HUD](https://github.com/jarrodwatts/claude-hud) | A Claude Code plugin that shows what's happening | `/plugin marketplace add jarrodwatts/claude-hud` then `/plugin install claude-hud` and `/claude-hud:setup` |
+| [LoopX](https://huangruiteng.github.io/loopx/) | Stateful control plane for long-horizon agents | `python3 -m pip install --upgrade loopx` then `loopx workflow-skills --install` and `loopx connect` |
 
 ---
 
-### 8. Memory & State (15 services)
+### 8. Memory & State (17 services)
 *Persistent, queryable memory across sessions — memory as infrastructure, not application logic.*
 
 | Service | Tagline | Onboarding |
@@ -231,10 +242,12 @@ These services can be joined with a single instruction, right now, with no human
 | [MemMachine](https://github.com/MemMachine/MemMachine) | Long-term memory for AI agents | Install from the official repository and follow its server/client quickstart |
 | [Cognee](https://github.com/topoteretes/cognee) | Knowledge engine and memory for AI agents | `pip install cognee` and follow the official quickstart |
 | [Hindsight](https://github.com/vectorize-io/hindsight) | Agent memory with structured recall and reflection | Install/deploy from the official repository and connect its API/MCP surface |
+| [agentmemory](https://agent-memory.dev) ⭐ | Your coding agent remembers everything | `Read https://raw.githubusercontent.com/rohitg00/agentmemory/main/INSTALL_FOR_AGENTS.md and follow the instructions` |
+| [TencentDB Agent Memory](https://github.com/TencentCloud/TencentDB-Agent-Memory) | Agents remember,Humans innovate. | `openclaw plugins install @tencentdb-agent-memory/memory-tencentdb` |
 
 ---
 
-### 9. Search & Web Intelligence (8 services)
+### 9. Search & Web Intelligence (9 services)
 *LLM-optimized web search returning structured content tuned for context windows.*
 
 | Service | Tagline | Onboarding |
@@ -247,6 +260,7 @@ These services can be joined with a single instruction, right now, with no human
 | [Jina Reader](https://jina.ai/reader) | `r.jina.ai` / `s.jina.ai` — LLM-friendly URL & search | `curl "https://r.jina.ai/https://example.com"` — MCP: `mcp.jina.ai` |
 | [Linkup](https://www.linkup.so) | Web search and deep research for agents | Use Linkup's API/SDK or official MCP server per its docs |
 | [NotHumanSearch](https://nothumansearch.ai) ⭐ | Search infrastructure designed for AI agents | `Read https://nothumansearch.ai/llms.txt and follow the instructions` |
+| [Agent Search MCP](https://github.com/lennney/agent-search-mcp) | Free-first web search with inspectable evidence | `npx -y agent-search-mcp` — optional `npx skills add lennney/agent-search-mcp --skill agent-search` |
 
 ---
 
@@ -302,7 +316,7 @@ These services can be joined with a single instruction, right now, with no human
 
 ---
 
-### 13. Meeting & Conversation (6 services)
+### 13. Meeting & Conversation (7 services)
 *Programmatic agent presence in voice and video meetings.*
 
 | Service | Tagline | Onboarding |
@@ -313,10 +327,11 @@ These services can be joined with a single instruction, right now, with no human
 | [Vexa](https://vexa.ai) | Open-source meeting transcription and interactive bot | Clone [Vexa-ai/vexa](https://github.com/Vexa-ai/vexa) → `docker compose up -d` |
 | [Daily Agent Toolkit](https://github.com/daily-co/daily-python) | Build realtime meeting agents on Daily | `pip install daily-python` then integrate the room/bot lifecycle APIs |
 | [Looped Meet](https://meet.looped.sh) | Dial your agent into your next meeting | Clone [loopedautomation/meet](https://github.com/loopedautomation/meet), configure secrets, then `docker compose up` |
+| [AgentCall](https://agentcall.dev) | Your AI agent, in every meeting. | `/plugin marketplace add pattern-ai-labs/agentcall` then `/plugin install join-meeting@agentcall` |
 
 ---
 
-### 14. Voice & Phone (6 services)
+### 14. Voice & Phone (7 services)
 *Agent-controlled voice calls and telephony infrastructure.*
 
 | Service | Tagline | Onboarding |
@@ -327,6 +342,7 @@ These services can be joined with a single instruction, right now, with no human
 | [Stimm](https://github.com/stimm-ai/stimm) | Open-source ultra-low-latency voice agent platform | Clone the repo and follow its provider setup |
 | [Pipecat](https://github.com/pipecat-ai/pipecat) | Open-source framework for real-time voice AI agents | `pip install pipecat-ai` then compose the STT/LLM/TTS pipeline |
 | [Qwen Audio Agent](https://github.com/QwenAudio/qwen-audio-agent) | Realtime voice runtime that keeps agents present | `npm install -g qwen-audio-agent` → `qwenaudio config` → `qwenaudio` |
+| [Patter](https://getpatter.com) | Open-source SDK that gives your AI agent a phone number | `npx skills add patterai/skills` then `npm install getpatter` or `pip install getpatter` |
 
 ---
 
@@ -346,7 +362,7 @@ These services can be joined with a single instruction, right now, with no human
 
 ---
 
-### 16. Agent Social & Community (6 services)
+### 16. Agent Social & Community (7 services)
 *Social networks where AI agents are first-class participants.*
 
 | Service | Tagline | Onboarding |
@@ -357,6 +373,7 @@ These services can be joined with a single instruction, right now, with no human
 | MCP Verse | Open town square for autonomous MCP agents | ⚠️ Former website/docs are offline; wait for a verified official replacement |
 | [KinthAI](https://kinthai.ai) | Agent economy network for collaboration and revenue | Visit [agents.kinthai.ai](https://agents.kinthai.ai) |
 | [Agent Chamber](https://github.com/LtyFantasy/agent-chamber) | Where AI agents meet, discuss, and get work done | Clone the repo → `./scripts/setup.sh` |
+| [AgentGram](https://agentgram.co) | The Open-Source Social Network for AI Agents | `pip install agentgram` then register via the SDK — MCP: `npx @agentgram/mcp-server` |
 
 ---
 

--- a/services/agent-harnesses-and-control-planes/README.md
+++ b/services/agent-harnesses-and-control-planes/README.md
@@ -35,6 +35,8 @@ Operator surfaces are an explicit narrow exception to the catalog's usual machin
 | [Agent QA](agent-qa.md) [![⭐](https://img.shields.io/github/stars/vostride/agent-qa?style=social)](https://github.com/vostride/agent-qa) | The self-improving QA agent for software teams | Live run IDs · observe/plan/execute/verify · file-backed memory · queue cancel | CLI · dashboard · MCP · Skills |
 | [Codex HUD (fwyc0573)](codex-hud-fwyc0573.md) [![⭐](https://img.shields.io/github/stars/fwyc0573/codex-hud?style=social)](https://github.com/fwyc0573/codex-hud) | Real-time statusline HUD for OpenAI Codex CLI | Live context/tools/subagents · multi-session view · attach/list/kill | tmux wrapper CLI · Codex rollout/config readers |
 | [Codex HUD (anhannin)](codex-hud-anhannin.md) [![⭐](https://img.shields.io/github/stars/anhannin/codex-hud?style=social)](https://github.com/anhannin/codex-hud) | Patched Codex status line for usage and session state | Model/project/git · 5-hour and 7-day usage windows | `status_line_command` · rollout JSONL reader |
+| [Claude HUD](claude-hud.md) [![⭐](https://img.shields.io/github/stars/jarrodwatts/claude-hud?style=social)](https://github.com/jarrodwatts/claude-hud) | A Claude Code plugin that shows what's happening | Context/usage · tools · subagents · todos | Claude Code plugin · statusline stdin/stdout |
+| [LoopX](loopx.md) [![⭐](https://img.shields.io/github/stars/huangruiteng/loopx?style=social)](https://github.com/huangruiteng/loopx) | The open, provider-neutral, stateful control plane for long-horizon agents | Objectives · gates · evidence · quota · claims/leases | CLI · workflow skills · host adapters |
 
 ## Criteria Reminder
 

--- a/services/agent-harnesses-and-control-planes/claude-hud.md
+++ b/services/agent-harnesses-and-control-planes/claude-hud.md
@@ -1,0 +1,164 @@
+# Claude HUD
+
+> **"A Claude Code plugin that shows what's happening"**
+
+| | |
+|---|---|
+| **Website** | https://github.com/jarrodwatts/claude-hud |
+| **Docs** | https://github.com/jarrodwatts/claude-hud#readme |
+| **GitHub** | https://github.com/jarrodwatts/claude-hud |
+| **Stars** | [![GitHub Stars](https://img.shields.io/github/stars/jarrodwatts/claude-hud?style=social)](https://github.com/jarrodwatts/claude-hud) |
+| **Classification** | `agent-native` |
+| **Category** | [Agent Harnesses & Operator Surfaces](README.md) |
+| **License** | MIT |
+| **Latest-month signal** | Last GitHub push 2026-08-18 (verified 2026-08-19) |
+| **Verified at** | 2026-08-19 |
+
+---
+
+## Official Website
+
+No separate website. The official home is:
+
+https://github.com/jarrodwatts/claude-hud
+
+---
+
+## Official Repo
+
+https://github.com/jarrodwatts/claude-hud
+
+---
+
+## How to Use (Agent Onboarding)
+
+**Interaction pattern:** `Claude Code plugin` + **status-line protocol**
+
+Inside Claude Code:
+
+```text
+/plugin marketplace add jarrodwatts/claude-hud
+/plugin install claude-hud
+/reload-plugins
+/claude-hud:setup
+```
+
+CLI equivalent:
+
+```bash
+claude plugin marketplace add jarrodwatts/claude-hud
+claude plugin install claude-hud@claude-hud
+```
+
+Then run `/reload-plugins` and `/claude-hud:setup` in the session. The HUD uses Claude Code's native statusline API (stdin JSON in, stdout rendered). It also reads the session transcript JSONL for tools, agents, and todos.
+
+---
+
+## Agent Skills
+
+**Status:** ⚠️ Plugin commands, not a portable `SKILL.md` package
+
+The plugin exposes `/claude-hud:setup` and `/claude-hud:configure`. That is Claude Code plugin UX, not `npx skills add`.
+
+Search community skills: `npx clawhub@latest search claude-hud`. See: https://agentskills.io/specification
+
+---
+
+## MCP
+
+**Status:** ⚠️ No MCP server
+
+Claude HUD can *display* configured MCP/Skills in the status line when those elements are enabled. It does not publish MCP tools or proxy MCP calls.
+
+---
+
+## What It Does
+
+Claude HUD is a purpose-built operator surface for a live Claude Code session. It renders model/provider, project/git, context-window fill, usage/rate-limit windows, and optional lines for in-flight tools, subagents, and todos. It is read-only observation: it does not enqueue work, approve tools, or mint credentials.
+
+This is the same class of surface as the catalog's Codex HUD entries, admitted on the **operator-surface track**.
+
+---
+
+## Why It Is Agent-Native
+
+Operator-surface track (not the standard five infrastructure criteria):
+
+| Requirement | Evidence |
+|---|---|
+| **Agent-operations-first** | README: **"A Claude Code plugin that shows what's happening — context usage, active tools, running agents, and todo progress."** — [jarrodwatts/claude-hud](https://github.com/jarrodwatts/claude-hud) |
+| **Agent-specific live state** | Native token/context data from Claude Code, plus transcript-parsed tool activity, subagent lines, todos, Skills/MCP display, usage windows |
+| **Session attribution** | State is the current Claude Code session (model, project, git, transcript). Not host CPU charts |
+| **Dedicated operational surface** | Statusline command protocol: Claude Code → stdin JSON → `claude-hud` → stdout in the terminal |
+| **Honest boundary** | Observation only. No autonomy, no approval enforcement, no delegated credentials, no MCP server, no portable Agent Skill package |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **Context health bar** | Live context-window fill from Claude Code (including 1M-context sessions) |
+| **Usage window** | Rate-limit / usage bar from native session data |
+| **Tool activity line** | In-progress and recent Read/Edit/Grep-style activity from the transcript |
+| **Agent / subagent line** | Running subagents with model and elapsed time |
+| **Todo line** | Current todo progress when enabled |
+
+---
+
+## Autonomy Model
+
+```
+Operator installs the plugin and runs /claude-hud:setup
+    -> Claude Code invokes the statusline after interactions
+    -> HUD reads stdin JSON + transcript JSONL
+    -> terminal shows session state
+    -> no enqueue, cancel, or approval actions
+```
+
+There is no autonomous control loop. The Claude Code agent continues as usual; the HUD only renders.
+
+---
+
+## Identity and Delegation Model
+
+- **Session identity:** The active Claude Code session and its transcript.
+- **No delegated authority:** Display is not permission to act.
+- **Config:** `~/.claude/plugins/claude-hud/config.json` or `$CLAUDE_CONFIG_DIR/claude-hud.json` overlays.
+- **MCP/Skills:** Shown when configured; not controlled by the HUD.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| Plugin | `/plugin marketplace add jarrodwatts/claude-hud` |
+| Statusline | stdin JSON → stdout render; 300ms debounce |
+| Transcript | JSONL for tools, agents, todos |
+| Configure | `/claude-hud:configure` or edit config JSON |
+
+---
+
+## Human-in-the-Loop Support
+
+The HUD *is* the human operator surface. It does not implement approval gates. Permission changes in Claude Code can trigger a re-render; the HUD does not decide them.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **Generic terminal theme** | Colors a shell; does not interpret Claude Code context, tools, or subagents |
+| **Process monitor** | Host CPU/RAM, not a concrete agent session transcript |
+| **IDE activity panel** | File-save telemetry, not Claude Code statusline + JSONL agent state |
+
+---
+
+## Use Cases
+
+- **Watch context pressure** — see fill before a compact is forced
+- **Follow tool/subagent work** — optional activity lines during a long turn
+- **Multi-directory Claude configs** — per-directory `claude-hud.json` overlays
+- **Codex cousins** — same operator-surface idea as the catalog Codex HUD entries, for Claude Code

--- a/services/agent-harnesses-and-control-planes/loopx.md
+++ b/services/agent-harnesses-and-control-planes/loopx.md
@@ -1,0 +1,169 @@
+# LoopX
+
+> **"The open, provider-neutral, stateful control plane for long-horizon agents."**
+
+| | |
+|---|---|
+| **Website** | https://huangruiteng.github.io/loopx/ |
+| **Docs** | https://huangruiteng.github.io/loopx/docs/ |
+| **GitHub** | https://github.com/huangruiteng/loopx |
+| **Stars** | [![GitHub Stars](https://img.shields.io/github/stars/huangruiteng/loopx?style=social)](https://github.com/huangruiteng/loopx) |
+| **Classification** | `agent-native` |
+| **Category** | [Agent Harnesses & Operator Surfaces](README.md) |
+| **License** | Apache-2.0 |
+| **Latest-month signal** | Last GitHub push 2026-08-19 (verified the same day) |
+| **Verified at** | 2026-08-19 |
+
+---
+
+## Official Website
+
+https://huangruiteng.github.io/loopx/
+
+---
+
+## Official Repo
+
+https://github.com/huangruiteng/loopx
+
+---
+
+## How to Use (Agent Onboarding)
+
+**Interaction pattern:** `CLI` + **workflow skills**
+
+```bash
+python3 -m pip install --upgrade loopx
+loopx workflow-skills --install
+loopx doctor
+cd /path/to/your-project
+loopx connect
+loopx status
+```
+
+If state is missing:
+
+```bash
+loopx start-goal --guided --project . --goal-text "Your long-running objective"
+```
+
+Official getting-started doc tells an already-running coding agent to connect the project, install from PyPI if needed, run `loopx doctor`, and reuse existing `.loopx/` state. Host-specific drivers (Codex App heartbeat, Claude Code `/loop`, OpenCode facade, and others) are listed in the README.
+
+---
+
+## Agent Skills
+
+**Status:** ✅ Available (installer-registered workflow skills)
+
+```bash
+loopx workflow-skills --install
+```
+
+The installer registers LoopX command-family skills on host surfaces (for example Codex `~/.codex/skills/loopx*`). Invoke via `$loopx` or `/skills` where the host requires it.
+
+| Skill | What It Teaches the Agent |
+|---|---|
+| LoopX command facade | Project connect, status, gates, todos, quota |
+| LoopX Project workflow | Longer governed-loop protocol for the current goal |
+
+Exact names depend on the host surface; `loopx workflow-skills --install` is the official registration command.
+
+---
+
+## MCP
+
+**Status:** ⚠️ Not the primary surface
+
+LoopX is a local-first CLI/state kernel that sits on top of existing harnesses. No official standalone MCP server is advertised as the default integration in the README.
+
+Search community skills: `npx clawhub@latest search loopx`. See: https://agentskills.io/specification
+
+---
+
+## What It Does
+
+LoopX is a provider-neutral control plane for work that outlives one chat turn. It keeps objectives, gates, todos, evidence, quota, and handoffs while Codex, Claude Code, Cursor, or another harness executes a bounded slice. Registered agents are peers that claim leases; humans keep dangerous permissions and final ownership. Official text: it is not an autonomous production controller.
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | README: **"The open, provider-neutral, stateful control plane for long-horizon agents."** — [huangruiteng/loopx](https://github.com/huangruiteng/loopx) |
+| **Agent-specific primitive** | Durable loop state (objective, gates, todos, evidence, quota) plus claim/lease/handoff operators — an agent-native Kanban, not a chat log |
+| **Autonomy-compatible control plane** | Bounded agent slices run without a click; quota decides the next tick. Human gates fire only when the state kernel says judgment is required |
+| **M2M integration surface** | `loopx` CLI, workflow skills, host adapters, local `.loopx/` state |
+| **Identity / delegation** | Goal/state ids, agent ids, claims and leases. No durable leader identity required. Dangerous writes stay with the human |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **Objective / goal state** | Durable goal plus `ACTIVE_GOAL_STATE` |
+| **Gates** | Owner, safety, publication, or private-data stops |
+| **Todos + evidence** | Continuation the next turn can read |
+| **Quota** | Whether another tick should run |
+| **Claim / lease / handoff** | Peer agents take and pass work |
+| **Doctor / connect** | Machine-checkable project health |
+
+---
+
+## Autonomy Model
+
+```
+pip install loopx -> workflow-skills --install -> connect project
+    -> harness executes one bounded turn
+    -> LoopX writes evidence, handoff, next todo
+    -> quota / scheduler_hint decides the next tick
+    -> if human judgment is required, ask and wait
+    -> else continue or stop
+```
+
+---
+
+## Identity and Delegation Model
+
+- **State identity:** `.loopx/registry.json` and goal-state files.
+- **Agent identity:** Registered peer agents with claims and leases; no required leader id.
+- **Human ownership:** Publishing, production writes, and final authority stay human.
+- **Ignore rules:** `.loopx/`, `.codex/goals/`, and `.local/` must not be committed.
+- **Not a cloud IAM product:** Local-first control plane.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| CLI | `loopx connect`, `doctor`, `status`, `start-goal`, `workflow-skills` |
+| Skills | Host-registered LoopX command/workflow skills |
+| State | `.loopx/`, goal-state markdown |
+| Host adapters | Codex App, Claude Code, OpenCode, Pi, KunlunCode, Cursor/shell |
+
+---
+
+## Human-in-the-Loop Support
+
+Explicit. Official line: **"Keep the loop moving. Keep the judgment human."** Gates ask a concrete question and wait. LoopX is not unattended production control; showcased multi-day runs are evidence of governed loops, not a promise of unattended prod autonomy.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **Chat memory + cron** | No gates, evidence, or claim/lease semantics |
+| **Generic project board** | Human tickets, not agent-claimable loop state |
+| **Single-session harness** | Drops objective/evidence across context refreshes |
+
+---
+
+## Use Cases
+
+- **Multi-day engineering or research objectives**
+- **Issue/PR loops** that must keep scope and review evidence
+- **Peer-agent teams** with leases and handoff
+- **Heartbeat / monitor work** gated by quota

--- a/services/agent-runtime-and-infrastructure/README.md
+++ b/services/agent-runtime-and-infrastructure/README.md
@@ -46,6 +46,8 @@ The services in this category were purpose-built to fill this gap.
 | [Modal](modal.md) [![⭐](https://img.shields.io/github/stars/modal-labs/modal-client?style=social)](https://github.com/modal-labs/modal-client) | AI infrastructure — serverless GPUs, inference, sandboxes, batch | Python SDK, CLI, HTTP endpoints | ❌ |
 | [Cyberdesk](cyberdesk.md) [![⭐](https://img.shields.io/github/stars/cyberdesk-hq/cyberdesk?style=social)](https://github.com/cyberdesk-hq/cyberdesk) | Open source virtual desktops for AI agents | SDK/API desktop lifecycle · computer actions · isolated sessions | ⚠️ |
 | [Polos](polos.md) [![⭐](https://img.shields.io/github/stars/polos-dev/polos?style=social)](https://github.com/polos-dev/polos) | Open-source runtime for AI agents — sandbox + durable workflow + HITL | Python/TS SDK · HTTP/webhook/cron/event triggers · Slack HITL · Docker/E2B sandbox | ⚠️ |
+| [Cloudflare Computer](cloudflare-computer.md) [![⭐](https://img.shields.io/github/stars/cloudflare/computer?style=social)](https://github.com/cloudflare/computer) | Give your agent a computer | `@cloudflare/computer` workspace FS + runtime.exec, preview only | ⚠️ |
+| [Agent Executor (AX)](google-ax.md) [![⭐](https://img.shields.io/github/stars/google/ax?style=social)](https://github.com/google/ax) | An open source distributed agent runtime | `ax` CLI, gRPC serve, conversation resume, event log | ⚠️ |
 
 
 

--- a/services/agent-runtime-and-infrastructure/cloudflare-computer.md
+++ b/services/agent-runtime-and-infrastructure/cloudflare-computer.md
@@ -1,0 +1,157 @@
+# Cloudflare Computer
+
+> **"Give your agent a computer 👾"**
+
+| | |
+|---|---|
+| **Website** | https://github.com/cloudflare/computer |
+| **Docs** | https://github.com/cloudflare/computer/tree/main/docs |
+| **GitHub** | https://github.com/cloudflare/computer |
+| **Stars** | [![GitHub Stars](https://img.shields.io/github/stars/cloudflare/computer?style=social)](https://github.com/cloudflare/computer) |
+| **Classification** | `agent-native` |
+| **Category** | [Agent Runtime & Infrastructure Services](README.md) |
+| **License** | MIT |
+| **Latest-month signal** | Last GitHub push 2026-08-18; npm package `@cloudflare/computer` documented as preview (verified 2026-08-19) |
+| **Verified at** | 2026-08-19 |
+
+---
+
+## Official Website
+
+No separate marketing site. The official home is the repository:
+
+https://github.com/cloudflare/computer
+
+---
+
+## Official Repo
+
+https://github.com/cloudflare/computer
+
+---
+
+## How to Use (Agent Onboarding)
+
+**Interaction pattern:** `SDK` (Durable Object workspace)
+
+```bash
+npm install @cloudflare/computer
+```
+
+Then attach `withWorkspace` to a Durable Object and call `workspace.fs` / `workspace.runtime.exec()`. The package README is the install and API map. Workers need `nodejs_compat`; isolate backends also need the `experimental` flag and a Worker Loader binding.
+
+An MCP example lives at `examples/mcp` in the repo (Code Mode `code` tool on a durable workspace). Repo `AGENTS.md` and `.agents/skills/` are for contributors working in this repository, not a published product Skill.
+
+**Honesty:** Official README marks the package **PREVIEW ONLY** — unstable APIs, not suitable for production.
+
+---
+
+## Agent Skills
+
+**Status:** ⚠️ Not published for product consumers
+
+In-repo `.agents/skills/` and `AGENTS.md` target collaborators on `cloudflare/computer`, not `npx skills add` for an external agent.
+
+Search community skills: `npx clawhub@latest search cloudflare-computer`. See: https://agentskills.io/specification
+
+---
+
+## MCP
+
+**Status:** ⚠️ Example only
+
+| Detail | Value |
+|---|---|
+| **MCP Repo** | Example at https://github.com/cloudflare/computer/tree/main/examples/mcp |
+| **Transport** | Example wiring (Code Mode `code` tool + workspace); not a published npm MCP package |
+| **Compatible Clients** | Whatever host you wire to the example |
+
+---
+
+## What It Does
+
+Cloudflare Computer is a Durable Object virtual filesystem (SQLite-backed) with one execution entry point, `workspace.runtime.exec`. Backends today are a full Linux container (FUSE + `computerd`), an isolate shell ([just-bash](https://github.com/vercel-labs/just-bash)), and isolate JavaScript. Agents get a small durable working directory plus optional AI SDK tools (`read`, `ls`, `grep`, `write`, `edit`, `exec`).
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | GitHub description: **"Give your agent a computer 👾"**. Package README: **"Built for agents that need a small, portable working directory"** — [repo](https://github.com/cloudflare/computer), [package](https://github.com/cloudflare/computer/blob/main/packages/computer/README.md) |
+| **Agent-specific primitive** | Durable workspace FS + pluggable `runtime.exec` (container / isolate shell / isolate JS) aimed at agent-scale workspaces, not a general PaaS disk |
+| **Autonomy-compatible control plane** | Once the Worker is deployed, the agent/runtime can read, write, and exec without a human desktop |
+| **M2M integration surface** | `@cloudflare/computer` API, capnweb RPC to `computerd`, example MCP, example HTTP `write`/`read`/`exec` |
+| **Identity / delegation** | Workspace state is the Durable Object's SQLite. Callers address a DO id (example uses `idFromName`). Egress policies can be none/all/custom. No separate KYA token |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **Workspace filesystem** | `node:fs/promises`-like API durable across DO restarts |
+| **`runtime.exec`** | One entry point; backend chooses shell vs JS module |
+| **Container backend** | Full Linux userland via FUSE + `computerd` |
+| **Isolate backends** | In-Worker just-bash or fresh Dynamic Worker JS |
+| **Agent tool helpers** | Optional AI SDK tools over the same workspace |
+
+---
+
+## Autonomy Model
+
+```
+Developer installs @cloudflare/computer on a Worker
+    -> Durable Object constructed with withWorkspace
+    -> agent or Worker code writes files and calls runtime.exec
+    -> selected backend runs against the same SQLite-backed FS
+    -> optional example MCP exposes a code tool on that workspace
+```
+
+Preview APIs may change; do not treat this as a production SLA.
+
+---
+
+## Identity and Delegation Model
+
+- **Workspace identity:** The Durable Object instance is the store.
+- **Backend IDs:** Multiple runtimes can register under stable IDs.
+- **Egress:** Examples show `none`, `all`, or custom URL policy.
+- **No delegated user OAuth:** This is compute/filesystem, not a user-token broker.
+- **Preview boundary:** Official text says not for production.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| npm | `@cloudflare/computer` |
+| FS / runtime API | `workspace.fs`, `workspace.runtime.exec` |
+| RPC | capnweb between DO and `computerd` |
+| Examples | container, worker-shell, worker-javascript, egress, mcp, think |
+
+---
+
+## Human-in-the-Loop Support
+
+None as a product gate. Humans deploy the Worker. Example UIs (`think-compare-runtimes`) are optional operator views.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **Ordinary Worker KV / R2 only** | Object storage without an agent workspace exec surface |
+| **Generic Docker host** | Not a Durable Object-authoritative FS with isolate/container backends on one API |
+| **Cloudflare Agents SDK alone** | Related runtime; Computer is the filesystem-plus-exec package (see also [Cloudflare Agents SDK](cloudflare-agents-sdk.md)) |
+
+---
+
+## Use Cases
+
+- **Agent working directory** — durable notes, artifacts, and commands on a DO
+- **Compare runtimes** — same task on container vs Worker shell
+- **Code Mode** — one `code` tool backed by the workspace (example)
+- **Prototypes only** — official preview warning still applies

--- a/services/agent-runtime-and-infrastructure/google-ax.md
+++ b/services/agent-runtime-and-infrastructure/google-ax.md
@@ -1,0 +1,162 @@
+# Agent Executor (AX)
+
+> **"An open source distributed agent runtime"**
+
+| | |
+|---|---|
+| **Website** | https://agentexecutor.io |
+| **Docs** | https://github.com/google/ax#readme |
+| **GitHub** | https://github.com/google/ax |
+| **Stars** | [![GitHub Stars](https://img.shields.io/github/stars/google/ax?style=social)](https://github.com/google/ax) |
+| **Classification** | `agent-native` |
+| **Category** | [Agent Runtime & Infrastructure Services](README.md) |
+| **License** | Apache-2.0 |
+| **Latest-month signal** | Last GitHub push 2026-08-13; README still marks early development (verified 2026-08-19) |
+| **Verified at** | 2026-08-19 |
+
+---
+
+## Official Website
+
+https://agentexecutor.io
+
+---
+
+## Official Repo
+
+https://github.com/google/ax
+
+---
+
+## How to Use (Agent Onboarding)
+
+**Interaction pattern:** `CLI` + optional gRPC server
+
+```bash
+go install github.com/google/ax/cmd/ax@latest
+ax --help
+
+# Local built-in Antigravity harness (needs GEMINI_API_KEY or Vertex ADC)
+ax --input "Can you list this directory?"
+
+# Resume
+ax --conversation <id> --input "Show me the contents of README.md"
+ax --conversation <id> --resume
+```
+
+Remote controller:
+
+```bash
+ax serve --config ax.yaml
+ax --input "Hello agents!" --server localhost:8494
+```
+
+Kubernetes on [Agent Substrate](https://github.com/agent-substrate/substrate) is the documented production-oriented deploy path (`manifests/README.md`). This catalog does **not** add Agent Substrate itself (open issue #101).
+
+---
+
+## Agent Skills
+
+**Status:** ⚠️ Hosted by the harness, not a published `npx skills add` package
+
+Built-in harnesses such as Antigravity can load Agent Skills when configured. See repo `examples/skills`. There is no official `npx skills add google/ax` command.
+
+Search community skills: `npx clawhub@latest search agent-executor`. See: https://agentskills.io/specification
+
+---
+
+## MCP
+
+**Status:** ⚠️ Consumer, not a published MCP server
+
+Antigravity can discover and call MCP tools when they are configured. AX does not ship a standalone MCP server package for controlling the runtime.
+
+---
+
+## What It Does
+
+AX (Agent Executor) is a self-hosted distributed harness runtime from Google. It provisions isolated environments from suspendable/resumable images, runs harnesses and agents, and keeps durable execution state in an event log so work can resume after failure. It is compute-agnostic, with the best-documented path on Kubernetes via Agent Substrate. Official text says AX is **not** a managed service and **not** an agentic framework.
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | GitHub: **"An open source distributed agent runtime"**. README: **"AX, short for Agent Executor, is a distributed harness runtime."** — [google/ax](https://github.com/google/ax) |
+| **Agent-specific primitive** | Conversation-scoped isolated harness execution with an event log, single-writer controller, and resume/suspend — not a generic job queue |
+| **Autonomy-compatible control plane** | `ax --input` / `--resume` continues work without a human clicking a UI. Human approval is a roadmap item (elicitation), not a per-step requirement today |
+| **M2M integration surface** | `ax` CLI, `ax serve` gRPC, YAML config, Kubernetes manifests |
+| **Identity / delegation** | Conversation IDs, optional `--agent` IDs, per-request `--agent-config`. Session-tenant actors on the control service. No user-OAuth delegation product |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **Conversation** | Durable execution id you can continue or resume |
+| **Event log** | SQLite (default example) scan/append store for recovery |
+| **Harness isolation** | Harnesses/skills/tools/agents as isolated actors |
+| **Resumption** | Recover incomplete executions; compute-layer suspend on compatible platforms |
+| **Built-in Antigravity harness** | Default local harness; Gemini API or Vertex |
+
+---
+
+## Autonomy Model
+
+```
+Operator installs ax CLI and sets model credentials
+    -> ax --input starts a conversation (UUID if omitted)
+    -> controller appends the event log and runs the harness actor
+    -> later: ax --conversation <id> --input … or --resume
+    -> optional ax serve for a remote gRPC controller
+```
+
+README warns of breaking changes before a stable release. External PRs are paused.
+
+---
+
+## Identity and Delegation Model
+
+- **Conversation ID:** The handle for resume and follow-up input.
+- **Agent ID / config:** Optional `--agent`, `--agent-config`, or `--agent-config-file`.
+- **Single-writer controller:** Consistent state; not a multi-leader cluster story in the README.
+- **Not a managed identity service:** You run AX; model keys are yours (`GEMINI_API_KEY` or Vertex ADC).
+- **Agent Substrate:** Isolation/resume substrate is optional and listed separately; not added here.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| CLI | `ax`, `ax serve`, `--conversation`, `--resume`, `--server` |
+| gRPC | Controller when `--server` is set (default example `:8494`) |
+| Config | `ax.yaml` (`version: v1alpha`) |
+| K8s | `manifests/` + Agent Substrate |
+
+---
+
+## Human-in-the-Loop Support
+
+Not a productized approval plane. Roadmap lists elicitation. Operators resume conversations from the CLI. Long idle periods are why AX wants suspend/resume rather than a human babysitting the actor.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **Kubernetes Job / Deployment** | Designed for stateless services or batch, not suspendable sandboxed agent actors with an event log |
+| **Agent framework (LangGraph, etc.)** | AX explicitly is not a framework; frameworks can run *as* harnesses |
+| **Hosted agent builder** | AX is self-hosted runtime infrastructure |
+
+---
+
+## Use Cases
+
+- **Long-running agent work** — resume after interruption with a conversation id
+- **Isolated harnesses** — run tools/skills/agents as separate actors
+- **K8s agent density** — documented path via Agent Substrate (not catalogued here)
+- **Local experiments** — `ax --input` with the built-in harness

--- a/services/agent-social-network/README.md
+++ b/services/agent-social-network/README.md
@@ -20,6 +20,7 @@ The emergence of this category in 2026 signals something significant: AI agents 
 | [MCP Verse](mcpverse.md) | Open playground — town square for autonomous MCP agents | MCP, TypeScript scaffold (`create-mcpverse-agent`), rooms & publications | ✅ |
 | [KinthAI](kinthai.md) | Agent economy network — agents earn revenue, collaborate, and self-organize | Web onboarding, agent marketplace, multi-agent orchestration, A2A protocol | ❌ |
 | [Agent Chamber](agent-chamber.md) [![⭐](https://img.shields.io/github/stars/LtyFantasy/agent-chamber?style=social)](https://github.com/LtyFantasy/agent-chamber) | Where agents meet, discuss, manage work, and build shared knowledge | MCP HTTP/SSE, REST API, Agent Skills, cursor events, Mission Control | ✅ |
+| [AgentGram](agentgram.md) [![⭐](https://img.shields.io/github/stars/agentgram/agentgram?style=social)](https://github.com/agentgram/agentgram) | The Open-Source Social Network for AI Agents | REST, Python/JS SDKs, MCP, AX Score | ✅ |
 
 
 ---

--- a/services/agent-social-network/agentgram.md
+++ b/services/agent-social-network/agentgram.md
@@ -1,0 +1,169 @@
+# AgentGram
+
+> **"The Open-Source Social Network for AI Agents"**
+
+| | |
+|---|---|
+| **Website** | https://agentgram.co |
+| **Docs** | https://agentgram.co/docs |
+| **GitHub** | https://github.com/agentgram/agentgram |
+| **Stars** | [![GitHub Stars](https://img.shields.io/github/stars/agentgram/agentgram?style=social)](https://github.com/agentgram/agentgram) |
+| **Classification** | `agent-native` |
+| **Category** | [Agent Social & Community Services](README.md) |
+| **License** | MIT |
+| **Latest-month signal** | Last GitHub push 2026-08-19; homepage also markets team MCP/AX Score governance (verified 2026-08-19) |
+| **Verified at** | 2026-08-19 |
+
+---
+
+## Official Website
+
+https://agentgram.co
+
+---
+
+## Official Repo
+
+https://github.com/agentgram/agentgram
+
+---
+
+## How to Use (Agent Onboarding)
+
+**Interaction pattern:** `SDK` + **MCP**
+
+```bash
+pip install agentgram
+python -c "from agentgram import AgentGram; AgentGram().agents.register(name='my-bot')"
+```
+
+TypeScript: `npm install agentgram`. MCP:
+
+```bash
+npx @agentgram/mcp-server
+```
+
+Self-host:
+
+```bash
+git clone https://github.com/agentgram/agentgram.git
+cd agentgram
+pnpm install
+# configure .env.local + Supabase, then
+pnpm dev
+```
+
+API docs: https://agentgram.co/docs/api. Homepage still shows `client.register` / `agent.post` / `agent.follow`.
+
+**Honesty:** On 2026-08-19 the marketing homepage also leads with **"MCP Governance & Audit for Teams"** (AX Score scans). GitHub and the agent register/post API remain the social-network product this entry catalogs. FAQ: agent and Explore surfaces remain available.
+
+---
+
+## Agent Skills
+
+**Status:** ⚠️ Partial (OpenClaw skill in the ecosystem table)
+
+README ecosystem lists `agentgram-openclaw` as an OpenClaw skill. No `npx skills add agentgram/agentgram` command is documented.
+
+Search community skills: `npx clawhub@latest search agentgram`. See: https://agentskills.io/specification
+
+---
+
+## MCP
+
+**Status:** ✅ Available
+
+| Detail | Value |
+|---|---|
+| **MCP Repo** | https://github.com/agentgram/agentgram-mcp |
+| **Transport** | As published by `@agentgram/mcp-server` (see that repo for the current transport) |
+| **Compatible Clients** | README: Claude Code, Cursor, and other MCP hosts |
+
+---
+
+## What It Does
+
+AgentGram is a self-hostable, API-first social network whose GitHub positioning is Reddit-for-agents: registration, posts, comments, follows, communities, and cryptographic identity (API key today; Ed25519 called out as designed/roadmap). Related packages add a Python/JS SDK, MCP server, and AX Score (site readiness scans). The live site additionally sells team MCP governance using that same identity/audit stack.
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | GitHub: **"The Open-Source Social Network for AI Agents"** and **"API-first architecture — Full programmatic access for autonomous agents"** — [agentgram/agentgram](https://github.com/agentgram/agentgram). Homepage still documents agent register/post |
+| **Agent-specific primitive** | Programmatic `register` + post/follow, plus Ed25519/API-key agent identity — not a human Twitter clone with a bot afterthought |
+| **Autonomy-compatible control plane** | SDK/REST/MCP can register and post without a human social UI |
+| **M2M integration surface** | REST (OpenAPI), `pip install agentgram`, `npm install agentgram`, `npx @agentgram/mcp-server` |
+| **Identity / delegation** | Agent records with API key and planned Ed25519 signatures; Supabase RLS; audit logs. Team AX Score is a separate governance readout on the same identity engine |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **Agent registration** | API-key (and designed Ed25519) identity |
+| **Posts / comments / follow** | Programmatic social graph |
+| **AXP / reputation** | README reputation and permission scoring |
+| **MCP server** | `@agentgram/mcp-server` |
+| **AX Score** | Discoverability scan (`npx @agentgram/ax-score` / `npx ax-score`) |
+
+---
+
+## Autonomy Model
+
+```
+pip install agentgram (or MCP / self-host)
+    -> agents.register(name=…)
+    -> agent.post / follow / read feed
+    -> optional AX Score scan of endpoints
+    -> humans may use the web UI or team governance views
+```
+
+---
+
+## Identity and Delegation Model
+
+- **Agent identity:** Register returns an agent record; auth is API key, with Ed25519 described as the stronger path (README roadmap still listed enhanced Ed25519 for v0.3.0).
+- **RLS / audit:** Supabase row-level security and audit logs.
+- **Team governance:** Homepage AX Score / allow-list story is for organizations reviewing MCP endpoints, not a substitute for agent registration.
+- **Billing:** Lemon Squeezy tiers mentioned in the README.
+- **Independence note:** Homepage discusses Moltbook's acquisition context; AgentGram claims independent operation.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| REST | Documented at https://agentgram.co/docs/api |
+| Python SDK | `pip install agentgram` |
+| JS SDK | `npm install agentgram` |
+| MCP | `npx @agentgram/mcp-server` |
+| AX Score | `npx @agentgram/ax-score` / `npx ax-score` |
+
+---
+
+## Human-in-the-Loop Support
+
+Humans can use the web UI, billing, and (on the current homepage) team MCP review. Agents do not need that UI to register or post via API.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **Human social networks** | Anti-bot policy; agents are guests |
+| **Generic forum software** | No agent registration or cryptographic agent identity |
+| **MCP allow-list spreadsheet** | Governance-only; no agent social primitives (the homepage's new pitch is this layer *in addition*, not instead of the GitHub social API) |
+
+---
+
+## Use Cases
+
+- **Self-hosted agent social graph** — posts, follows, communities
+- **MCP-hosted participation** — Cursor/Claude Code via `@agentgram/mcp-server`
+- **AX Score checks** — machine-readable readiness of a site or MCP endpoint
+- **Independent Moltbook-class network** — MIT, self-host, API-first

--- a/services/browser-and-web-execution/README.md
+++ b/services/browser-and-web-execution/README.md
@@ -38,6 +38,7 @@ The web was designed for humans sitting in front of browsers. AI agents that nee
 | [Vessel Browser](vessel-browser.md) [![⭐](https://img.shields.io/github/stars/unmodeled-tyler/vessel-browser?style=social)](https://github.com/unmodeled-tyler/vessel-browser) | Built from the ground-up for agents — durable state, action undo, MCP control, BYOK | MCP (stdio), npm CLI, AppImage (Linux/Windows) | ✅ |
 | [CamoFox Browser](camofox.md) [![⭐](https://img.shields.io/github/stars/jo-inc/camofox-browser?style=social)](https://github.com/jo-inc/camofox-browser) | Stealth headless browser for AI agents | CLI/server automation, browser profiles, screenshots/extraction | ⚠️ |
 | [Moli](moli.md) [![⭐](https://img.shields.io/github/stars/lexmount/moli?style=social)](https://github.com/lexmount/moli) | Structured-first browser engine for AI agents | Rust CLI, stdio MCP, CDP, WebDriver Classic/BiDi, semantic-tree output | ✅ |
+| [Kernel](kernel.md) [![⭐](https://img.shields.io/github/stars/kernel/kernel-images?style=social)](https://github.com/kernel/kernel-images) | you build agents. we give them the internet. | CLI, Playwright/CDP/computer-use, kernel-cli skill, hosted unikernel browsers | ⚠️ |
 
 
 

--- a/services/browser-and-web-execution/kernel.md
+++ b/services/browser-and-web-execution/kernel.md
@@ -1,0 +1,179 @@
+# Kernel
+
+> **"you build agents. we give them the internet."**
+
+| | |
+|---|---|
+| **Website** | https://www.kernel.sh/ |
+| **Docs** | https://www.kernel.sh/docs |
+| **GitHub** | https://github.com/kernel/kernel-images |
+| **Stars** | [![GitHub Stars](https://img.shields.io/github/stars/kernel/kernel-images?style=social)](https://github.com/kernel/kernel-images) |
+| **Classification** | `agent-native` |
+| **Category** | [Browser & Web Execution Services](README.md) |
+| **License** | Apache-2.0 (`kernel/kernel-images`, `kernel/cli`) |
+| **Latest-month signal** | `kernel-images` last push 2026-08-18; `kernel/cli` last push 2026-08-18 (verified 2026-08-19) |
+| **Verified at** | 2026-08-19 |
+
+---
+
+## Official Website
+
+https://www.kernel.sh/
+
+Product documentation: https://www.kernel.sh/docs
+
+---
+
+## Official Repo
+
+https://github.com/kernel/kernel-images — open-source browser images that power the hosted service
+
+https://github.com/kernel/cli — official CLI (`@onkernel/cli`)
+
+https://github.com/kernel/skills — official `kernel-cli` Agent Skill
+
+The GitHub org slug is `kernel` (the `onkernel/…` paths resolve to the same org). There is no separate `onkernel/kernel` application repo as of 2026-08-19.
+
+---
+
+## How to Use (Agent Onboarding)
+
+**Interaction pattern:** `CLI` + **published Agent Skill**
+
+Official docs tell a coding agent to read the Kernel CLI skill, then install and authenticate:
+
+```bash
+brew install kernel/tap/kernel
+# or
+npm install -g @onkernel/cli
+
+kernel --version
+export KERNEL_API_KEY=your_api_key
+# fallback: kernel login
+kernel browsers create -o json
+```
+
+Skill source: https://github.com/kernel/skills/blob/main/plugins/kernel-cli/skills/kernel-cli/SKILL.md
+
+Serverless agent loops (co-located with the browser):
+
+```bash
+kernel create --template computer-use
+kernel deploy agent.ts
+kernel invoke my-agent my-task --payload '{"url": "https://example.com"}'
+```
+
+Self-host the images from `kernel/kernel-images` via Docker or Unikraft; CDP is on port 9222.
+
+---
+
+## Agent Skills
+
+**Status:** ✅ Available
+
+Official skill at [kernel/skills](https://github.com/kernel/skills):
+
+| Skill | What It Teaches the Agent |
+|---|---|
+| `kernel-cli` | Install/auth the CLI, create browsers, run Playwright in-session, computer-use screenshots, deploy/invoke apps, manage profiles, auth, proxies, and pools |
+
+---
+
+## MCP
+
+**Status:** ⚠️ Not published as a standalone MCP package
+
+Kernel's documented machine surfaces are the CLI, Playwright/CDP/WebDriver BiDi, computer-use APIs, and the `kernel-cli` skill. No official MCP server package was listed on the docs index or CLI skill as of 2026-08-19.
+
+Search community skills: `npx clawhub@latest search kernel`. See: https://agentskills.io/specification
+
+---
+
+## What It Does
+
+Kernel is cloud browser infrastructure for AI agents. It spins up sandboxed Chromium (hosted unikernel images, advertised cold start under 30ms) that agents drive with Playwright, CDP, WebDriver BiDi, or computer-use actions. The platform adds stealth/CAPTCHA/proxy handling, managed auth, live view, MP4 replay, browser pools, and a serverless app platform that runs agent loops next to the browser.
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | Homepage: **"you build agents. we give them the internet."** Docs: **"We build crazy fast, open source infra for AI agents to access the internet."** — [kernel.sh](https://www.kernel.sh/), [docs](https://www.kernel.sh/docs) |
+| **Agent-specific primitive** | Remote sandboxed Chromium plus managed auth, stealth, live view, replay, and `btel` browser telemetry so an agent can act on the web and debug failures |
+| **Autonomy-compatible control plane** | `KERNEL_API_KEY` + CLI/SDK create, drive, and delete sessions without a human clicking the browser. `kernel login` is only the interactive fallback |
+| **M2M integration surface** | CLI (`brew` / `npm i -g @onkernel/cli`), JSON output, Playwright execute, CDP, computer-use, deploy/invoke, official Skill |
+| **Identity / delegation** | Browser sessions, optional names/tags, projects, API keys, and org concurrency limits. Managed auth keeps site credentials out of the agent transcript |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **Sandboxed Chromium session** | Cloud browser the agent creates, drives, and deletes |
+| **Computer-use / Playwright execute** | In-session automation and OS-level screenshot/input |
+| **Managed auth** | Platform-handled login so agents do not complete site auth themselves |
+| **Live view + replay** | Operator watch URL and MP4 recording |
+| **Browser pools** | Pre-warmed browsers for low-latency acquire |
+| **App platform** | Deploy and `invoke` an agent loop co-located with its browser |
+
+---
+
+## Autonomy Model
+
+```
+Agent installs CLI / reads kernel-cli skill
+    -> authenticate with KERNEL_API_KEY (or human completes kernel login once)
+    -> kernel browsers create -o json
+    -> drive via Playwright execute, CDP, or computer-use
+    -> optional live view / replay for debugging
+    -> kernel browsers delete when done
+    -> or deploy + invoke a long-running app on the app platform
+```
+
+---
+
+## Identity and Delegation Model
+
+- **Session identity:** Each browser has an ID; CLI JSON is the machine handle.
+- **Project / API key:** Keys are scoped; `--project` or `KERNEL_PROJECT` selects the project.
+- **Managed auth:** Site credentials stay with Kernel's auth connections, not in the LLM context.
+- **No long-lived agent passport:** Kernel models browser and project identity, not a KYA token.
+- **Self-host warning:** Unikraft live-view URLs in the image README are public if leaked.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| CLI | `kernel browsers`, `deploy`, `invoke`, `auth`, pools, profiles, proxies |
+| Agent Skill | `kernel-cli` in [kernel/skills](https://github.com/kernel/skills) |
+| CDP / Playwright / BiDi | Connect to hosted or self-hosted Chromium |
+| Open-source images | https://github.com/kernel/kernel-images |
+
+---
+
+## Human-in-the-Loop Support
+
+Live view and MP4 replay are the operator surfaces. `kernel login` is an interactive OAuth fallback when no API key is set. Destructive CLI actions keep confirmation prompts unless the agent opts into non-interactive flags.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **Local Playwright** | No hosted session isolation, managed auth, stealth, or agent-facing live view |
+| **Generic cloud VM + Chrome** | Not an agent browser primitive; no pools, replay API, or managed auth |
+| **Human remote-desktop** | Requires a person to operate the browser |
+
+---
+
+## Use Cases
+
+- **Computer-use agents** — screenshots, mouse/keyboard, and Playwright in a sandboxed browser
+- **Agentic checkout / form filling** — stealth, proxies, and managed auth
+- **QA agents** — parallel sessions and live/replay debugging
+- **Self-host experiments** — run `kernel-images` on Docker or Unikraft

--- a/services/communication/README.md
+++ b/services/communication/README.md
@@ -23,6 +23,8 @@ Human communication infrastructure (Gmail, Outlook, Slack) was built around the 
 | [MCP Agent Mail (Rust)](mcp-agent-mail-rust.md) | "Gmail for coding agents" with high-performance MCP runtime | MCP tools/resources, local HTTP runtime, TUI + robot CLI | ✅ |
 | [AgenticMail](agenticmail.md) [![⭐](https://img.shields.io/github/stars/agenticmail/agenticmail?style=social)](https://github.com/agenticmail/agenticmail) | Email & SMS infrastructure for AI agents | REST API (75+ endpoints), self-hosted Stalwart + Google Voice bridge, Webhooks | ⚠️ |
 | [Caspian](caspian.md) [![⭐](https://img.shields.io/github/stars/TryCaspian/caspian-sdk?style=social)](https://github.com/TryCaspian/caspian-sdk) | One agent communication identity across human channels | URL onboarding, Python/TypeScript SDKs, CLI, REST events, Webhooks | ⚠️ |
+| [Atomic Mail](atomic-mail.md) [![⭐](https://img.shields.io/github/stars/Atomic-Mail/atomic-mail-agentic?style=social)](https://github.com/Atomic-Mail/atomic-mail-agentic) | Not AI for your email. Email for your AI. | Homepage onboarding, JMAP, local/hosted MCP, AgentSkill | ✅ |
+| [AgentTeam Email](agentteam-email.md) [![⭐](https://img.shields.io/github/stars/agentteamhq/agentteam-email?style=social)](https://github.com/agentteamhq/agentteam-email) | Open-source email infrastructure for AI agents | `at-email` CLI, Agent Skill, self-host Compose/Helm, draft review | ⚠️ |
 
 
 

--- a/services/communication/agentteam-email.md
+++ b/services/communication/agentteam-email.md
@@ -1,0 +1,159 @@
+# AgentTeam Email
+
+> **"Open-source email infrastructure for AI agents."**
+
+| | |
+|---|---|
+| **Website** | https://www.agentteam.email |
+| **Docs** | https://agentteamemail.mintlify.com/get-started/quickstart |
+| **GitHub** | https://github.com/agentteamhq/agentteam-email |
+| **Stars** | [![GitHub Stars](https://img.shields.io/github/stars/agentteamhq/agentteam-email?style=social)](https://github.com/agentteamhq/agentteam-email) |
+| **Classification** | `agent-native` |
+| **Category** | [Communication Services](README.md) |
+| **License** | MIT |
+| **Latest-month signal** | Last GitHub push 2026-08-01; docs and CLI/skill paths still published (verified 2026-08-19) |
+| **Verified at** | 2026-08-19 |
+
+---
+
+## Official Website
+
+https://www.agentteam.email
+
+Product documentation: https://agentteamemail.mintlify.com/get-started/quickstart
+
+---
+
+## Official Repo
+
+https://github.com/agentteamhq/agentteam-email
+
+---
+
+## How to Use (Agent Onboarding)
+
+**Interaction pattern:** `CLI` + **published Agent Skill**
+
+```bash
+npx --yes @agentteamhq/email@latest --version
+at-email agent connect
+# or
+at-email agent trial
+at-email agent enroll TOKEN
+```
+
+The bundled skill lives in [skills/at-email-cli](https://github.com/agentteamhq/agentteam-email/tree/main/skills/at-email-cli). Official CLI and skill docs: https://agentteamemail.mintlify.com/usage/cli-and-agent-skill
+
+Self-host with Docker Compose or Helm after the [quickstart](https://agentteamemail.mintlify.com/get-started/quickstart). Hosted setup uses Cloudflare OAuth to attach a sending domain.
+
+---
+
+## Agent Skills
+
+**Status:** ✅ Available
+
+The repository ships `skills/at-email-cli`. The website points agents at the AT Email skill on skills.sh.
+
+| Skill | What It Teaches the Agent |
+|---|---|
+| `at-email-cli` | Connect or enroll, then check mailbox status, review messages, search, and send approved outbound mail |
+
+---
+
+## MCP
+
+**Status:** ⚠️ Not published
+
+No official MCP server is documented in the README or product site as of 2026-08-19. The portable surface is the `at-email` CLI and the bundled skill.
+
+Search community skills: `npx clawhub@latest search agentteam-email`. See: https://agentskills.io/specification to contribute an MCP wrapper.
+
+---
+
+## What It Does
+
+AgentTeam Email (AT Email) is open-source mail infrastructure that provisions a real mailbox per agent on a domain you control. Operators connect Cloudflare for send/receive, keep inbound mail in an R2 bucket before processing, and give agents scoped read/draft/send rights. A web client exists for humans, but the product is built around agent mailboxes, review-before-send, and an `at-email` CLI the agent can run.
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | GitHub: **"Open-source email infrastructure for AI agents."** Homepage: **"Give every agent a real mailbox on your domain"** — [repo](https://github.com/agentteamhq/agentteam-email), [site](https://www.agentteam.email) |
+| **Agent-specific primitive** | Per-agent mailbox with scoped powers (read, draft, or send) plus safe review of untrusted inbound mail. Not a shared human inbox |
+| **Autonomy-compatible control plane** | CLI connect/trial/enroll lets an authorized agent operate a mailbox. Optional human review can gate outbound send |
+| **M2M integration surface** | `at-email` CLI (`@agentteamhq/email`), bundled Agent Skill, self-host APIs, Mintlify docs |
+| **Identity / delegation** | Each agent address is a distinct mailbox on the connected domain, with permissions and an activity trail of reads, drafts, and approvals |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **Agent mailbox** | Dedicated address for receive, review, and send |
+| **Per-agent permissions** | Read-only, draft, or send on a domain-owned identity |
+| **Draft review lane** | Humans can approve, edit, schedule, or block outbound mail |
+| **Bucket-first receive** | Inbound mail lands in R2 before the app processes it |
+| **`at-email` CLI** | Status, review, search, and approved send for agents |
+
+---
+
+## Autonomy Model
+
+```
+Operator connects a Cloudflare domain (hosted) or self-hosts Compose/Helm
+    -> provision an agent mailbox and scoped permissions
+    -> agent runs at-email agent connect / trial / enroll
+    -> agent reads, searches, and drafts from the CLI/skill
+    -> outbound send is either permitted or held for human review
+    -> activity log attributes reads, drafts, and approvals to the agent address
+```
+
+---
+
+## Identity and Delegation Model
+
+- **Mailbox identity:** Each agent gets a real address on the operator's domain (for example `research@…`).
+- **Scoped powers:** Operators grant read, draft, or send per agent.
+- **Audit:** Activity log tracks reads, drafts, replies, and inbound mail per address.
+- **Human domain ownership:** Cloudflare OAuth and DNS stay with the operator; agents do not own the zone.
+- **Untrusted inbound:** Official docs describe a dedicated review surface for mail the agent should not blindly execute.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| CLI | `at-email` / `npx --yes @agentteamhq/email@latest` |
+| Agent Skill | `skills/at-email-cli` |
+| Hosted app | https://www.agentteam.email |
+| Docs | https://agentteamemail.mintlify.com |
+| Self-host | Docker Compose or Helm |
+
+---
+
+## Human-in-the-Loop Support
+
+First-class. The product markets draft review before send, per-agent permission limits, and an activity trail. Agents can still operate autonomously inside the powers they were granted.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **Shared team inbox** | Built for human seats, not per-agent identities and scoped send rights |
+| **Forwarding alias** | Routes mail only; no agent CLI, permissions, or review lane |
+| **Human ESP dashboard** | Requires a person to operate the mailbox; no agent enroll/connect path |
+
+---
+
+## Use Cases
+
+- **Agent-owned operations** — give a long-running agent its own domain address
+- **Human-reviewed sending** — agents draft; people approve or restrict what leaves the domain
+- **Shared inbox triage** — route support or alerts to agents that summarize and surface what matters
+- **Self-hosted mail control** — run the MIT stack on Compose or Kubernetes

--- a/services/communication/atomic-mail.md
+++ b/services/communication/atomic-mail.md
@@ -1,0 +1,177 @@
+# Atomic Mail
+
+> **"Not AI for your email. Email for your AI."**
+
+| | |
+|---|---|
+| **Website** | https://atomicmail.ai/ |
+| **Docs** | https://atomicmail.ai/ |
+| **GitHub** | https://github.com/Atomic-Mail/atomic-mail-agentic |
+| **Stars** | [![GitHub Stars](https://img.shields.io/github/stars/Atomic-Mail/atomic-mail-agentic?style=social)](https://github.com/Atomic-Mail/atomic-mail-agentic) |
+| **Classification** | `agent-native` |
+| **Category** | [Communication Services](README.md) |
+| **License** | MIT |
+| **Latest-month signal** | Last GitHub push 2026-08-11; homepage and client repo still document PoW signup, JMAP, MCP, and AgentSkill (verified 2026-08-19) |
+| **Verified at** | 2026-08-19 |
+
+---
+
+## Official Website
+
+https://atomicmail.ai/
+
+---
+
+## Official Repo
+
+https://github.com/Atomic-Mail/atomic-mail-agentic
+
+---
+
+## ⭐ How to Use (Agent Onboarding)
+
+**Interaction pattern:** `URL Onboarding` ⭐ — the homepage is the join document.
+
+```text
+Read https://atomicmail.ai and follow the instructions to create an inbox at Atomic Mail.
+```
+
+The official GitHub README uses the same pattern: read https://atomicmail.ai, then register. Autonomous signup uses proof-of-work; no human CAPTCHA or dashboard is required for an `@atomicmail.ai` inbox.
+
+Local MCP (stdio), from the homepage:
+
+```json
+{
+  "mcpServers": {
+    "atomicmail": {
+      "command": "npx",
+      "args": ["-y", "@atomicmail/mcp"]
+    }
+  }
+}
+```
+
+Hosted remote MCP (OAuth or inbox API key) is at `https://mcp.atomicmail.ai/mcp`. The GitHub client repo also publishes `@atomicmail/mcp-github` and `@atomicmail/agent-skill-github` as thin wrappers around the same PoW + JMAP stack.
+
+---
+
+## Agent Skills
+
+**Status:** ✅ Available
+
+The homepage documents a local AgentSkill package. The GitHub README shows:
+
+```bash
+npx --package=@atomicmail/agent-skill-github atomicmail register --username "myagent" --watch scheduled
+```
+
+Repo docs also ship `docs/SKILL.md` as the agent runbook. ClawHub install is documented as `openclaw skills install atomicmail`.
+
+| Skill | What It Teaches the Agent |
+|---|---|
+| `atomicmail` / AgentSkill CLI | Register via PoW, call JMAP (`jmap_request`), and recover with `help` |
+
+---
+
+## MCP
+
+**Status:** ✅ Available
+
+| Detail | Value |
+|---|---|
+| **MCP Repo** | https://github.com/Atomic-Mail/atomic-mail-agentic |
+| **Transport** | Local stdio (`npx -y @atomicmail/mcp` on the homepage; `@atomicmail/mcp-github` in the client repo) or hosted Streamable HTTP at `https://mcp.atomicmail.ai/mcp` |
+| **Compatible Clients** | Claude, ChatGPT, Cursor, Claude Code, Codex, and other MCP hosts that accept stdio or a remote HTTP URL |
+
+Tools documented by the client repo: `register`, `jmap_request`, and `help`.
+
+---
+
+## What It Does
+
+Atomic Mail is an AI-agent-first email provider. An agent registers its own `username@atomicmail.ai` inbox (username 5–21 characters) and then reads, sends, drafts, searches, and threads mail over JMAP (RFC 8620 / 8621). Access is gated by a proof-of-work signup so agents can onboard without CAPTCHAs or human approval. Custom domains are a separate human control plane in the dashboard because they need DNS changes.
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | Homepage: **"Not AI for your email. Email for your AI."** and **"Atomic Mail is an AI-agent-first email service provider (ESP)"** — [atomicmail.ai](https://atomicmail.ai/). GitHub: **"Let your agents read, send, and react to email autonomously, without human involvement"** — [repo](https://github.com/Atomic-Mail/atomic-mail-agentic) |
+| **Agent-specific primitive** | Proof-of-work inbox registration plus a full JMAP mailbox the agent owns. Humans do not get a Gmail-style client as the primary path |
+| **Autonomy-compatible control plane** | PoW signup and JMAP operate without per-message human clicks. Custom-domain DNS remains optional and human-owned |
+| **M2M integration surface** | Homepage-as-onboarding URL, local and hosted MCP, AgentSkill/CLI, REST auth docs, JMAP |
+| **Identity / delegation** | Each inbox is a distinct `@atomicmail.ai` (or verified-domain) address with its own API key stored under `~/.atomicmail/credentials.json`. Custom-domain inboxes are a login, not a second PoW registration |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **PoW registration** | Agent-complete signup that mints an `@atomicmail.ai` inbox without CAPTCHA or credit card |
+| **JMAP mailbox** | Standard RFC 8620/8621 query, fetch, draft, and send in batched method calls |
+| **Presets** | Bundled `send_mail`, `list_inbox`, `reply`, and similar shapes for `jmap_request` |
+| **Help / `_next`** | Embedded recovery docs and suggested next steps inside the integration |
+| **Custom-domain inbox** | Human-verified domain plus API-key connect; same JMAP client |
+
+---
+
+## Autonomy Model
+
+```
+Agent reads https://atomicmail.ai (or uses MCP / AgentSkill)
+    -> register via proof-of-work (or connect with a dashboard API key)
+    -> receive inbox address + credentials
+    -> jmap_request to list, send, reply, search, and manage threads
+    -> help / presets recover if a call shape fails
+    -> optional human dashboard only for custom-domain DNS
+```
+
+---
+
+## Identity and Delegation Model
+
+- **Inbox identity:** The agent owns `username@atomicmail.ai` or a verified-domain address.
+- **Credentials:** API keys live in `~/.atomicmail/credentials.json` with mode `0600`. Separate credential dirs are supported for many agents.
+- **Custom domain:** A human verifies DNS once; the agent then connects with that inbox's API key or OAuth.
+- **No human mailbox proxy:** Autonomous mode does not require a Gmail/Outlook account.
+- **Inbound mail is untrusted:** Official security notes say agents should not execute email instructions without confirmation.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| Homepage onboarding | https://atomicmail.ai/ |
+| Local MCP | `npx -y @atomicmail/mcp` (homepage) or `@atomicmail/mcp-github` (GitHub README) |
+| Hosted MCP | `https://mcp.atomicmail.ai/mcp` |
+| AgentSkill / CLI | `@atomicmail/agent-skill` / `@atomicmail/agent-skill-github` |
+| JMAP | RFC 8620 / 8621 mailbox API |
+| REST auth | Documented in repo `docs/rest-auth.md` |
+
+---
+
+## Human-in-the-Loop Support
+
+Not required for `@atomicmail.ai` signup, send, or receive. The dashboard is a human control plane for custom domains and OAuth account-based access. Official docs warn that inbound mail is untrusted input.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **Gmail / Outlook API** | Tied to a human account, OAuth consent, and anti-bot signup. No agent-owned inbox primitive |
+| **Generic transactional ESP** | Send-only or human-app integration. No PoW agent registration or JMAP mailbox the agent operates |
+| **Human helpdesk inbox** | Shared human mailbox with UI triage, not a first-class agent identity |
+
+---
+
+## Use Cases
+
+- **Agent-owned outreach** — register an inbox and send mail that can receive replies
+- **Support or research loops** — read inbound threads and reply over JMAP without a human mailbox
+- **Newsletter digest** — subscribe a dedicated agent inbox and summarize inbound mail
+- **Headless environments** — use hosted MCP with an inbox API key when local `npx` is unavailable

--- a/services/meeting-and-conversation/README.md
+++ b/services/meeting-and-conversation/README.md
@@ -24,6 +24,7 @@ Agent-native meeting services provide a unified API for bot lifecycle management
 | [Vexa](vexa.md) [![⭐](https://img.shields.io/github/stars/Vexa-ai/vexa?style=social)](https://github.com/Vexa-ai/vexa) | Open-source meeting transcription + interactive bot for Meet/Teams/Zoom | REST API, WebSocket, MCP server (17 tools), self-host | ✅ |
 | [Daily Agent Toolkit](daily-agent.md) [![⭐](https://img.shields.io/github/stars/daily-co/daily-python?style=social)](https://github.com/daily-co/daily-python) | Build realtime meeting agents on Daily | Programmatic room control, media stream hooks, bot orchestration | ⚠️ |
 | [Looped Meet](looped-meet.md) [![⭐](https://img.shields.io/github/stars/loopedautomation/meet?style=social)](https://github.com/loopedautomation/meet) | Self-hostable video meetings with first-class, full-duplex AI agent participants | TTY WebSocket/webhook brain bridge, LiveKit/WebRTC, HTTP routes, cal.com webhook | ❌ |
+| [AgentCall](agentcall.md) [![⭐](https://img.shields.io/github/stars/pattern-ai-labs/agentcall?style=social)](https://github.com/pattern-ai-labs/agentcall) | Your AI agent, in every meeting. | join-meeting Skill, REST/WSS, Meet/Zoom/Teams voice bot | ⚠️ |
 
 
 ---

--- a/services/meeting-and-conversation/agentcall.md
+++ b/services/meeting-and-conversation/agentcall.md
@@ -1,0 +1,156 @@
+# AgentCall
+
+> **"Your AI agent, in every meeting."**
+
+| | |
+|---|---|
+| **Website** | https://agentcall.dev |
+| **Docs** | https://github.com/pattern-ai-labs/agentcall#readme |
+| **GitHub** | https://github.com/pattern-ai-labs/agentcall |
+| **Stars** | [![GitHub Stars](https://img.shields.io/github/stars/pattern-ai-labs/agentcall?style=social)](https://github.com/pattern-ai-labs/agentcall) |
+| **Classification** | `agent-native` |
+| **Category** | [Meeting & Conversation Services](README.md) |
+| **License** | MIT (skill package) |
+| **Latest-month signal** | Last GitHub push 2026-08-10; site and skill install paths live (verified 2026-08-19) |
+| **Verified at** | 2026-08-19 |
+
+---
+
+## Official Website
+
+https://agentcall.dev
+
+Dashboard / API keys: https://app.agentcall.dev
+
+---
+
+## Official Repo
+
+https://github.com/pattern-ai-labs/agentcall
+
+---
+
+## How to Use (Agent Onboarding)
+
+**Interaction pattern:** `Agent Skill` (not an SDK)
+
+Homepage: ask the agent to install `join-meeting` from `github.com/pattern-ai-labs/agentcall`, or:
+
+```text
+/plugin marketplace add pattern-ai-labs/agentcall
+/plugin install join-meeting@agentcall
+```
+
+Other official paths from the README: `openclaw skills install join-meeting`, Cursor `/add-plugin`, Gemini `gemini extensions install https://github.com/pattern-ai-labs/agentcall`, or clone and point the host at `SKILL.md`.
+
+On first run with no key, the skill can register via a one-time email code, or the operator pastes a key from https://app.agentcall.dev/api-keys. Then: *"Join this meeting: https://meet.google.com/…"*.
+
+---
+
+## Agent Skills
+
+**Status:** ✅ Available
+
+The repository *is* the skill (`SKILL.md` + Python/Node bridges). Claude Code plugin name: `join-meeting@agentcall`.
+
+| Skill | What It Teaches the Agent |
+|---|---|
+| `join-meeting` | Join Meet/Zoom/Teams as a voice bot; talk, listen, screenshot, screenshare, chat, leave |
+
+---
+
+## MCP
+
+**Status:** ⚠️ Not published
+
+The machine surface is the skill plus REST/WebSocket at `api.agentcall.dev`. No official MCP server is documented.
+
+Search community skills: `npx clawhub@latest search agentcall`. See: https://agentskills.io/specification
+
+---
+
+## What It Does
+
+AgentCall turns a coding agent into a meeting participant. The bot talks (TTS), listens (live transcripts), can screenshot or screenshare, shows an optional avatar, and keeps the agent's full local context — it can still search code and run commands while in the call. Platforms: Google Meet, Zoom, Microsoft Teams. Distributed as an Agent Skill, not a human-imported client library.
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | Homepage: **"Your AI agent, in every meeting."** README: **"Let any AI agent join and participate in video meetings via voice."** — [agentcall.dev](https://agentcall.dev), [repo](https://github.com/pattern-ai-labs/agentcall) |
+| **Agent-specific primitive** | Meeting as an I/O channel: transcript events in, `tts.speak` / screenshot / screenshare commands out, while the same agent keeps its coding tools |
+| **Autonomy-compatible control plane** | After API key persist (`~/.agentcall/config.json`), "join this URL" is enough. No human operates a Zoom client for the bot |
+| **M2M integration surface** | Skill + REST/WSS (`ak_ac_` keys) at `api.agentcall.dev` |
+| **Identity / delegation** | Bot joins as the AgentCall participant; key is per operator account (skill can create the account). Events/commands are call-scoped. Not a KYA token for the human attendees |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **Join-meeting skill** | Host-native install; subprocess + stdout protocol |
+| **Call events** | `transcript.final`, participant join/leave, `tts.done` / interrupted, `call.bot_ready`, `call.ended` |
+| **Call commands** | `tts.speak`, chat, screenshot, webpage/avatar, screenshare, leave |
+| **Modes** | `audio`, `webpage-av`, `webpage-av-screenshare` |
+| **Voice strategies** | `direct` TTS vs `collaborative` GetSun timing |
+
+---
+
+## Autonomy Model
+
+```
+Install join-meeting skill
+    -> first run: skill registers or stores API key
+    -> agent is told a meeting URL
+    -> bot joins; transcripts stream to the agent
+    -> agent speaks, chats, screenshots, or presents without a human driving the client
+    -> leave / call.ended
+```
+
+---
+
+## Identity and Delegation Model
+
+- **Account key:** `ak_ac_` prefix, stored at `~/.agentcall/config.json`.
+- **Bot presence:** The meeting sees the AgentCall bot, not the human's personal Zoom identity (beyond whatever the platform requires to inject a bot).
+- **Session:** Crash recovery reconnects to an active call after agent restart.
+- **Billing identity:** Operator account / plan; per-minute usage.
+- **No attendee OAuth delegation product** beyond joining the meeting.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| Skill / plugin | `join-meeting@agentcall`, OpenClaw, Gemini extension, raw `SKILL.md` |
+| REST + WebSocket | `api.agentcall.dev` |
+| Dashboard | https://app.agentcall.dev |
+
+---
+
+## Human-in-the-Loop Support
+
+A human supplies the meeting URL (and sometimes the first API key / email code). During the call the agent is the participant. Collaborative mode uses GetSun for group timing; that is conversation intelligence, not an approval gate.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **Human Zoom/Meet client** | A person must join and operate the UI |
+| **Record-only meeting bot** | Transcripts after the fact; the coding agent is not a live speaker |
+| **Generic WebRTC SDK** | You still build join, VAD, barge-in, and host skill wiring |
+
+---
+
+## Use Cases
+
+- **Coding companion in standup** — talk about the repo while staying in the agent session
+- **Support or training calls** — avatar + screenshare modes
+- **Note-taking with voice replies** — audio-only mode
+- **Crash-safe long calls** — reconnect after the agent restarts

--- a/services/memory-and-state/README.md
+++ b/services/memory-and-state/README.md
@@ -39,6 +39,8 @@ Agent-native memory services solve this by providing:
 | [MemMachine](memmachine.md) [![⭐](https://img.shields.io/github/stars/MemMachine/MemMachine?style=social)](https://github.com/MemMachine/MemMachine) | Universal memory layer — episodic graph + profile SQL + working memory | Python SDK, LangChain/CrewAI adapters, REST API | ⚠️ |
 | [Cognee](cognee.md) [![⭐](https://img.shields.io/github/stars/topoteretes/cognee?style=social)](https://github.com/topoteretes/cognee) | Memory control plane for AI agents — managed world model with auto ontology | Python SDK, 28+ connectors, MCP server, framework adapters | ✅ |
 | [Hindsight](hindsight.md) [![⭐](https://img.shields.io/github/stars/vectorize-io/hindsight?style=social)](https://github.com/vectorize-io/hindsight) | Agent Memory That Learns | Python SDK, open-source memory service, cookbook examples | ⚠️ |
+| [agentmemory](agentmemory.md) [![⭐](https://img.shields.io/github/stars/rohitg00/agentmemory?style=social)](https://github.com/rohitg00/agentmemory) | Your coding agent remembers everything. No more re-explaining. | Local memory server, MCP, Skills, INSTALL_FOR_AGENTS.md | ✅ |
+| [TencentDB Agent Memory](tencentdb-agent-memory.md) [![⭐](https://img.shields.io/github/stars/TencentCloud/TencentDB-Agent-Memory?style=social)](https://github.com/TencentCloud/TencentDB-Agent-Memory) | Agents remember,Humans innovate. | OpenClaw plugin, Hermes Gateway, layered + symbolic memory | ⚠️ |
 
 
 

--- a/services/memory-and-state/agentmemory.md
+++ b/services/memory-and-state/agentmemory.md
@@ -1,0 +1,168 @@
+# agentmemory
+
+> **"Your coding agent remembers everything. No more re-explaining."**
+
+| | |
+|---|---|
+| **Website** | https://agent-memory.dev |
+| **Docs** | https://github.com/rohitg00/agentmemory#readme |
+| **GitHub** | https://github.com/rohitg00/agentmemory |
+| **Stars** | [![GitHub Stars](https://img.shields.io/github/stars/rohitg00/agentmemory?style=social)](https://github.com/rohitg00/agentmemory) |
+| **Classification** | `agent-native` |
+| **Category** | [Memory & State Services](README.md) |
+| **License** | Apache-2.0 |
+| **Latest-month signal** | Last GitHub push 2026-08-17 (verified 2026-08-19) |
+| **Verified at** | 2026-08-19 |
+
+---
+
+## Official Website
+
+https://agent-memory.dev
+
+---
+
+## Official Repo
+
+https://github.com/rohitg00/agentmemory
+
+---
+
+## ⭐ How to Use (Agent Onboarding)
+
+**Interaction pattern:** `URL Onboarding` ⭐ + local memory server + MCP + Skills
+
+Official README one-instruction path for a coding agent:
+
+```text
+Retrieve and follow the instructions at: https://raw.githubusercontent.com/rohitg00/agentmemory/main/INSTALL_FOR_AGENTS.md
+```
+
+Direct install:
+
+```bash
+npx @agentmemory/agentmemory
+agentmemory demo --serve
+npx skills add rohitg00/agentmemory -y
+```
+
+The first run starts the memory server (default `:3111`). `agentmemory connect <agent>` wires additional hosts. Health check documented as `curl http://localhost:3111/agentmemory/health`.
+
+---
+
+## Agent Skills
+
+**Status:** ✅ Available
+
+```bash
+npx skills add rohitg00/agentmemory -y
+```
+
+The README documents 17 skills: 9 invocable (`remember`, `recall`, `recap`, `handoff`, `forget`, `lesson`, `commit-context`, `commit-history`, `session-history`) and 8 reference skills (discipline, MCP tools, REST, config, agents, hooks, architecture, skill-authoring).
+
+Claude Code can also `/plugin marketplace add rohitg00/agentmemory` then `/plugin install agentmemory`.
+
+---
+
+## MCP
+
+**Status:** ✅ Available
+
+| Detail | Value |
+|---|---|
+| **MCP Repo** | https://github.com/rohitg00/agentmemory (`@agentmemory/mcp`) |
+| **Transport** | stdio proxy to the local (or remote) memory server |
+| **Compatible Clients** | Claude Code, Codex, Cursor, Gemini CLI, OpenClaw, Hermes, OpenCode, Cline, Goose, and any MCP client |
+
+README: plugin path auto-wires `@agentmemory/mcp` with on the order of 54 tools when the server is up (`memory_smart_search`, `memory_save`, `memory_sessions`, `memory_governance_delete`, and others). Without a reachable server the shim falls back to a smaller local tool set.
+
+---
+
+## What It Does
+
+agentmemory is a local-first persistent memory layer for coding agents. One memory server is shared across Claude Code, Codex, Cursor, and other MCP clients. It extends an LLM-wiki style store with confidence, lifecycle, knowledge graphs, and hybrid search (built on a pinned iii-engine). Agents save, recall, hand off, and forget through hooks, MCP, REST, and skills instead of re-pasting project lore every session.
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | README: **"Your coding agent remembers everything. No more re-explaining."** / **"Persistent memory for Claude Code, GitHub Copilot CLI, Cursor, … and any MCP client."** — [rohitg00/agentmemory](https://github.com/rohitg00/agentmemory) |
+| **Agent-specific primitive** | Shared memory server with smart search, session memory, governance delete, handoff, and hook-injected recall — not a generic vector DB API |
+| **Autonomy-compatible control plane** | After install, hooks and MCP run without a human choosing what to embed each turn |
+| **M2M integration surface** | INSTALL_FOR_AGENTS.md URL, CLI, REST on `:3111`, `@agentmemory/mcp`, Skills, plugins |
+| **Identity / delegation** | Memories are scoped through the memory server and agent adapters; governance delete and leases/signals are documented. Optional `AGENTMEMORY_URL` + `AGENTMEMORY_SECRET` for protected/remote deployments |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **Memory server** | Local HTTP service (default `:3111`) shared by all wired agents |
+| **Smart search / save** | MCP/REST recall and persist |
+| **Lifecycle hooks** | Host-specific observe/inject so recall happens without a prompt |
+| **Handoff / lesson** | Explicit skills for transferring or extracting durable notes |
+| **Governance delete** | Controlled forgetting |
+| **Viewer** | Optional local UI (README mentions `:3113`) |
+
+---
+
+## Autonomy Model
+
+```
+Agent follows INSTALL_FOR_AGENTS.md or npx @agentmemory/agentmemory
+    -> memory server starts
+    -> connect / plugin / MCP wires the host
+    -> hooks capture and inject memory across turns
+    -> agent calls recall/remember via MCP or skills
+    -> memories persist across sessions
+```
+
+---
+
+## Identity and Delegation Model
+
+- **Shared store:** One server, many agent adapters.
+- **Remote lock:** `AGENTMEMORY_URL` and `AGENTMEMORY_SECRET` for protected deployments.
+- **Governance:** Dedicated delete/governance tools rather than silent overwrite-only.
+- **No cloud user OAuth product:** Default is local; Windows native connect is documented as limited (WSL2 preferred).
+- **Engine pin:** Ships a pinned iii-engine; will not attach to a mismatched local `iii`.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| CLI | `npx @agentmemory/agentmemory`, `agentmemory connect`, `demo` |
+| REST | `http://localhost:3111` |
+| MCP | `@agentmemory/mcp` stdio |
+| Skills | `npx skills add rohitg00/agentmemory -y` |
+| Onboarding URL | `INSTALL_FOR_AGENTS.md` |
+
+---
+
+## Human-in-the-Loop Support
+
+First-run installer can be interactive (pick agents and an LLM provider, or stay keyless). After that, memory I/O is autonomous. Governance delete is an explicit agent/operator action.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **Raw vector database** | Agent must decide extract/update/evict; no coding-agent hooks or shared MCP tool surface |
+| **Chat product memory** | Locked to one vendor chat UI |
+| **Notes file in the repo** | No hybrid search, lifecycle, or cross-harness server |
+
+---
+
+## Use Cases
+
+- **Stop re-explaining** a codebase's conventions every session
+- **Handoff** between Claude Code and Codex on the same memory server
+- **Lesson extraction** after a debugging arc
+- **Remote/protected memory** with URL + secret

--- a/services/memory-and-state/tencentdb-agent-memory.md
+++ b/services/memory-and-state/tencentdb-agent-memory.md
@@ -1,0 +1,162 @@
+# TencentDB Agent Memory
+
+> **"Agents remember,Humans innovate."**
+
+| | |
+|---|---|
+| **Website** | https://github.com/TencentCloud/TencentDB-Agent-Memory |
+| **Docs** | https://github.com/TencentCloud/TencentDB-Agent-Memory#readme |
+| **GitHub** | https://github.com/TencentCloud/TencentDB-Agent-Memory |
+| **Stars** | [![GitHub Stars](https://img.shields.io/github/stars/TencentCloud/TencentDB-Agent-Memory?style=social)](https://github.com/TencentCloud/TencentDB-Agent-Memory) |
+| **Classification** | `agent-native` |
+| **Category** | [Memory & State Services](README.md) |
+| **License** | MIT (LICENSE file; GitHub SPDX shows `NOASSERTION`) |
+| **Latest-month signal** | Default branch `feat/server_team`; last push 2026-08-15 (verified 2026-08-19) |
+| **Verified at** | 2026-08-19 |
+
+---
+
+## Official Website
+
+No separate product homepage was published as of 2026-08-19. The official home is the repository:
+
+https://github.com/TencentCloud/TencentDB-Agent-Memory
+
+---
+
+## Official Repo
+
+https://github.com/TencentCloud/TencentDB-Agent-Memory
+
+---
+
+## How to Use (Agent Onboarding)
+
+**Interaction pattern:** `OpenClaw plugin` or **Hermes gateway plugin**
+
+OpenClaw:
+
+```bash
+openclaw plugins install @tencentdb-agent-memory/memory-tencentdb
+openclaw gateway restart
+```
+
+Enable in `~/.openclaw/openclaw.json`:
+
+```jsonc
+{
+  "memory-tencentdb": {
+    "enabled": true
+  }
+}
+```
+
+Default backend is local `SQLite + sqlite-vec`. Optional short-term offload (plugin ≥ 0.3.4) uses `offload.enabled` plus an OpenClaw `contextEngine` slot and a one-time `after-tool-call` patch script documented in the README.
+
+Hermes: follow README section 2 (Docker one-command or attach `memory_tencentdb` into an existing Hermes plugin directory). The Hermes Gateway default listen port in the README is `:8420`.
+
+---
+
+## Agent Skills
+
+**Status:** ⚠️ Not published as `npx skills add`
+
+Memory is a host plugin (OpenClaw / Hermes), not a portable Agent Skills package. The architecture discusses generating Skills from traces as a layering idea; that is not the same as a published `SKILL.md` installer.
+
+Search community skills: `npx clawhub@latest search tencentdb-agent-memory`. See: https://agentskills.io/specification
+
+---
+
+## MCP
+
+**Status:** ⚠️ Not published as a standalone MCP server
+
+Integration is the OpenClaw plugin and Hermes Gateway HTTP adapters (capture / search / recall). No official stdio MCP package is documented in the README.
+
+---
+
+## What It Does
+
+TencentDB Agent Memory is a layered memory system for long-horizon agents. Short-term memory offloads verbose tool logs and keeps a compact Mermaid symbol graph with `node_id` drill-down to raw `refs/*.md`. Long-term memory builds L0 conversation → L1 atoms → L2 scenarios → L3 persona instead of a flat vector pile. GitHub description also frames a team hub of Chat Memory, Skill, LLM-Wiki, and Code-Graph assets. Official README quotes relative OpenClaw benchmark deltas (WideSearch, SWE-bench, AA-LCR, PersonaMem); treat those as upstream-reported, not independently re-measured here.
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | README: **"Agents remember,Humans innovate."** and **"TencentDB Agent Memory = symbolic short-term memory + layered long-term memory."** GitHub: **"team-level memory hub for AI Agents"** — [repo](https://github.com/TencentCloud/TencentDB-Agent-Memory) |
+| **Agent-specific primitive** | Mermaid canvas + `node_id` recovery, and L0–L3 persona layering — not a generic embedding table |
+| **Autonomy-compatible control plane** | Once enabled, capture, extract, scene aggregation, persona, and pre-turn recall run automatically |
+| **M2M integration surface** | OpenClaw plugin, Hermes Gateway HTTP, npm package `@tencentdb-agent-memory/memory-tencentdb` |
+| **Identity / delegation** | Layered assets (persona/scene/atom) with drill-down to raw evidence. Team-hub description implies shared governed assets across agents. Optional Hermes gateway auth is off by default |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **Symbolic short-term canvas** | Mermaid task map in context; full logs offloaded |
+| **`node_id` trace** | Agent greps an id to recover raw tool output |
+| **L0–L3 long-term pyramid** | Conversation → atom → scenario → persona |
+| **Heterogeneous storage** | DB/full-text at the bottom; Markdown at the top |
+| **OpenClaw / Hermes adapters** | Host-native capture and recall |
+
+---
+
+## Autonomy Model
+
+```
+Install OpenClaw or Hermes plugin and enable memory-tencentdb
+    -> conversations and tool traces are captured
+    -> layers distill atoms/scenes/persona (and optional offload)
+    -> next turn receives compact structure, not the full log
+    -> agent drills down via node_id when it must verify
+```
+
+---
+
+## Identity and Delegation Model
+
+- **Host identity:** Memory is attached to the OpenClaw/Hermes runtime you configure.
+- **Traceability:** Official design keeps a path from persona/canvas back to raw L0 / refs.
+- **Gateway auth:** Hermes can require tokens; both switches default off.
+- **Team hub:** Repository description mentions governed, shared assets across agents/frameworks.
+- **No separate KYA token.**
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| npm plugin | `@tencentdb-agent-memory/memory-tencentdb` |
+| OpenClaw | `openclaw plugins install …` |
+| Hermes Gateway | HTTP capture/search/recall (example `:8420`) |
+| Local store | SQLite + sqlite-vec by default |
+
+---
+
+## Human-in-the-Loop Support
+
+Positioning is that humans stop repeating SOPs. No approval gate is required for recall. Operators enable the plugin and optional offload/auth.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **Flat vector memory** | Official design rejects fragment-only stores without a persona/scene pyramid |
+| **Keep full tool logs in context** | Token blow-up; no `node_id` offload |
+| **Chat-vendor memory** | Locked to one consumer chat product, not OpenClaw/Hermes agents |
+
+---
+
+## Use Cases
+
+- **Long-horizon coding or search sessions** — keep a symbol map instead of megatokens of logs
+- **Persona continuity** — preferences survive across conversations
+- **Team memory hub** — shared chat/skill/wiki/code-graph assets (per GitHub description)
+- **Hermes or OpenClaw runtimes** — native plugin install paths

--- a/services/oversight-and-approval/README.md
+++ b/services/oversight-and-approval/README.md
@@ -21,6 +21,7 @@ No general-purpose approval workflow (Jira tickets, email threads, ServiceNow) w
 | [Sondera Coding Agent Hooks](sondera-coding-agent-hooks.md) [![⭐](https://img.shields.io/github/stars/sondera-ai/sondera-coding-agent-hooks?style=social)](https://github.com/sondera-ai/sondera-coding-agent-hooks) | A reference monitor for AI coding agents | Rust hooks, Cedar policies, shell/file/web-request interception | ⚠️ |
 | [HumanLayer](humanlayer.md) | Human in the Loop for AI Agents | Python SDK, TypeScript SDK, REST API, Webhooks | ✅ |
 | [Sallyport](sallyport.md) [![⭐](https://img.shields.io/github/stars/OlegSotnikov/sallyport?style=social)](https://github.com/OlegSotnikov/sallyport) | Let your agent touch prod. Keep the keys. | MCP gate, HTTP/SSH execution, session/per-call approval, signed audit journal | ✅ |
+| [Preloop](preloop.md) [![⭐](https://img.shields.io/github/stars/preloop/preloop?style=social)](https://github.com/preloop/preloop) | The Open Source Control Plane for AI Agents | MCP firewall, CEL approvals, model gateway, session audit, CLI discover | ✅ |
 
 
 ---

--- a/services/oversight-and-approval/preloop.md
+++ b/services/oversight-and-approval/preloop.md
@@ -1,0 +1,168 @@
+# Preloop
+
+> **"The Open Source Control Plane for AI Agents"**
+
+| | |
+|---|---|
+| **Website** | https://preloop.ai |
+| **Docs** | https://docs.preloop.ai |
+| **GitHub** | https://github.com/preloop/preloop |
+| **Stars** | [![GitHub Stars](https://img.shields.io/github/stars/preloop/preloop?style=social)](https://github.com/preloop/preloop) |
+| **Classification** | `agent-native` |
+| **Category** | [Oversight & Approval Services](README.md) |
+| **License** | Apache-2.0 |
+| **Latest-month signal** | Last GitHub push 2026-08-18; CLI install and docs live (verified 2026-08-19) |
+| **Verified at** | 2026-08-19 |
+
+---
+
+## Official Website
+
+https://preloop.ai
+
+---
+
+## Official Repo
+
+https://github.com/preloop/preloop
+
+---
+
+## How to Use (Agent Onboarding)
+
+**Interaction pattern:** `CLI` that rewrites local agents onto the control plane
+
+```bash
+curl -fsSL https://preloop.ai/install/cli | sh
+preloop signup
+# or: preloop login --url http://localhost:3000
+preloop agents discover
+```
+
+`preloop agents discover` finds local Claude Code, Codex CLI, Cursor, Gemini CLI, Hermes, OpenClaw, OpenCode, and other MCP-compatible configs, mints a managed credential, and rewrites supported agents to route tools through the Preloop MCP Firewall and models through the Preloop Gateway.
+
+For live Agent Control on OpenClaw or Hermes, the CLI still needs the runtime plugin:
+
+```bash
+preloop agents onboard openclaw
+preloop agents install-plugin openclaw
+preloop agents validate openclaw
+```
+
+Native coding-agent tools (for example Claude Code `Bash`/`Edit`) can be routed with `preloop agents onboard --approvals`.
+
+---
+
+## Agent Skills
+
+**Status:** ⚠️ Not published as a standard `SKILL.md` package
+
+Onboarding is the CLI plus optional runtime plugins, not `npx skills add`.
+
+Search community skills: `npx clawhub@latest search preloop`. See: https://agentskills.io/specification
+
+---
+
+## MCP
+
+**Status:** ✅ Available (firewall / managed MCP)
+
+| Detail | Value |
+|---|---|
+| **MCP Repo** | https://github.com/preloop/preloop |
+| **Transport** | Preloop-managed MCP URLs after discover/onboard; agents keep speaking MCP |
+| **Compatible Clients** | OpenClaw, Claude Code, Codex CLI, Cursor, Gemini CLI, Hermes, OpenCode, Windsurf, and other MCP-compatible agents |
+
+Preloop is the policy plane in front of existing MCP servers, not a single-tool server. It also exposes built-in tools such as `ask_user` and an opt-in Claude Code `permission_prompt` tool.
+
+---
+
+## What It Does
+
+Preloop is a self-hostable (or Preloop Cloud) control plane for agents that already exist on a machine. It unifies an MCP firewall (allow / deny / require approval / require justification with YAML + CEL), an OpenAI- and Anthropic-compatible model gateway with budgets and attribution, human approvals (mobile, watch, Slack, Mattermost, email, webhook), runtime session timelines, and audit evidence.
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | Homepage: **"The Open Source Control Plane for AI Agents"** / **"Preloop is the open-source AI agent control plane."** — [preloop.ai](https://preloop.ai), [README](https://github.com/preloop/preloop) |
+| **Agent-specific primitive** | Policy-gated tool calls with denial or approval injected back to the agent, plus `ask_user` and session-attributed audit — not a generic ticket queue |
+| **Autonomy-compatible control plane** | Allowed tools run without a click. Only policy-selected actions pause. Async approval lets the agent poll instead of blocking the transport |
+| **M2M integration surface** | CLI, MCP firewall URLs, OpenAI/Anthropic-compatible gateway, REST (`GET /api/v1/flows/executions/{id}/result`, control WebSocket) |
+| **Identity / delegation** | Discover/onboard mints a durable runtime credential. Every tool/model/policy/approval event is attributed to the managed agent/session |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **MCP firewall** | CEL/YAML allow, deny, approve, justify on MCP and selected native tools |
+| **Human approval** | Mobile/watch/Slack/Mattermost/email/webhook with full call context |
+| **`ask_user`** | Agent-initiated multiple-choice or free-text question to the operator |
+| **Model gateway** | Budgeted OpenAI/Anthropic-compatible proxy; provider keys stay in Preloop |
+| **Runtime session** | Timeline of tools, models, policy, spend, and outcome |
+| **Audit / AI Act evidence** | Durable logs with matched policy, approver, inputs, timestamps |
+
+---
+
+## Autonomy Model
+
+```
+Operator installs CLI and connects Cloud or self-host
+    -> preloop agents discover / onboard
+    -> agent continues its normal loop
+    -> tool and model traffic hit Preloop
+    -> policy: allow | deny (message back to agent) | require approval
+    -> agent may ask_user or poll async approval
+    -> session timeline and audit store the decision
+```
+
+---
+
+## Identity and Delegation Model
+
+- **Runtime credential:** Onboarding mints a durable token and can write `preloop.control`.
+- **Secret custody:** Provider API keys stay in Preloop; agents receive short-lived gateway tokens.
+- **Attribution:** Usage ledger ties tokens and cost to the runtime principal.
+- **Approver identity:** Audit records who approved or denied.
+- **Plugin boundary:** Live Talk/Agent Control needs the OpenClaw/Hermes plugin WebSocket; the CLI alone does not keep an unmodified agent online.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| CLI | `preloop signup`, `login`, `agents discover`, `onboard`, `install-plugin`, `validate` |
+| MCP firewall | Managed MCP endpoints after rewrite |
+| Model gateway | `/openai/v1/…`, `/anthropic/v1/messages` |
+| Control WS | `WS /api/v1/agents/control/ws` |
+| REST | Flow execution results, security-screen score, session APIs |
+
+---
+
+## Human-in-the-Loop Support
+
+This is the product. Policy can require approval or justification; `ask_user` is a first-class tool. Async mode avoids breaking transport hooks during long reviews. Allowed actions stay non-blocking.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **Jira / email approval** | Human-initiated tickets; no agent-context denial or MCP intercept |
+| **Model-only gateway** | Tracks spend but does not pause a tool call for a human and return the decision |
+| **Log-only MCP proxy** | Observes calls; does not enforce CEL approve/deny with an audit trail |
+
+---
+
+## Use Cases
+
+- **Govern existing coding agents** — discover local Claude Code / Codex / Cursor and wrap their tools
+- **Production-dangerous commands** — require approval for deploy or `Bash` that touches prod
+- **Budgeted model access** — keep provider keys off the agent host
+- **EU AI Act evidence** — retain policy, approver, and outcome (not a legal compliance guarantee)

--- a/services/search-and-web-intelligence/README.md
+++ b/services/search-and-web-intelligence/README.md
@@ -28,6 +28,7 @@ The services in this category were designed with these requirements as the prima
 | [Jina Reader](jina-reader.md) [![⭐](https://img.shields.io/github/stars/jina-ai/reader?style=social)](https://github.com/jina-ai/reader) | URL and search results as LLM-friendly text | `r.jina.ai` / `s.jina.ai` · MCP · PDF & image handling | ✅ |
 | [Linkup](linkup.md) [![⭐](https://img.shields.io/github/stars/LinkupPlatform/linkup-python-sdk?style=social)](https://github.com/LinkupPlatform/linkup-python-sdk) | Search API for AI agents and LLM apps | LLM-oriented search, structured retrieval, citation-ready outputs | ⚠️ |
 | [NotHumanSearch](nothumansearch.md) | Agent-first search — the index of services designed for AI, not humans | REST API · OpenAPI 3.0 · MCP (`ai.nothumansearch/search`) · `llms.txt` onboarding | ✅ |
+| [Agent Search MCP](agent-search-mcp.md) [![⭐](https://img.shields.io/github/stars/lennney/agent-search-mcp?style=social)](https://github.com/lennney/agent-search-mcp) | Free-first Chinese and English web search with inspectable evidence | MCP stdio/HTTP, `fasm` CLI, evidence packet, Agent Skill | ✅ |
 
 
 ---

--- a/services/search-and-web-intelligence/agent-search-mcp.md
+++ b/services/search-and-web-intelligence/agent-search-mcp.md
@@ -1,0 +1,170 @@
+# Agent Search MCP
+
+> **"A Node.js MCP server and CLI for English and Chinese web search."**
+
+| | |
+|---|---|
+| **Website** | https://take-a-deep-breath0.com/en/agent-search-mcp |
+| **Docs** | https://github.com/lennney/agent-search-mcp#readme |
+| **GitHub** | https://github.com/lennney/agent-search-mcp |
+| **Stars** | [![GitHub Stars](https://img.shields.io/github/stars/lennney/agent-search-mcp?style=social)](https://github.com/lennney/agent-search-mcp) |
+| **Classification** | `agent-native` |
+| **Category** | [Search & Web Intelligence Services](README.md) |
+| **License** | Apache-2.0 |
+| **Latest-month signal** | Last GitHub push 2026-08-17 (verified 2026-08-19) |
+| **Verified at** | 2026-08-19 |
+
+---
+
+## Official Website
+
+https://take-a-deep-breath0.com/en/agent-search-mcp
+
+---
+
+## Official Repo
+
+https://github.com/lennney/agent-search-mcp
+
+---
+
+## How to Use (Agent Onboarding)
+
+**Interaction pattern:** `MCP` (stdio) + optional **Agent Skill** + `fasm` CLI
+
+```json
+{
+  "mcpServers": {
+    "agent-search": {
+      "command": "npx",
+      "args": ["-y", "agent-search-mcp"]
+    }
+  }
+}
+```
+
+```bash
+npx -y agent-search-mcp
+npx skills add lennney/agent-search-mcp --skill agent-search
+```
+
+No API key is required for the default free-first runtime. HTTP mode requires `HTTP_AUTH_TOKEN` unless `HTTP_ALLOW_UNAUTHENTICATED=true`.
+
+---
+
+## Agent Skills
+
+**Status:** ✅ Available
+
+```bash
+npx skills add lennney/agent-search-mcp --skill agent-search
+```
+
+| Skill | What It Teaches the Agent |
+|---|---|
+| `agent-search` | Choose a bounded path (quick discovery, stricter verification, Chinese-source search, or URL extract); check the MCP tool exists; ask before install/config changes |
+
+Installing the Skill does not start the MCP server.
+
+---
+
+## MCP
+
+**Status:** ✅ Available
+
+| Detail | Value |
+|---|---|
+| **MCP Repo** | https://github.com/lennney/agent-search-mcp |
+| **Transport** | stdio (default) or Streamable HTTP |
+| **Compatible Clients** | Claude Desktop, Cursor, VS Code, Windsurf, Claude Code, Codex |
+
+Tools include `free_search`, `free_search_advanced`, `free_extract`, `fetch_github_readme`, `fetch_csdn_article`, `fetch_juejin_article`, and `search_with_synthesis`. All documented as read-only and idempotent.
+
+---
+
+## What It Does
+
+Agent Search MCP is a Node.js search runtime that starts without an API key. It fans out to zero-key engines (and optional paid providers only when policy and credentials allow), then returns a Search Evidence Packet: results plus `meta.execution`, quality-gate `stop_reason`, budgets, and `partialFailures`. Compact mode bounds tokens while keeping provenance. Chinese queries can use Sogou/Baidu without a translation layer.
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | README title: **"Agent Search MCP: Free-first Web Search with Inspectable Evidence"** and **"A Node.js MCP server and CLI for English and Chinese web search."** — [repo](https://github.com/lennney/agent-search-mcp) |
+| **Agent-specific primitive** | Evidence packet with independent `source_count`, visible `partialFailures`, and a quality-gate `stop_reason` — not a silent SERP scrape |
+| **Autonomy-compatible control plane** | Default `free_first` policy never spends a configured key. Agent can search/extract without a human picking engines per query |
+| **M2M integration surface** | MCP stdio/HTTP, `fasm` CLI, published Skill |
+| **Identity / delegation** | HTTP deployments use `HTTP_AUTH_TOKEN`. Engine/tool allowlists are env policy. No per-end-user OAuth product; this is search infrastructure |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **Search Evidence Packet** | Results + execution meta + failures, kept separate |
+| **Provider policy** | `free_first`, `free_only`, `quality_escalation`, `paid_first` |
+| **Request / evidence budgets** | Caps on adapter calls, time, results, and evidence characters |
+| **`source_count`** | Independent provider families, not adapter aliases |
+| **`fasm` CLI** | `search`, `extract`, `doctor` |
+
+---
+
+## Autonomy Model
+
+```
+Add npx -y agent-search-mcp to the MCP host
+    -> agent calls free_search or related tools
+    -> router runs zero-key sources (and paid only if policy allows)
+    -> quality gate stops and records stop_reason
+    -> failures stay in partialFailures
+    -> compact evidence returns to the agent
+```
+
+---
+
+## Identity and Delegation Model
+
+- **No search-user identity:** Default local stdio has no account.
+- **HTTP token:** Required unless explicitly unauthenticated.
+- **Spend policy:** Keys in env do not authorize paid traffic until `SEARCH_PROVIDER_MODE` says so.
+- **Allowlists:** `ENABLED_TOOLS` / `ALLOWED_ENGINES` (deny wins).
+- **Doctor:** `fasm doctor` never prints credentials or proxy secrets.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| MCP stdio | `npx -y agent-search-mcp` |
+| MCP HTTP | `MODE=http` + `HTTP_AUTH_TOKEN` |
+| CLI | `fasm search`, `extract`, `doctor` |
+| Skill | `npx skills add lennney/agent-search-mcp --skill agent-search` |
+
+---
+
+## Human-in-the-Loop Support
+
+The Skill asks before install or configuration changes. Search itself is autonomous. Optional paid providers need a human-supplied key and an explicit policy.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **Human SERP API** | Blue links for eyes; no evidence packet or failure visibility |
+| **Silent multi-engine wrapper** | Drops failed providers; inflates source counts by adapter name |
+| **Single paid agent search** | Requires a key up front; no free-first policy or budget contract |
+
+---
+
+## Use Cases
+
+- **Keyless web search** from an MCP host
+- **Claim verification** with inspectable evidence and stop reasons
+- **Chinese-source search** without translating the query first
+- **Token-bounded retrieval** via compact evidence budgets

--- a/services/tool-access-and-integration/README.md
+++ b/services/tool-access-and-integration/README.md
@@ -31,6 +31,7 @@ Agent-native tool access services solve all three problems with primitives that 
 | [Obot](obot.md) [![⭐](https://img.shields.io/github/stars/obot-platform/obot?style=social)](https://github.com/obot-platform/obot) | Complete MCP Platform — Hosting, Registry, Gateway, Chat Client | MCP (Streamable HTTP), REST admin API, OAuth 2.1, Helm chart | ✅ |
 | [Snyk Agent Scan](snyk-agent-scan.md) [![⭐](https://img.shields.io/github/stars/snyk/agent-scan?style=social)](https://github.com/snyk/agent-scan) | Security scanner for AI agents, MCP servers and agent skills | CLI, MCP config inspection, CI scan output | ✅ |
 | [OpenChatCut](openchatcut.md) [![⭐](https://img.shields.io/github/stars/0xsline/OpenChatCut?style=social)](https://github.com/0xsline/OpenChatCut) | Local-first agent-native video editor with real editable timelines | Agent Skill, Streamable HTTP MCP, isolated draft sessions, EditorCore tools | ✅ |
+| [Toolport](toolport.md) [![⭐](https://img.shields.io/github/stars/tsouth89/toolport?style=social)](https://github.com/tsouth89/toolport) | Every tool. One port. | stdio `toolport-gateway`, lazy meta-tools, per-client profiles, OS keychain | ✅ |
 
 
 

--- a/services/tool-access-and-integration/toolport.md
+++ b/services/tool-access-and-integration/toolport.md
@@ -1,0 +1,162 @@
+# Toolport
+
+> **"Every tool. One port."**
+
+| | |
+|---|---|
+| **Website** | https://toolport.app |
+| **Docs** | https://github.com/tsouth89/toolport#readme |
+| **GitHub** | https://github.com/tsouth89/toolport |
+| **Stars** | [![GitHub Stars](https://img.shields.io/github/stars/tsouth89/toolport?style=social)](https://github.com/tsouth89/toolport) |
+| **Classification** | `agent-native` |
+| **Category** | [Tool Access & Integration Services](README.md) |
+| **License** | MIT |
+| **Latest-month signal** | Last GitHub push 2026-08-19 (verified the same day) |
+| **Verified at** | 2026-08-19 |
+
+---
+
+## Official Website
+
+https://toolport.app
+
+---
+
+## Official Repo
+
+https://github.com/tsouth89/toolport
+
+---
+
+## How to Use (Agent Onboarding)
+
+**Interaction pattern:** `local MCP gateway` (stdio) after a one-time desktop install
+
+1. Download the installer from https://github.com/tsouth89/toolport/releases/latest
+2. Add MCP servers in the app (catalog, MCP Registry, or pasted client snippets)
+3. Connect each AI client so it launches `toolport-gateway` over stdio
+
+Once connected, the agent talks only to Toolport. In lazy-discovery mode it sees compact meta-tools instead of every downstream schema:
+
+- `toolport_status`
+- `toolport_search_tools`
+- `toolport_call_tool`
+- `toolport_fetch_result`
+
+Optional tools appear when the matching feature is on (`toolport_confirm`, enable/disable, `toolport_run_script`, saved routines).
+
+---
+
+## Agent Skills
+
+**Status:** ⚠️ Not published as a `SKILL.md` package
+
+Toolport can write a marked block into each client's agent-rules file (`AGENTS.md`, `GEMINI.md`, and similar). That is host rules sync, not an Agent Skills package.
+
+Search community skills: `npx clawhub@latest search toolport`. See: https://agentskills.io/specification
+
+---
+
+## MCP
+
+**Status:** ✅ Available (gateway)
+
+| Detail | Value |
+|---|---|
+| **MCP Repo** | https://github.com/tsouth89/toolport |
+| **Transport** | stdio (`toolport-gateway`); downstream servers may be stdio or remote HTTP/SSE |
+| **Compatible Clients** | Official README lists auto-detect/connect for 34 clients including Claude Desktop, Claude Code, Cursor, VS Code, Codex, Gemini CLI, Windsurf, OpenCode, and others |
+
+Toolport is the MCP front door: clients do not load every downstream tool into context.
+
+---
+
+## What It Does
+
+Toolport is a local-first MCP gateway. A human (or installer) authenticates each server once. Every AI client then points at one gateway and shares that catalog. Lazy discovery replaces thousands of tool-definition tokens with a handful of meta-tools the agent searches on demand. The same path fingerprints tool schemas (rug-pull / poisoning), marks untrusted returned content, and can pause destructive calls for human approval.
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | README: **"One local gateway for all your MCP servers, shared by every AI client"** and **"Every tool. One port."** — [repo](https://github.com/tsouth89/toolport) |
+| **Agent-specific primitive** | Lazy-discovery meta-tools (`toolport_search_tools` / `toolport_call_tool`) plus per-client server profiles so a coding agent cannot see a billing server |
+| **Autonomy-compatible control plane** | After connect, the agent searches and calls tools without a human picking each server. Approval mode is optional and only pauses configured destructive calls |
+| **M2M integration surface** | `toolport-gateway` stdio MCP is what every client launches |
+| **Identity / delegation** | Per-agent/client profiles scope which servers exist. Secrets stay in the OS keychain and are never written into client MCP configs |
+
+This is not a duplicate of ToolHive or IBM MCP Gateway: those emphasize isolated hosting or federated production gateways. Toolport's catalog-quality primitive is lazy discovery and token-bounded tool access on the local path.
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **Lazy meta-tools** | Four compact tools replace the full downstream catalog in context |
+| **Per-agent profiles** | Each client only sees assigned servers |
+| **Tool integrity** | Fingerprints detect silent schema changes and injection-like descriptions |
+| **Content defense** | Flags injection-like *returned* content as external data |
+| **Approval gate** | Optional pause on destructive calls; deny returns a declined tool call |
+| **Routines** | Promote a proven Code Mode run to a saved, schema-checked tool |
+
+---
+
+## Autonomy Model
+
+```
+Operator installs Toolport and authenticates servers once
+    -> connect each AI client to toolport-gateway
+    -> agent calls toolport_search_tools, then toolport_call_tool
+    -> gateway routes to the namespaced downstream tool
+    -> optional approval card for destructive calls
+    -> audit log records latency and errors per server
+```
+
+---
+
+## Identity and Delegation Model
+
+- **Client profile:** Each AI client is a scoped view of the registry.
+- **Secrets:** OS keychain only; clients never receive downstream API keys.
+- **Namespaced tools:** Downstream names become `server__tool` to avoid collisions.
+- **No minted agent passport:** Identity is the local client profile plus the gateway audit log.
+- **Agent control of servers:** `toolport_enable_server` / `toolport_disable_server` are off by default.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| Desktop app | Tauri app for servers, profiles, credentials, clients |
+| Gateway | `toolport-gateway` stdio MCP |
+| Downstream | stdio or remote HTTP/SSE MCP servers |
+| Agent rules sync | Marked blocks in `AGENTS.md` and similar |
+
+---
+
+## Human-in-the-Loop Support
+
+Optional approval mode pauses destructive calls until the operator approves or denies in the app (OS notification when waiting). Deny blocks the call. Routine promotion also requires a one-shot desktop approval card. The gateway itself does not require a click for ordinary allowed tools.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **Per-client MCP config** | Repeats auth and dumps every tool schema into every request |
+| **Generic HTTP proxy** | No lazy discovery, tool integrity, or per-agent server profiles |
+| **Host-only MCP catalog UI** | A human picker is not a runtime search/call plane for the agent |
+
+---
+
+## Use Cases
+
+- **Many MCP servers, one context budget** — keep tool definitions flat
+- **One auth, many coding agents** — share Stripe/GitHub/etc. across Cursor, Claude, Codex
+- **Scoped agents** — hide billing tools from a coding profile
+- **Local supply-chain checks** — flag rug-pulls and poisoned tool text before a call

--- a/services/voice-and-phone/README.md
+++ b/services/voice-and-phone/README.md
@@ -23,6 +23,7 @@ No consumer VOIP or call center platform was designed with these requirements as
 | [Stimm](stimm.md) [![⭐](https://img.shields.io/github/stars/stimm-ai/stimm?style=social)](https://github.com/stimm-ai/stimm) | Open-source voice agent platform — dual-agent + optimistic VUI over WebRTC | WebRTC, orchestrator API, BYO STT/LLM/TTS adapters | ⚠️ |
 | [Pipecat](pipecat.md) [![⭐](https://img.shields.io/github/stars/pipecat-ai/pipecat?style=social)](https://github.com/pipecat-ai/pipecat) | Open-source framework for real-time voice AI agents | Realtime voice pipeline, in-call tool invocation, WebRTC/SIP adapters | ⚠️ |
 | [Qwen Audio Agent](qwen-audio-agent.md) [![⭐](https://img.shields.io/github/stars/QwenAudio/qwen-audio-agent?style=social)](https://github.com/QwenAudio/qwen-audio-agent) | Realtime voice runtime that keeps agents talking while backend work continues | ACP backend bridge, local Gateway, CLI, TUI/WebUI/desktop, realtime audio | ❌ |
+| [Patter](patter.md) [![⭐](https://img.shields.io/github/stars/PatterAI/Patter?style=social)](https://github.com/PatterAI/Patter) | The open-source SDK that gives your AI agent a phone number | Python/TS SDK, Skills, Twilio/Telnyx/Plivo, OpenTelemetry | ⚠️ |
 
 
 ---

--- a/services/voice-and-phone/patter.md
+++ b/services/voice-and-phone/patter.md
@@ -1,0 +1,178 @@
+# Patter
+
+> **"Patter is the open-source SDK that gives your AI agent a phone number."**
+
+| | |
+|---|---|
+| **Website** | https://getpatter.com |
+| **Docs** | https://docs.getpatter.com |
+| **GitHub** | https://github.com/PatterAI/Patter |
+| **Stars** | [![GitHub Stars](https://img.shields.io/github/stars/PatterAI/Patter?style=social)](https://github.com/PatterAI/Patter) |
+| **Classification** | `agent-native` |
+| **Category** | [Voice & Phone Services](README.md) |
+| **License** | MIT |
+| **Latest-month signal** | Last GitHub push 2026-08-13 (verified 2026-08-19) |
+| **Verified at** | 2026-08-19 |
+
+---
+
+## Official Website
+
+https://getpatter.com
+
+---
+
+## Official Repo
+
+https://github.com/PatterAI/Patter
+
+Skills live in a separate official repo: https://github.com/PatterAI/skills
+
+---
+
+## How to Use (Agent Onboarding)
+
+**Interaction pattern:** `SDK` + **published Agent Skills**
+
+```bash
+npx skills add patterai/skills
+npm install getpatter
+# or
+pip install getpatter
+```
+
+TypeScript (from the official README):
+
+```typescript
+import { Patter, Twilio, OpenAIRealtime } from "getpatter";
+
+const phone = new Patter({ carrier: new Twilio(), phoneNumber: "+15550001234" });
+const agent = phone.agent({
+  engine: new OpenAIRealtime(),
+  systemPrompt: "You are a friendly receptionist for Acme Corp.",
+  firstMessage: "Hello! How can I help?",
+});
+await phone.serve({ agent, tunnel: true });
+```
+
+Python uses the same objects via `from getpatter import Patter, Twilio, OpenAIRealtime`. Credentials come from environment variables documented at https://docs.getpatter.com. `tunnel: true` starts a Cloudflare quick tunnel for local dev.
+
+---
+
+## Agent Skills
+
+**Status:** ✅ Available
+
+```bash
+npx skills add patterai/skills
+```
+
+Official index: https://www.skills.sh/patterai/skills — README says the bundle works in Agent Skills-compatible harnesses.
+
+| Skill | What It Teaches the Agent |
+|---|---|
+| Patter skills bundle | How to compose the voice stack (carrier, STT/TTS/realtime, tools, tunnel) in Python or TypeScript |
+
+Exact skill names live in `PatterAI/skills`; install via the command above rather than inventing filenames.
+
+---
+
+## MCP
+
+**Status:** ⚠️ Not published
+
+Primary surfaces are the Python/TypeScript SDKs, docs, and Skills. No official MCP server is documented in the README.
+
+Search community skills: `npx clawhub@latest search patter`. See: https://agentskills.io/specification
+
+---
+
+## What It Does
+
+Patter is an open-source voice stack between an application and the phone network. It runs the agent loop and lets you swap LLM, STT, TTS, realtime, and carrier providers (Twilio, Telnyx, Plivo). Modes: Realtime, Pipeline, Hybrid. Built-in tools, transfer, guardrails, and OpenTelemetry traces are vendor-neutral across carriers. Same API in Python and TypeScript.
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | README: **"Patter is the open-source SDK that gives your AI agent a phone number."** GitHub: **"Give your AI agent a phone number in 4 lines"** — [PatterAI/Patter](https://github.com/PatterAI/Patter) |
+| **Agent-specific primitive** | A phone number bound to an agent loop with mid-call tools, transfer, and guardrails — not a human softphone |
+| **Autonomy-compatible control plane** | `phone.serve({ agent })` answers/places calls without a person holding a handset. Provider keys are env, not per-utterance clicks |
+| **M2M integration surface** | `getpatter` npm/PyPI, docs, Skills, webhooks/tunnel |
+| **Identity / delegation** | The agent's telephony identity is the provisioned number + carrier account. OTel traces each call. No KYA wallet |
+
+Same catalog neighborhood as Vapi/Retell, but the official positioning is the self-hosted OSS alternative.
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **`Patter` + `phone.agent`** | Bind a number to an engine and prompts |
+| **Provider layers** | Swap LLM/STT/TTS/realtime/carrier in one line |
+| **Tools / transfer / guardrails** | Same behavior on every carrier |
+| **Tunnel** | Cloudflare quick tunnel for local `serve` |
+| **OpenTelemetry** | Vendor-neutral call trace |
+
+---
+
+## Autonomy Model
+
+```
+Install SDK + set carrier and model env vars
+    -> construct Patter + agent
+    -> serve (tunnel or static webhook_url)
+    -> inbound/outbound calls hit the agent loop
+    -> tools/transfer/guardrails run mid-call
+    -> call ends; trace is recorded
+```
+
+---
+
+## Identity and Delegation Model
+
+- **Number identity:** The phone number you attach is the agent's reachable identity.
+- **Carrier account:** Twilio/Telnyx/Plivo credentials stay in env.
+- **Call trace:** OpenTelemetry, not a human recording inbox.
+- **Telemetry opt-out:** Anonymous SDK telemetry is documented; disable with `telemetry=False`, `getpatter telemetry disable`, or `PATTER_TELEMETRY_DISABLED=1` (also honors `DO_NOT_TRACK=1`). Official note: no call content, prompts, numbers, or keys.
+- **You run the loop:** Patter is infrastructure you host, not a hosted agent identity provider.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| npm | `getpatter` |
+| PyPI | `getpatter` |
+| Skills | `npx skills add patterai/skills` |
+| Docs | https://docs.getpatter.com |
+| Templates | Separate example repos listed in the README |
+
+---
+
+## Human-in-the-Loop Support
+
+Not required per utterance. Guardrails and call transfer can escalate to a human. A local dashboard template exists for operators. Production needs a static webhook rather than only the dev tunnel.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **Human PBX / softphone** | A person places and answers calls |
+| **Carrier API only** | Media + STT/TTS + agent loop are still yours to invent |
+| **Chat-only voice widget** | Not a first-class PSTN number the agent owns |
+
+---
+
+## Use Cases
+
+- **Inbound receptionist** — answer a number with a realtime engine
+- **Outbound + AMD** — official outbound template
+- **BYO voice pipeline** — Deepgram + ElevenLabs (or other listed providers)
+- **Own the stack** — MIT SDK instead of a closed voice-agent SaaS

--- a/skill.md
+++ b/skill.md
@@ -5,7 +5,7 @@ description: >
   surfaces for live agents. Use the catalog to find services by task, understand
   each service's onboarding pattern, and immediately start using any service with
   URL Onboarding in one instruction.
-version: "2026-08-18"
+version: "2026-08-19"
 license: CC0-1.0
 catalog: https://github.com/haoruilee/awesome-agent-native-services
 allowed-tools: WebSearch Read
@@ -67,12 +67,14 @@ These services can be joined with a single instruction, right now, with no human
 | **mails.dev** | Email for agents: @mails.dev mailbox, send/inbox, wait-for-code | `Read https://mails.dev/skill.md and follow the instructions` |
 | **MailboxKit** | Agent email in one API — REST v1, webhooks, skill.md | `Read https://mailboxkit.com/skill.md and follow the instructions` |
 | **Agents Mail** | Agent email identity: registration, inbox lifecycle, send/reply API | `Read https://agentsmail.org/skill.md and follow the instructions` |
+| **Atomic Mail** | Agent-owned `@atomicmail.ai` inbox over JMAP | `Read https://atomicmail.ai and follow the instructions to create an inbox` |
+| **agentmemory** | Persistent coding-agent memory server, MCP, and skills | `Read https://raw.githubusercontent.com/rohitg00/agentmemory/main/INSTALL_FOR_AGENTS.md and follow the instructions` |
 
 ---
 
-## Full Catalog — 16 Categories, 173 Services
+## Full Catalog — 16 Categories, 188 Services
 
-### 1. Communication (13 services)
+### 1. Communication (15 services)
 *Give agents a first-class communication identity on the internet.*
 
 | Service | Tagline | Onboarding |
@@ -90,10 +92,12 @@ These services can be joined with a single instruction, right now, with no human
 | [MCP Agent Mail (Rust)](https://github.com/Dicklesworthstone/mcp_agent_mail_rust) | "Gmail for coding agents" with MCP tools/resources | Install script from repo README, then run `am` |
 | [AgenticMail](https://github.com/agenticmail/agenticmail) | Email and SMS infrastructure for AI agents | Clone the repo and run `docker compose up -d` |
 | [Caspian](https://api.trycaspianai.com) ⭐ | One agent identity across human communication channels | `Read https://api.trycaspianai.com/SKILL.md and follow it end to end` |
+| [Atomic Mail](https://atomicmail.ai) ⭐ | Not AI for your email. Email for your AI. | `Read https://atomicmail.ai and follow the instructions to create an inbox` |
+| [AgentTeam Email](https://www.agentteam.email) | Open-source email infrastructure for AI agents | `npx --yes @agentteamhq/email@latest` then `at-email agent connect` |
 
 ---
 
-### 2. Browser & Web Execution (23 services)
+### 2. Browser & Web Execution (24 services)
 *Remote browser and web data extraction for agents.*
 
 | Service | Tagline | Onboarding |
@@ -121,10 +125,11 @@ These services can be joined with a single instruction, right now, with no human
 | [Vessel Browser](https://github.com/unmodeled-tyler/vessel-browser) | Durable agent browser with action undo | `npm install -g vessel-browser` → `vessel-browser --mcp` |
 | [CamoFox Browser](https://github.com/jo-inc/camofox-browser) | Stealth headless browser for AI agents | `npm install -g camofox-browser` then start the browser server |
 | [Moli](https://github.com/lexmount/moli) | Structured-first browser engine for AI agents | Build the Rust workspace, then run `moli fetch`, `moli serve`, or `moli mcp` |
+| [Kernel](https://www.kernel.sh) | you build agents. we give them the internet. | `brew install kernel/tap/kernel` or `npm install -g @onkernel/cli`, then `kernel browsers create -o json` |
 
 ---
 
-### 3. Tool Access & Integration (15 services)
+### 3. Tool Access & Integration (16 services)
 *Runtime tool discovery, auth, and execution without human pre-configuration.*
 
 | Service | Tagline | Onboarding |
@@ -144,10 +149,11 @@ These services can be joined with a single instruction, right now, with no human
 | [Obot](https://github.com/obot-platform/obot) | MCP gateway and tool runtime for agents | Deploy Obot and register/connect MCP servers |
 | [Snyk Agent Scan](https://github.com/snyk/agent-scan) | Scan agent tools and MCP configurations for risk | Install the CLI from the repo and scan the target agent configuration |
 | [OpenChatCut](https://github.com/0xsline/OpenChatCut) | Local-first agent-native video editor | `npx skills add 0xsline/OpenChatCut`, then ask the agent to set it up |
+| [Toolport](https://toolport.app) | Every tool. One port. | Install from GitHub Releases, add servers, connect each AI client to `toolport-gateway` |
 
 ---
 
-### 4. Oversight & Approval (4 services)
+### 4. Oversight & Approval (5 services)
 *Structured, programmatic human approval before high-stakes actions.*
 
 | Service | Tagline | Onboarding |
@@ -156,6 +162,7 @@ These services can be joined with a single instruction, right now, with no human
 | [Sondera Coding Agent Hooks](https://github.com/sondera-ai/sondera-coding-agent-hooks) | A reference monitor for AI coding agents | Install Rust hooks and Cedar policies around coding-agent sessions |
 | [HumanLayer](https://humanlayer.dev) | Human in the Loop for AI Agents | `pip install humanlayer` → `@hl.require_approval()` |
 | [Sallyport](https://github.com/OlegSotnikov/sallyport) | Credential gate for agents touching production | `brew install --cask olegsotnikov/tap/sallyport`, then add `sp mcp` to the agent |
+| [Preloop](https://preloop.ai) | The Open Source Control Plane for AI Agents | Install the CLI from https://preloop.ai then `preloop signup` and `preloop agents discover` |
 
 ---
 
@@ -176,7 +183,7 @@ These services can be joined with a single instruction, right now, with no human
 
 ---
 
-### 6. Agent Runtime & Infrastructure (25 services)
+### 6. Agent Runtime & Infrastructure (27 services)
 *Secure execution, session isolation, secrets, identity, and gateway for production agents.*
 
 | Service | Tagline | Onboarding |
@@ -206,10 +213,12 @@ These services can be joined with a single instruction, right now, with no human
 | [Modal](https://modal.com) | Serverless AI infra — GPUs, sandboxes, batch | `pip install modal` → `modal setup` — [modal.com/docs](https://modal.com/docs) |
 | [Cyberdesk](https://github.com/cyberdesk-hq/cyberdesk) | Open-source virtual desktops for AI agents | `pip install cyberdesk` — [docs.cyberdesk.io](https://docs.cyberdesk.io) |
 | [Polos](https://github.com/polos-dev/polos) | Agent runtime with sandbox, durable workflow, and HITL | `pip install polos` or `npm install polos` |
+| [Cloudflare Computer](https://github.com/cloudflare/computer) | Give your agent a computer | `npm install @cloudflare/computer` then attach `withWorkspace` to a Durable Object (preview only) |
+| [Agent Executor (AX)](https://github.com/google/ax) | An open source distributed agent runtime | `go install github.com/google/ax/cmd/ax@latest` then `ax --input "…"` |
 
 ---
 
-### 7. Agent Harnesses & Operator Surfaces (7 services)
+### 7. Agent Harnesses & Operator Surfaces (9 services)
 *Durable agent-loop control, multi-agent orchestration, and live operator surfaces tied to concrete sessions.*
 
 | Service | Tagline | Onboarding |
@@ -221,10 +230,12 @@ These services can be joined with a single instruction, right now, with no human
 | [Agent QA](https://vostride.com/) | The self-improving QA agent for software teams | `npx agent-qa init` → `codex mcp add agent-qa -- agent-qa mcp` |
 | [Codex HUD (fwyc0573)](https://github.com/fwyc0573/codex-hud) | Real-time statusline and multi-session HUD for Codex CLI | Clone the repo → `./bin/codex-hud-install` → launch `codex` |
 | [Codex HUD (anhannin)](https://github.com/anhannin/codex-hud) | Patched Codex status line for usage and session state | Review the patch/install script, then run `Codex-HUD/install.sh` and start a new session |
+| [Claude HUD](https://github.com/jarrodwatts/claude-hud) | A Claude Code plugin that shows what's happening | `/plugin marketplace add jarrodwatts/claude-hud` then `/plugin install claude-hud` and `/claude-hud:setup` |
+| [LoopX](https://huangruiteng.github.io/loopx/) | Stateful control plane for long-horizon agents | `python3 -m pip install --upgrade loopx` then `loopx workflow-skills --install` and `loopx connect` |
 
 ---
 
-### 8. Memory & State (15 services)
+### 8. Memory & State (17 services)
 *Persistent, queryable memory across sessions — memory as infrastructure, not application logic.*
 
 | Service | Tagline | Onboarding |
@@ -244,10 +255,12 @@ These services can be joined with a single instruction, right now, with no human
 | [MemMachine](https://github.com/MemMachine/MemMachine) | Long-term memory for AI agents | Install from the official repository and follow its server/client quickstart |
 | [Cognee](https://github.com/topoteretes/cognee) | Knowledge engine and memory for AI agents | `pip install cognee` and follow the official quickstart |
 | [Hindsight](https://github.com/vectorize-io/hindsight) | Agent memory with structured recall and reflection | Install/deploy from the official repository and connect its API/MCP surface |
+| [agentmemory](https://agent-memory.dev) ⭐ | Your coding agent remembers everything | `Read https://raw.githubusercontent.com/rohitg00/agentmemory/main/INSTALL_FOR_AGENTS.md and follow the instructions` |
+| [TencentDB Agent Memory](https://github.com/TencentCloud/TencentDB-Agent-Memory) | Agents remember,Humans innovate. | `openclaw plugins install @tencentdb-agent-memory/memory-tencentdb` |
 
 ---
 
-### 9. Search & Web Intelligence (8 services)
+### 9. Search & Web Intelligence (9 services)
 *LLM-optimized web search returning structured content tuned for context windows.*
 
 | Service | Tagline | Onboarding |
@@ -260,6 +273,7 @@ These services can be joined with a single instruction, right now, with no human
 | [Jina Reader](https://jina.ai/reader) | `r.jina.ai` / `s.jina.ai` — LLM-friendly URL & search | `curl "https://r.jina.ai/https://example.com"` — MCP: `mcp.jina.ai` |
 | [Linkup](https://www.linkup.so) | Web search and deep research for agents | Use Linkup's API/SDK or official MCP server per its docs |
 | [NotHumanSearch](https://nothumansearch.ai) ⭐ | Search infrastructure designed for AI agents | `Read https://nothumansearch.ai/llms.txt and follow the instructions` |
+| [Agent Search MCP](https://github.com/lennney/agent-search-mcp) | Free-first web search with inspectable evidence | `npx -y agent-search-mcp` — optional `npx skills add lennney/agent-search-mcp --skill agent-search` |
 
 ---
 
@@ -315,7 +329,7 @@ These services can be joined with a single instruction, right now, with no human
 
 ---
 
-### 13. Meeting & Conversation (6 services)
+### 13. Meeting & Conversation (7 services)
 *Programmatic agent presence in voice and video meetings.*
 
 | Service | Tagline | Onboarding |
@@ -326,10 +340,11 @@ These services can be joined with a single instruction, right now, with no human
 | [Vexa](https://vexa.ai) | Open-source meeting transcription and interactive bot | Clone [Vexa-ai/vexa](https://github.com/Vexa-ai/vexa) → `docker compose up -d` |
 | [Daily Agent Toolkit](https://github.com/daily-co/daily-python) | Build realtime meeting agents on Daily | `pip install daily-python` then integrate the room/bot lifecycle APIs |
 | [Looped Meet](https://meet.looped.sh) | Dial your agent into your next meeting | Clone [loopedautomation/meet](https://github.com/loopedautomation/meet), configure secrets, then `docker compose up` |
+| [AgentCall](https://agentcall.dev) | Your AI agent, in every meeting. | `/plugin marketplace add pattern-ai-labs/agentcall` then `/plugin install join-meeting@agentcall` |
 
 ---
 
-### 14. Voice & Phone (6 services)
+### 14. Voice & Phone (7 services)
 *Agent-controlled voice calls and telephony infrastructure.*
 
 | Service | Tagline | Onboarding |
@@ -340,6 +355,7 @@ These services can be joined with a single instruction, right now, with no human
 | [Stimm](https://github.com/stimm-ai/stimm) | Open-source ultra-low-latency voice agent platform | Clone the repo and follow its provider setup |
 | [Pipecat](https://github.com/pipecat-ai/pipecat) | Open-source framework for real-time voice AI agents | `pip install pipecat-ai` then compose the STT/LLM/TTS pipeline |
 | [Qwen Audio Agent](https://github.com/QwenAudio/qwen-audio-agent) | Realtime voice runtime that keeps agents present | `npm install -g qwen-audio-agent` → `qwenaudio config` → `qwenaudio` |
+| [Patter](https://getpatter.com) | Open-source SDK that gives your AI agent a phone number | `npx skills add patterai/skills` then `npm install getpatter` or `pip install getpatter` |
 
 ---
 
@@ -359,7 +375,7 @@ These services can be joined with a single instruction, right now, with no human
 
 ---
 
-### 16. Agent Social & Community (6 services)
+### 16. Agent Social & Community (7 services)
 *Social networks where AI agents are first-class participants.*
 
 | Service | Tagline | Onboarding |
@@ -370,6 +386,7 @@ These services can be joined with a single instruction, right now, with no human
 | MCP Verse | Open town square for autonomous MCP agents | ⚠️ Former website/docs are offline; wait for a verified official replacement |
 | [KinthAI](https://kinthai.ai) | Agent economy network for collaboration and revenue | Visit [agents.kinthai.ai](https://agents.kinthai.ai) |
 | [Agent Chamber](https://github.com/LtyFantasy/agent-chamber) | Where AI agents meet, discuss, and get work done | Clone the repo → `./scripts/setup.sh` |
+| [AgentGram](https://agentgram.co) | The Open-Source Social Network for AI Agents | `pip install agentgram` then register via the SDK — MCP: `npx @agentgram/mcp-server` |
 
 ---
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Maintainer-requested batch add (no linked issues). 

## Admitted (15)

| Service | Category | Onboarding pattern |
|---|---|---|
| Atomic Mail | communication | URL Onboarding (`Read https://atomicmail.ai`) + MCP + AgentSkill |
| AgentTeam Email | communication | `at-email` CLI + bundled Agent Skill |
| Kernel | browser-and-web-execution | CLI (`@onkernel/cli`) + official `kernel-cli` Skill |
| Toolport | tool-access-and-integration | Local stdio MCP gateway (`toolport-gateway`) |
| Preloop | oversight-and-approval | CLI `preloop agents discover` onto MCP firewall + gateway |
| Cloudflare Computer | agent-runtime-and-infrastructure | SDK (`npm install @cloudflare/computer`); preview-only |
| Agent Executor (AX) | agent-runtime-and-infrastructure | `ax` CLI / `ax serve` |
| Claude HUD | agent-harnesses-and-control-planes | Operator-surface track: Claude Code plugin + statusline |
| LoopX | agent-harnesses-and-control-planes | CLI + `loopx workflow-skills --install` |
| agentmemory | memory-and-state | URL Onboarding (`INSTALL_FOR_AGENTS.md`) + MCP + Skills |
| TencentDB Agent Memory | memory-and-state | OpenClaw / Hermes plugins |
| Agent Search MCP | search-and-web-intelligence | `npx -y agent-search-mcp` + optional Skill |
| AgentCall | meeting-and-conversation | `join-meeting` Agent Skill / plugin |
| Patter | voice-and-phone | SDK (`getpatter`) + `npx skills add patterai/skills` |
| AgentGram | agent-social-network | Python/JS SDK + `npx @agentgram/mcp-server` |

Catalog counts: **173 → 188 services**, still 16 categories.

## Dropped from this batch

| Candidate | Why |
|---|---|
| **Microsandbox** | Failed criterion 1. Official positioning is a general microVM runtime for untrusted workloads (AI agents, user code, plugins, CI, scrapers). Agent Skills/MCP are adaptations, not agent-first design. |
| Agent-Sandbox (agent-sandbox/agent-sandbox) | Pre-skipped: catalog already has hosted Agent Sandbox (`agentsandbox.co`). |
| Docker MCP Gateway | Pre-skipped: too close to ToolHive + MCP Gateway. |
| ACK | Pre-skipped: protocol kit, not a live service. |
| Coinbase Agentic Wallet skills | Pre-skipped: same vendor as existing Coinbase CDP (x402). |
| Observra, DuraGraph, polyrouter | Pre-skipped: thin / not honest catalog quality. |
| OpenAgentEmail, The Colony, Causentra, AgentSearch, Agent Substrate | Pre-skipped backups. Agent Substrate stays out; AX may run on it but this PR does not add Substrate or close #101. |
| AgentLot | Explicit hold (open issue #101). |

## Notes

- Classification is `agent-native` for every admitted entry. Claude HUD uses the operator-surface track (same class as the existing Codex HUD dossiers).
- Cloudflare Computer is admitted with an honest **PREVIEW ONLY / not for production** boundary from the official README.
- AgentGram GitHub remains “social network for AI agents”; the live homepage also markets team MCP/AX Score governance. The dossier records both.
- Official taglines, licenses, and install commands are from pages/READMEs verified 2026-08-19. Star counts are live badges, not hardcoded facts.

## Validation

Regenerate and local health checks passed:

- `bash scripts/build-github-pages.sh` — 188 services, 16 collections
- `python3 scripts/build-machine-catalog.py` and `--check`
- `python3 scripts/check-repository-health.py --local --freshness-max-days 45` — inventory, local links (602), and research freshness passed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-560db7bd-b95d-44ff-b60f-628ab874f303?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-560db7bd-b95d-44ff-b60f-628ab874f303&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

