### PR TITLE
[New Service] SandBase CLI

### DIFF
--- a/.skills/add-to-awesome-list/SKILL.md
+++ b/.skills/add-to-awesome-list/SKILL.md
@@ -9,7 +9,7 @@ license: CC0-1.0
 compatibility: Works with agents that can read repository files and browse official sources.
 metadata:
   repo: https://github.com/haoruilee/awesome-agent-native-services
-  catalog-version: "2026-08-19"
+  catalog-version: "2026-08-25"
 allowed-tools: WebSearch Read Bash
 ---
 

--- a/.skills/evaluate-agent-native/SKILL.md
+++ b/.skills/evaluate-agent-native/SKILL.md
@@ -8,7 +8,7 @@ license: CC0-1.0
 compatibility: Works with agents that can inspect official websites, repositories, and protocol documentation.
 metadata:
   repo: https://github.com/haoruilee/awesome-agent-native-services
-  catalog-version: "2026-08-19"
+  catalog-version: "2026-08-25"
 allowed-tools: WebSearch Read
 ---
 

--- a/.skills/find-agent-service/SKILL.md
+++ b/.skills/find-agent-service/SKILL.md
@@ -9,7 +9,7 @@ license: CC0-1.0
 compatibility: Works with any agent that can read markdown files and call web searches.
 metadata:
   repo: https://github.com/haoruilee/awesome-agent-native-services
-  catalog-version: "2026-08-19"
+  catalog-version: "2026-08-25"
 allowed-tools: WebSearch Read
 ---
 

--- a/.skills/install-agent-service/SKILL.md
+++ b/.skills/install-agent-service/SKILL.md
@@ -9,7 +9,7 @@ license: CC0-1.0
 compatibility: Works with Claude Code plugin skills and agents that can read SKILL.md.
 metadata:
   repo: https://github.com/haoruilee/awesome-agent-native-services
-  catalog-version: "2026-08-19"
+  catalog-version: "2026-08-25"
 allowed-tools: WebSearch Read Bash
 ---
 

--- a/README.md
+++ b/README.md
@@ -83,13 +83,13 @@ Recommended flow for agents: start with `skill.md` for quick discovery, switch t
 
 ## Categories
 
-**188 services across 16 categories.**
+**189 services across 16 categories.**
 
 | # | Category | Services | Description |
 |---|---|---|---|
 | 1 | [Communication](#1-communication-services) | 15 | Give agents a communication identity on the internet |
 | 2 | [Browser & Web Execution](#2-browser--web-execution-services) | 24 | Remote browser and web data extraction for agents |
-| 3 | [Tool Access & Integration](#3-tool-access--integration-services) | 16 | Runtime tool discovery, auth, and execution |
+| 3 | [Tool Access & Integration](#3-tool-access--integration-services) | 17 | Runtime tool discovery, auth, and execution |
 | 4 | [Oversight & Approval](#4-oversight--approval-services) | 5 | Human-in-the-loop approval and escalation |
 | 5 | [Commerce & Payments](#5-commerce--payment-services) | 9 | Agent-native wallets, identity, and transactions |
 | 6 | [Agent Runtime & Infrastructure](#6-agent-runtime--infrastructure-services) | 27 | Execution, session isolation, secrets, and gateway |
@@ -195,6 +195,7 @@ Recommended flow for agents: start with `skill.md` for quick discovery, switch t
 | [Snyk Agent Scan](services/tool-access-and-integration/snyk-agent-scan.md) [![⭐](https://img.shields.io/github/stars/snyk/agent-scan?style=social)](https://github.com/snyk/agent-scan) | Security scanner for AI agents, MCP servers and agent skills | Agent component inventory · MCP inspection · Prompt/tool risk detection · CI gates | ✅ | `uvx snyk-agent-scan@latest scan` |
 | [OpenChatCut](services/tool-access-and-integration/openchatcut.md) [![⭐](https://img.shields.io/github/stars/0xsline/OpenChatCut?style=social)](https://github.com/0xsline/OpenChatCut) | Local-first agent-native video editor with editable timelines | Agent Skill · Streamable HTTP MCP · isolated drafts · EditorCore tools | ✅ | `npx skills add 0xsline/OpenChatCut`, then ask the agent: `Set up OpenChatCut` |
 | [Toolport](services/tool-access-and-integration/toolport.md) [![⭐](https://img.shields.io/github/stars/tsouth89/toolport?style=social)](https://github.com/tsouth89/toolport) | Every tool. One port. | Lazy MCP meta-tools · per-client profiles · tool integrity · keychain secrets | ✅ | Install from [GitHub Releases](https://github.com/tsouth89/toolport/releases/latest), add servers, then connect each AI client to `toolport-gateway` |
+| [SandBase CLI](services/tool-access-and-integration/sandbase-cli.md) [![⭐](https://img.shields.io/github/stars/sandbaseai/cli?style=social)](https://github.com/sandbaseai/cli) | Give your AI agent superpowers. One command. 2,000+ AI models. | Local MCP bridge · discover/inspect/run · client-scoped credentials · Agent Skill | ✅ | Immutable `v0.1.17` tarball: `npx -y https://github.com/sandbaseai/cli/releases/download/v0.1.17/sandbaseai-cli-0.1.17.tgz connect`, then `npx skills add sandbaseai/cli --skill sandbase` |
 
 ---
 

--- a/catalog.json
+++ b/catalog.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://lihaorui.com/awesome-agent-native-services/catalog.schema.json",
   "schema_version": "1.0.0",
-  "catalog_version": "2026-08-19",
-  "generated_at": "2026-08-19",
+  "catalog_version": "2026-08-25",
+  "generated_at": "2026-08-25",
   "license": "CC0-1.0",
   "source": {
     "repository": "https://github.com/haoruilee/awesome-agent-native-services",
@@ -11,7 +11,7 @@
     "service_directory": "services",
     "content_digest": {
       "algorithm": "sha256",
-      "value": "414695665d51ecd39d640f5519d206566b775a824065983bfcf91544738baac1",
+      "value": "84ca549b1cb86e190f88a1926ee804fad074d40d2b76640d4194a2fc9116a5fc",
       "input_paths": [
         "README.md",
         "skill.md",
@@ -68,6 +68,7 @@
         "services/tool-access-and-integration/nango.md",
         "services/tool-access-and-integration/obot.md",
         "services/tool-access-and-integration/openchatcut.md",
+        "services/tool-access-and-integration/sandbase-cli.md",
         "services/tool-access-and-integration/smithery.md",
         "services/tool-access-and-integration/snyk-agent-scan.md",
         "services/tool-access-and-integration/toolhive.md",
@@ -224,7 +225,7 @@
   },
   "counts": {
     "categories": 16,
-    "services": 188
+    "services": 189
   },
   "categories": [
     {
@@ -246,7 +247,7 @@
       "name": "Tool Access & Integration",
       "description": "Services that let AI agents discover, authenticate, and invoke external tools at runtime — without a human pre-configuring credentials or selecting which integrations to activate.",
       "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/README.md",
-      "service_count": 16
+      "service_count": 17
     },
     {
       "id": "oversight-and-approval",
@@ -1915,6 +1916,40 @@
       "verification_sources": [
         "https://github.com/0xsline/OpenChatCut/releases/tag/v0.2.1",
         "https://github.com/0xsline/OpenChatCut/commit/a3c6d66d26e914e51b624638ae8861d0fd595720"
+      ]
+    },
+    {
+      "id": "tool-access-and-integration/sandbase-cli",
+      "slug": "sandbase-cli",
+      "name": "SandBase CLI",
+      "tagline": "Give your AI agent superpowers. One command. 2,000+ AI models.",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "tool-access-and-integration",
+      "website": "https://www.sandbase.ai",
+      "repository": "https://github.com/sandbaseai/cli",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/sandbase-cli.md",
+      "source_path": "services/tool-access-and-integration/sandbase-cli.md",
+      "onboarding": {
+        "type": "mcp",
+        "pattern": "local MCP bridge (stdio) after one browser approval",
+        "instruction": "npx -y https://github.com/sandbaseai/cli/releases/download/v0.1.17/sandbaseai-cli-0.1.17.tgz connect",
+        "url": "https://github.com/sandbaseai/cli/releases/download/v0.1.17/sandbaseai-cli-0.1.17.tgz"
+      },
+      "protocols": [
+        "agent-skill",
+        "mcp",
+        "cli",
+        "stdio",
+        "http"
+      ],
+      "mcp_status": "available",
+      "agent_skill_status": "available",
+      "latest_month_signal": "Last GitHub push 2026-08-23; immutable v0.1.17 published 2026-08-19",
+      "verified_at": "2026-08-25",
+      "verification_sources": [
+        "https://github.com/sandbaseai/cli/releases/tag/v0.1.17"
       ]
     },
     {

--- a/docs/catalog.json
+++ b/docs/catalog.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://lihaorui.com/awesome-agent-native-services/catalog.schema.json",
   "schema_version": "1.0.0",
-  "catalog_version": "2026-08-19",
-  "generated_at": "2026-08-19",
+  "catalog_version": "2026-08-25",
+  "generated_at": "2026-08-25",
   "license": "CC0-1.0",
   "source": {
     "repository": "https://github.com/haoruilee/awesome-agent-native-services",
@@ -11,7 +11,7 @@
     "service_directory": "services",
     "content_digest": {
       "algorithm": "sha256",
-      "value": "414695665d51ecd39d640f5519d206566b775a824065983bfcf91544738baac1",
+      "value": "84ca549b1cb86e190f88a1926ee804fad074d40d2b76640d4194a2fc9116a5fc",
       "input_paths": [
         "README.md",
         "skill.md",
@@ -68,6 +68,7 @@
         "services/tool-access-and-integration/nango.md",
         "services/tool-access-and-integration/obot.md",
         "services/tool-access-and-integration/openchatcut.md",
+        "services/tool-access-and-integration/sandbase-cli.md",
         "services/tool-access-and-integration/smithery.md",
         "services/tool-access-and-integration/snyk-agent-scan.md",
         "services/tool-access-and-integration/toolhive.md",
@@ -224,7 +225,7 @@
   },
   "counts": {
     "categories": 16,
-    "services": 188
+    "services": 189
   },
   "categories": [
     {
@@ -246,7 +247,7 @@
       "name": "Tool Access & Integration",
       "description": "Services that let AI agents discover, authenticate, and invoke external tools at runtime — without a human pre-configuring credentials or selecting which integrations to activate.",
       "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/README.md",
-      "service_count": 16
+      "service_count": 17
     },
     {
       "id": "oversight-and-approval",
@@ -1915,6 +1916,40 @@
       "verification_sources": [
         "https://github.com/0xsline/OpenChatCut/releases/tag/v0.2.1",
         "https://github.com/0xsline/OpenChatCut/commit/a3c6d66d26e914e51b624638ae8861d0fd595720"
+      ]
+    },
+    {
+      "id": "tool-access-and-integration/sandbase-cli",
+      "slug": "sandbase-cli",
+      "name": "SandBase CLI",
+      "tagline": "Give your AI agent superpowers. One command. 2,000+ AI models.",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "tool-access-and-integration",
+      "website": "https://www.sandbase.ai",
+      "repository": "https://github.com/sandbaseai/cli",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/sandbase-cli.md",
+      "source_path": "services/tool-access-and-integration/sandbase-cli.md",
+      "onboarding": {
+        "type": "mcp",
+        "pattern": "local MCP bridge (stdio) after one browser approval",
+        "instruction": "npx -y https://github.com/sandbaseai/cli/releases/download/v0.1.17/sandbaseai-cli-0.1.17.tgz connect",
+        "url": "https://github.com/sandbaseai/cli/releases/download/v0.1.17/sandbaseai-cli-0.1.17.tgz"
+      },
+      "protocols": [
+        "agent-skill",
+        "mcp",
+        "cli",
+        "stdio",
+        "http"
+      ],
+      "mcp_status": "available",
+      "agent_skill_status": "available",
+      "latest_month_signal": "Last GitHub push 2026-08-23; immutable v0.1.17 published 2026-08-19",
+      "verified_at": "2026-08-25",
+      "verification_sources": [
+        "https://github.com/sandbaseai/cli/releases/tag/v0.1.17"
       ]
     },
     {

--- a/docs/categories/index.md
+++ b/docs/categories/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Agent-Native Collections"
-description: "Browse 188 agent-native services across 16 curated infrastructure collections."
+description: "Browse 189 agent-native services across 16 curated infrastructure collections."
 permalink: /categories/
 page_kind: document
 ---
@@ -27,7 +27,7 @@ page_kind: document
     <span class="collection-card__copy">
     <span class="collection-card__number">03</span>
     <span class="collection-card__title">Tool Access &amp; Integration</span>
-    <span class="collection-card__count">16</span>
+    <span class="collection-card__count">17</span>
     </span>
   </a>
   <a class="collection-card atlas-visual--04" href="{{ '/categories/oversight-and-approval/' | relative_url }}">

--- a/docs/categories/tool-access-and-integration.md
+++ b/docs/categories/tool-access-and-integration.md
@@ -6,7 +6,7 @@ hero_image: "/assets/images/editorial-network.webp"
 permalink: /categories/tool-access-and-integration/
 page_kind: collection
 collection_number: "03"
-service_count: 16
+service_count: 17
 ---
 
 <p class="collection-source"><a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/README.md">Collection notes ↗</a></p>
@@ -132,7 +132,18 @@ service_count: 16
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--12">
+  <article class="service-card service-card--new atlas-sheet--service atlas-visual--12">
+    <span class="service-card__image" aria-hidden="true"></span>
+    <div class="service-card__copy">
+    <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
+    <h2 class="service-card__title">SandBase CLI</h2>
+    <div class="service-card__actions">
+      <a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/sandbase-cli.md">Open dossier ↗</a>
+      <a href="https://github.com/sandbaseai/cli">Official repo ↗</a>
+    </div>
+    </div>
+  </article>
+  <article class="service-card atlas-sheet--service atlas-visual--13">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -143,7 +154,7 @@ service_count: 16
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--13">
+  <article class="service-card atlas-sheet--service atlas-visual--14">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -154,7 +165,7 @@ service_count: 16
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--14">
+  <article class="service-card atlas-sheet--service atlas-visual--15">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -165,7 +176,7 @@ service_count: 16
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--15">
+  <article class="service-card atlas-sheet--service atlas-visual--16">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -176,7 +187,7 @@ service_count: 16
     </div>
     </div>
   </article>
-  <article class="service-card service-card--new atlas-sheet--service atlas-visual--16">
+  <article class="service-card service-card--new atlas-sheet--arrival atlas-visual--01">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,9 +3,9 @@ title: "The Agent-Native Index"
 description: "A curated 2026 collection of agent-native infrastructure: MCP tools, harnesses, identity, memory, sandboxes, browsers, payments, and runtimes."
 image: /assets/images/social-preview.png
 page_kind: home
-service_count: 188
+service_count: 189
 collection_count: 16
-new_arrivals_count: 36
+new_arrivals_count: 37
 ---
 
 <section id="new-arrivals" aria-labelledby="new-arrivals-title">
@@ -103,7 +103,15 @@ new_arrivals_count: 36
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--12" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-social-network/agentgram.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--12" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/sandbase-cli.md">
+      <span class="arrival-card__image" aria-hidden="true"></span>
+      <span class="arrival-card__copy">
+        <span class="arrival-card__category">Tool Access &amp; Integration</span>
+        <strong class="arrival-card__name">SandBase CLI</strong>
+        <span class="arrival-card__arrow" aria-hidden="true">↗</span>
+      </span>
+    </a>
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--13" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-social-network/agentgram.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Agent Social &amp; Community</span>
@@ -111,7 +119,7 @@ new_arrivals_count: 36
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--13" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/toolport.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--14" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/toolport.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Tool Access &amp; Integration</span>
@@ -119,7 +127,7 @@ new_arrivals_count: 36
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--14" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/loopx.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--15" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/loopx.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Agent Harnesses &amp; Operator Surfaces</span>
@@ -127,7 +135,7 @@ new_arrivals_count: 36
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--15" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/cloudflare-computer.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--16" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/cloudflare-computer.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Agent Runtime &amp; Infrastructure</span>
@@ -135,7 +143,7 @@ new_arrivals_count: 36
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--16" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/oversight-and-approval/preloop.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--01" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/oversight-and-approval/preloop.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Oversight &amp; Approval</span>
@@ -143,7 +151,7 @@ new_arrivals_count: 36
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--01" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/claude-hud.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--02" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/claude-hud.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Agent Harnesses &amp; Operator Surfaces</span>
@@ -151,7 +159,7 @@ new_arrivals_count: 36
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--02" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/search-and-web-intelligence/agent-search-mcp.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--03" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/search-and-web-intelligence/agent-search-mcp.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Search &amp; Web Intelligence</span>
@@ -159,7 +167,7 @@ new_arrivals_count: 36
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--03" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/agentmemory.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--04" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/agentmemory.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Memory &amp; State</span>
@@ -167,7 +175,7 @@ new_arrivals_count: 36
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--04" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/google-ax.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--05" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/google-ax.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Agent Runtime &amp; Infrastructure</span>
@@ -175,7 +183,7 @@ new_arrivals_count: 36
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--05" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/voice-and-phone/patter.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--06" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/voice-and-phone/patter.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Voice &amp; Phone</span>
@@ -183,7 +191,7 @@ new_arrivals_count: 36
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--06" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/communication/atomic-mail.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--07" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/communication/atomic-mail.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Communication</span>
@@ -191,7 +199,7 @@ new_arrivals_count: 36
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--07" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/meeting-and-conversation/agentcall.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--08" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/meeting-and-conversation/agentcall.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Meeting &amp; Conversation</span>
@@ -199,7 +207,7 @@ new_arrivals_count: 36
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--08" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/communication/agentteam-email.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--09" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/communication/agentteam-email.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Communication</span>
@@ -207,7 +215,7 @@ new_arrivals_count: 36
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--09" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/tencentdb-agent-memory.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--10" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/tencentdb-agent-memory.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Memory &amp; State</span>
@@ -215,7 +223,7 @@ new_arrivals_count: 36
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--10" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/longhorizon-harness.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--11" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/longhorizon-harness.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Agent Harnesses &amp; Operator Surfaces</span>
@@ -223,7 +231,7 @@ new_arrivals_count: 36
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--11" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/search-and-web-intelligence/contextx.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--12" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/search-and-web-intelligence/contextx.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Search &amp; Web Intelligence</span>
@@ -231,7 +239,7 @@ new_arrivals_count: 36
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--12" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/qm.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--13" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/qm.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Agent Harnesses &amp; Operator Surfaces</span>
@@ -239,7 +247,7 @@ new_arrivals_count: 36
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--13" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/axern.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--14" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/axern.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Code Execution</span>
@@ -247,7 +255,7 @@ new_arrivals_count: 36
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--14" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-social-network/agent-chamber.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--15" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-social-network/agent-chamber.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Agent Social &amp; Community</span>
@@ -255,7 +263,7 @@ new_arrivals_count: 36
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--15" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/voice-and-phone/qwen-audio-agent.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--16" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/voice-and-phone/qwen-audio-agent.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Voice &amp; Phone</span>
@@ -263,7 +271,7 @@ new_arrivals_count: 36
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--16" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/llm-gateway-and-routing/sageroute.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--01" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/llm-gateway-and-routing/sageroute.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">LLM Gateway &amp; Routing</span>
@@ -271,7 +279,7 @@ new_arrivals_count: 36
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--01" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/observability-and-tracing/numbat.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--02" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/observability-and-tracing/numbat.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Observability &amp; Tracing</span>
@@ -279,7 +287,7 @@ new_arrivals_count: 36
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--02" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/memmy-agent.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--03" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/memmy-agent.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Memory &amp; State</span>
@@ -287,7 +295,7 @@ new_arrivals_count: 36
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--03" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/meeting-and-conversation/looped-meet.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--04" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/meeting-and-conversation/looped-meet.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Meeting &amp; Conversation</span>
@@ -295,7 +303,7 @@ new_arrivals_count: 36
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--04" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/durable-execution-and-scheduling/pi-dispatch.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--05" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/durable-execution-and-scheduling/pi-dispatch.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Durable Execution &amp; Scheduling</span>
@@ -319,7 +327,7 @@ new_arrivals_count: 36
   <div class="section-intro">
     <span class="section-number">02</span>
     <h2 class="section-title" id="collections-title">The collections</h2>
-    <p class="section-note">16 fields · 188 dossiers</p>
+    <p class="section-note">16 fields · 189 dossiers</p>
   </div>
   <div class="collection-grid">
     <a class="collection-card atlas-visual--01" href="{{ '/categories/communication/' | relative_url }}">
@@ -343,7 +351,7 @@ new_arrivals_count: 36
       <span class="collection-card__copy">
       <span class="collection-card__number">03</span>
       <span class="collection-card__title">Tool Access &amp; Integration</span>
-      <span class="collection-card__count">16</span>
+      <span class="collection-card__count">17</span>
       </span>
     </a>
     <a class="collection-card atlas-visual--04" href="{{ '/categories/oversight-and-approval/' | relative_url }}">
@@ -470,6 +478,6 @@ new_arrivals_count: 36
   <div>
   <span class="section-number">03</span>
   <h2 class="section-title">Full source.</h2>
-  <a class="source-gateway__link" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/README.md">Open 188 dossiers ↗</a>
+  <a class="source-gateway__link" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/README.md">Open 189 dossiers ↗</a>
   </div>
 </section>

--- a/docs/skill.md
+++ b/docs/skill.md
@@ -59,7 +59,7 @@ These services can be joined with a single instruction, right now, with no human
 
 ---
 
-## Full Catalog — 16 Categories, 188 Services
+## Full Catalog — 16 Categories, 189 Services
 
 ### 1. Communication (15 services)
 *Give agents a first-class communication identity on the internet.*
@@ -116,7 +116,7 @@ These services can be joined with a single instruction, right now, with no human
 
 ---
 
-### 3. Tool Access & Integration (16 services)
+### 3. Tool Access & Integration (17 services)
 *Runtime tool discovery, auth, and execution without human pre-configuration.*
 
 | Service | Tagline | Onboarding |
@@ -137,6 +137,7 @@ These services can be joined with a single instruction, right now, with no human
 | [Snyk Agent Scan](https://github.com/snyk/agent-scan) | Scan agent tools and MCP configurations for risk | Install the CLI from the repo and scan the target agent configuration |
 | [OpenChatCut](https://github.com/0xsline/OpenChatCut) | Local-first agent-native video editor | `npx skills add 0xsline/OpenChatCut`, then ask the agent to set it up |
 | [Toolport](https://toolport.app) | Every tool. One port. | Install from GitHub Releases, add servers, connect each AI client to `toolport-gateway` |
+| [SandBase CLI](https://github.com/sandbaseai/cli) | Give your AI agent superpowers. One command. 2,000+ AI models. | GitHub `v0.1.17` tarball `connect`, then `npx skills add sandbaseai/cli --skill sandbase` |
 
 ---
 

--- a/services/tool-access-and-integration/README.md
+++ b/services/tool-access-and-integration/README.md
@@ -32,6 +32,7 @@ Agent-native tool access services solve all three problems with primitives that 
 | [Snyk Agent Scan](snyk-agent-scan.md) [![⭐](https://img.shields.io/github/stars/snyk/agent-scan?style=social)](https://github.com/snyk/agent-scan) | Security scanner for AI agents, MCP servers and agent skills | CLI, MCP config inspection, CI scan output | ✅ |
 | [OpenChatCut](openchatcut.md) [![⭐](https://img.shields.io/github/stars/0xsline/OpenChatCut?style=social)](https://github.com/0xsline/OpenChatCut) | Local-first agent-native video editor with real editable timelines | Agent Skill, Streamable HTTP MCP, isolated draft sessions, EditorCore tools | ✅ |
 | [Toolport](toolport.md) [![⭐](https://img.shields.io/github/stars/tsouth89/toolport?style=social)](https://github.com/tsouth89/toolport) | Every tool. One port. | stdio `toolport-gateway`, lazy meta-tools, per-client profiles, OS keychain | ✅ |
+| [SandBase CLI](sandbase-cli.md) [![⭐](https://img.shields.io/github/stars/sandbaseai/cli?style=social)](https://github.com/sandbaseai/cli) | Give your AI agent superpowers. One command. 2,000+ AI models. | local stdio MCP · `discover → inspect → run` · CLI connect/doctor/catalog · Agent Skill | ✅ |
 
 
 

--- a/services/tool-access-and-integration/sandbase-cli.md
+++ b/services/tool-access-and-integration/sandbase-cli.md
@@ -1,0 +1,197 @@
+# SandBase CLI
+
+> **"Give your AI agent superpowers. One command. 2,000+ AI models."**
+
+| | |
+|---|---|
+| **Website** | https://www.sandbase.ai |
+| **Docs** | https://github.com/sandbaseai/cli#readme |
+| **GitHub** | https://github.com/sandbaseai/cli |
+| **Stars** | [![GitHub Stars](https://img.shields.io/github/stars/sandbaseai/cli?style=social)](https://github.com/sandbaseai/cli) |
+| **Classification** | `agent-native` |
+| **Category** | [Tool Access & Integration Services](README.md) |
+| **License** | Apache-2.0 |
+| **Latest-month signal** | Last GitHub push 2026-08-23; immutable [`v0.1.17`](https://github.com/sandbaseai/cli/releases/tag/v0.1.17) published 2026-08-19 |
+| **Verified at** | 2026-08-25 |
+
+This entry catalogs **SandBase CLI** — the local MCP bridge and published Agent Skill — not the broader SandBase store, harness, or skills org. Issue [#103](https://github.com/haoruilee/awesome-agent-native-services/issues/103) was submitted by an authorized promoter.
+
+---
+
+## Official Website
+
+https://www.sandbase.ai
+
+The homepage is a broader builder/FDE platform ("Agent-native delivery platform for builders and FDEs") with a Store, Setup, API, and Build Agent product. This catalog lists only the CLI.
+
+---
+
+## Official Repo
+
+https://github.com/sandbaseai/cli
+
+---
+
+## How to Use (Agent Onboarding)
+
+**Interaction pattern:** `local MCP bridge` (stdio) after one browser approval
+
+The official repo's current canonical install is the immutable GitHub Release tarball, not npm `latest`:
+
+```sh
+npx -y https://github.com/sandbaseai/cli/releases/download/v0.1.17/sandbaseai-cli-0.1.17.tgz connect
+```
+
+Approve the SandBase browser authorization once. The CLI stores a restricted local credential, installs the on-demand stdio MCP bridge for detected clients, and the agent then uses `discover → inspect → run`.
+
+**Release split (verified 2026-08-25):** the GitHub Release tarball is built from the immutable `v0.1.17` tag (SHA-256 `1ad535b2899ca460b57b3c268aef278fee28fd28e649a89b92951514fd71fffa`). The npm `latest` tag currently serves **v0.1.14** while tokenless trusted publishing is being enabled. Do not treat `npx @sandbaseai/cli` as the current CLI.
+
+Read-only compatibility catalog (no sign-in, no config writes):
+
+```sh
+npx -y https://github.com/sandbaseai/cli/releases/download/v0.1.17/sandbaseai-cli-0.1.17.tgz catalog --json
+```
+
+Optional published skill (install after connect; this is still a one-time browser-approval flow, not a one-URL join):
+
+```sh
+npx skills add sandbaseai/cli --skill sandbase
+```
+
+---
+
+## Agent Skills
+
+**Status:** ✅ Available
+
+```bash
+npx skills add sandbaseai/cli --skill sandbase
+```
+
+| Skill | What It Teaches the Agent |
+|---|---|
+| [`sandbase`](https://github.com/sandbaseai/cli/blob/main/skills/sandbase/SKILL.md) | When to use the six MCP tools, the `discover → inspect → run` loop, async polling, pricing/balance checks, and the one-time browser connect step |
+
+Also listed at [skills.sh/sandbaseai/cli/sandbase](https://www.skills.sh/sandbaseai/cli/sandbase). This is the CLI-packaged Skill, not the separate [sandbaseai/sandbase-skills](https://github.com/sandbaseai/sandbase-skills) org catalog.
+
+---
+
+## MCP
+
+**Status:** ✅ Available (local on-demand bridge)
+
+| Detail | Value |
+|---|---|
+| **MCP Repo** | https://github.com/sandbaseai/cli |
+| **Transport** | stdio local bridge launched by the client; no daemon or background process |
+| **Authentication** | One browser OAuth device-flow + PKCE approval; credential stored locally with `0600` |
+| **Compatible Clients** | Official README lists 25 targets, including Cursor, Cursor CLI, Claude Code, Codex, Kiro IDE/CLI, Windsurf, Gemini CLI, Amp, Warp, OpenCode, Qwen Code, Kimi CLI, Hermes, OpenClaw, plus manual setup for ChatGPT and Claude Desktop |
+
+After connecting, the agent sees six tools: `sandbase_discover`, `sandbase_inspect`, `sandbase_run`, `sandbase_run_get`, `sandbase_runs`, `sandbase_account`.
+
+---
+
+## What It Does
+
+SandBase CLI is an Apache-2.0 TypeScript CLI that connects a coding agent to a catalog of 2,000+ models and APIs through a compact local MCP surface. The operator (or an installer) runs `connect` once; the CLI detects supported clients, opens a browser authorization, writes a client-scoped credential, and adds only SandBase-owned MCP configuration.
+
+After that, the agent searches the catalog (`sandbase_discover`), reads the current schema and price (`sandbase_inspect`), and executes (`sandbase_run`), polling async jobs with `sandbase_run_get`. `sandbase_runs` and `sandbase_account` expose recent cost and balance without starting a paid run.
+
+This is a **tool-access bridge**, not an LLM gateway and not the SandBase Store. The homepage and [Getting Started](https://www.sandbase.ai/docs/getting-started/) docs describe a builder/FDE platform (Store, Setup, Build Agent). Those products are out of scope here. The sibling [SandBase Harness](https://github.com/sandbaseai/sandbase-harness) and [sandbase-skills](https://github.com/sandbaseai/sandbase-skills) repositories are also not cataloged.
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | Official README leads with **"Give your AI agent superpowers. One command. 2,000+ AI models."** and **"One command connects your agent to 2,000+ AI models through the [Model Context Protocol](https://modelcontextprotocol.io)."** — [sandbaseai/cli](https://github.com/sandbaseai/cli) |
+| **Agent-specific primitive** | Six MCP tools for a planning loop (`discover → inspect → run`) plus async poll, recent-cost, and balance tools. A human model dashboard or per-provider REST API does not expose this compact runtime selection surface — [MCP tools](https://github.com/sandbaseai/cli#mcp-tools-available-to-your-agent-after-connecting), [SKILL.md](https://github.com/sandbaseai/cli/blob/main/skills/sandbase/SKILL.md) |
+| **Autonomy-compatible control plane** | After one browser approval, the agent invokes the six tools without a human confirming each call. `sandbase_inspect` exposes schema and current price first; `unregister` removes only SandBase-owned state — [How it works](https://github.com/sandbaseai/cli#how-it-works), [Security](https://github.com/sandbaseai/cli#security). Initial authorization is not autonomous and is not URL Onboarding |
+| **M2M integration surface** | On-demand stdio MCP bridge; `connect` / `doctor` / `unregister` / `catalog --json`; published Agent Skill; `llms-install.md` for automated installers — [CLI commands](https://github.com/sandbaseai/cli#cli-commands), [llms-install.md](https://github.com/sandbaseai/cli/blob/main/llms-install.md) |
+| **Identity / delegation** | Each connected client gets a `CredentialRecord` (`credentialId`, `client`, `scope`, `mcpUrl`, `createdAt`) stored in a client-keyed local file. Ownership checks require `scope` to include `mcp:invoke` — [types.ts](https://github.com/sandbaseai/cli/blob/main/src/types.ts), [store.ts](https://github.com/sandbaseai/cli/blob/main/src/credentials/store.ts), [commands.ts](https://github.com/sandbaseai/cli/blob/main/src/commands.ts). This is **client-scoped delegated credentials under a user SandBase account**, not independent KYA or agent legal identity |
+
+Tool Access is the correct category: the primitive is runtime discovery and delegated execution of models **and** APIs (search, scrape, social, media). It is not a per-agent LLM router.
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **`sandbase_discover`** | Search the live catalog of 2,000+ models and APIs |
+| **`sandbase_inspect`** | Return current input schema, price, and execution template before a call |
+| **`sandbase_run`** | Execute the selected model or API |
+| **`sandbase_run_get`** | Poll an asynchronous job (video generation, large scrapes) by run ID |
+| **`sandbase_runs`** | List recent calls with status and cost |
+| **`sandbase_account`** | Read account balance without starting a paid run |
+| **Client-scoped credential** | Per-client local record with `mcp:invoke` scope, `0600` file mode, ownership-aware rollback |
+| **25-client catalog** | Machine-readable `catalog --json` describing auto, guided, and manual client targets |
+
+---
+
+## Autonomy Model
+
+```
+Operator runs the v0.1.17 GitHub Release `connect` command
+    -> CLI opens OAuth device-flow + PKCE browser approval (one human click)
+    -> credential stored locally (0600), MCP bridge added for the target client
+    -> agent calls sandbase_discover, then sandbase_inspect, then sandbase_run
+    -> async jobs are polled with sandbase_run_get
+    -> sandbase_runs / sandbase_account report cost and balance
+    -> unregister / dashboard revoke removes only SandBase-owned state
+```
+
+No daemon. The client launches the stdio bridge on demand. The CLI is not a general policy or approval engine.
+
+---
+
+## Identity and Delegation Model
+
+- **User account:** Browser approval binds a SandBase user account. The CLI does not mint an independent agent passport or KYA token.
+- **Client-scoped credential:** `CredentialRecord` is keyed by client and includes `credentialId`, `client`, `scope`, `mcpUrl`, and `createdAt` ([types.ts](https://github.com/sandbaseai/cli/blob/main/src/types.ts)).
+- **Delegation scope:** Ownership validation requires `scope` to include `mcp:invoke` ([commands.ts](https://github.com/sandbaseai/cli/blob/main/src/commands.ts)).
+- **Isolation:** The local store writes one record per client; shared configuration slots refuse silent takeover by another client.
+- **Secrets:** Device-flow + PKCE; no secrets in URLs or CLI args; files written with `0600` ([fs-safe.ts](https://github.com/sandbaseai/cli/blob/main/src/fs-safe.ts), [Security](https://github.com/sandbaseai/cli#security)).
+- **Audit / cost:** `sandbase_runs` returns recent model/API calls with status and cost. That is run/cost history, not a full replay or approval artifact.
+- **Revocation:** `unregister` removes only SandBase-owned MCP/Skill state; keys can also be revoked in the [SandBase Dashboard](https://sandbase.ai/console/keys).
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| Local MCP | On-demand stdio bridge exposing six `sandbase_*` tools |
+| CLI | `connect`, `doctor`, `unregister`, `catalog --json` |
+| Agent Skill | `npx skills add sandbaseai/cli --skill sandbase` |
+| Installer notes | [llms-install.md](https://github.com/sandbaseai/cli/blob/main/llms-install.md) |
+| Parent platform API | Separate HTTP API on sandbase.ai — not this catalog entry |
+| npm package | `@sandbaseai/cli` exists; `latest` is v0.1.14 as of 2026-08-25 |
+
+---
+
+## Human-in-the-Loop Support
+
+One browser approval is required to create the local credential. After that, ordinary discover/inspect/run calls do not prompt the operator. The CLI is not a per-action approval gate. Balance top-up and key revocation happen in the human dashboard. `llms-install.md` states the user must complete authorization personally and must not paste a credential into chat.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **SandBase Store / Build Agent homepage** | Human-facing capability marketplace and FDE workflow builder. It is the parent platform, not an agent MCP control plane. Not cataloged here |
+| **Per-provider REST keys** | Each vendor has its own schema, auth, pricing, and async lifecycle. No single `discover → inspect → run` loop or client-scoped local delegation |
+| **Generic LLM gateway** | Routes chat completions. SandBase CLI also searches, scrapes, and calls social/media APIs through the same six tools |
+| **Manual per-client MCP config** | Repeats auth and dumps provider-specific tools into every host. No ownership-aware rollback or 25-client catalog |
+
+---
+
+## Use Cases
+
+- **Coding agents that need live data** — web search, scrape, social, or image/video generation without wiring each provider key
+- **Schema-before-spend** — inspect current price and input schema, then run
+- **Async media jobs** — start a video generation run and poll by `run_id`
+- **Shared laptop, scoped clients** — connect Cursor and Codex separately; each keeps its own credential record
+- **Support / CI inspection** — `catalog --json` and `doctor` without signing in or rewriting config

--- a/skill.md
+++ b/skill.md
@@ -5,7 +5,7 @@ description: >
   surfaces for live agents. Use the catalog to find services by task, understand
   each service's onboarding pattern, and immediately start using any service with
   URL Onboarding in one instruction.
-version: "2026-08-19"
+version: "2026-08-25"
 license: CC0-1.0
 catalog: https://github.com/haoruilee/awesome-agent-native-services
 allowed-tools: WebSearch Read
@@ -72,7 +72,7 @@ These services can be joined with a single instruction, right now, with no human
 
 ---
 
-## Full Catalog — 16 Categories, 188 Services
+## Full Catalog — 16 Categories, 189 Services
 
 ### 1. Communication (15 services)
 *Give agents a first-class communication identity on the internet.*
@@ -129,7 +129,7 @@ These services can be joined with a single instruction, right now, with no human
 
 ---
 
-### 3. Tool Access & Integration (16 services)
+### 3. Tool Access & Integration (17 services)
 *Runtime tool discovery, auth, and execution without human pre-configuration.*
 
 | Service | Tagline | Onboarding |
@@ -150,6 +150,7 @@ These services can be joined with a single instruction, right now, with no human
 | [Snyk Agent Scan](https://github.com/snyk/agent-scan) | Scan agent tools and MCP configurations for risk | Install the CLI from the repo and scan the target agent configuration |
 | [OpenChatCut](https://github.com/0xsline/OpenChatCut) | Local-first agent-native video editor | `npx skills add 0xsline/OpenChatCut`, then ask the agent to set it up |
 | [Toolport](https://toolport.app) | Every tool. One port. | Install from GitHub Releases, add servers, connect each AI client to `toolport-gateway` |
+| [SandBase CLI](https://github.com/sandbaseai/cli) | Give your AI agent superpowers. One command. 2,000+ AI models. | GitHub `v0.1.17` tarball `connect`, then `npx skills add sandbaseai/cli --skill sandbase` |
 
 ---
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #103.

Maintainer-authored after the [✅ Go on #103](https://github.com/haoruilee/awesome-agent-native-services/issues/103#issuecomment-5365295004). Category is **Tool Access & Integration** (not LLM Gateway). Inventory is **189 services / 16 categories**.

## Type of change

- [x] 🆕 New service entry

## Linked issue

Closes #103

Issue #103 was submitted by an authorized SandBase promoter (disclosed on the issue). This PR catalogs only the CLI.

## Service being added / changed

**Service name:** SandBase CLI
**File(s) modified:**
- `services/tool-access-and-integration/sandbase-cli.md` (new)
- `services/tool-access-and-integration/README.md`
- `README.md`
- `skill.md` (count bump + row; catalog version `2026-08-25`)
- regenerated `catalog.json`, `docs/**`

## Honesty notes

- **CLI vs store:** homepage is a broader builder/FDE platform (Store, Setup, Build Agent). This entry is the local MCP bridge + published `sandbase` Skill only. Harness and `sandbase-skills` org are not cataloged.
- **Identity:** client-scoped delegated credentials under a user SandBase account (`CredentialRecord` + `mcp:invoke`). Not independent KYA / agent legal identity.
- **Onboarding:** one browser approval is required. Not URL Onboarding. Machine contract type is `mcp`.
- **Release split (verified 2026-08-25):** GitHub immutable `v0.1.17` tarball is the canonical install; npm `latest` is still **v0.1.14**.
- Official quotes, license (Apache-2.0), install commands, and dates are from official sources checked today.

## New service checklist

### Admission track — evidence

- [x] Standard five-criteria track

| Criterion | Evidence (quote + source URL) |
|---|---|
| 1. Agent-first positioning | “Give your AI agent superpowers. One command. 2,000+ AI models.” — https://github.com/sandbaseai/cli |
| 2. Agent-specific primitive | Six MCP tools, workflow `discover → inspect → run` — https://github.com/sandbaseai/cli#mcp-tools-available-to-your-agent-after-connecting |
| 3. Autonomy-compatible control plane | One browser approval, then agent invokes tools; `unregister` is ownership-aware — https://github.com/sandbaseai/cli#how-it-works |
| 4. Machine-to-machine integration surface | Local stdio MCP, `catalog --json`, published Skill — https://github.com/sandbaseai/cli#cli-commands |
| 5. Agent identity / delegation semantics | Per-client `CredentialRecord`; scope must include `mcp:invoke` — https://github.com/sandbaseai/cli/blob/main/src/types.ts |

### File structure

- [x] Created `services/tool-access-and-integration/sandbase-cli.md`
- [x] Added a row to `services/tool-access-and-integration/README.md`
- [x] Added a row to the Tool Access section in the root `README.md`

### Required sections

All 14 required sections are present, with the newest meta table (Website / Docs / GitHub / live Stars badge / Classification / Category / License / Latest-month signal / Verified at 2026-08-25).

### Classification

- [x] `agent-native`

### Bonus signals

- [ ] ⭐ URL Onboarding
- [ ] Dedicated agent legal identity / KYA
- [x] MCP server published
- [x] Agent Skills published (`npx skills add sandbaseai/cli --skill sandbase`)
- [ ] Per-agent memory/session
- [ ] Full replay/approval artifacts (recent cost history only)

## Final checks

- [x] Official website, repo, release, Skill, docs, and blog links verified live on 2026-08-25 (`https://www.sandbase.ai/docs/setup/cli` is 404 and was not used)
- [x] Affiliation on #103 disclosed; this PR adds no extra financial interest
- [x] Regenerated with `bash scripts/build-github-pages.sh` and `python3 scripts/build-machine-catalog.py`
- [x] `python3 scripts/build-machine-catalog.py --check` passed
- [x] `python3 scripts/check-repository-health.py --local --freshness-max-days 45` passed

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0a9c65aa-bfd0-47ec-9fa2-16fbf5ad953c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0a9c65aa-bfd0-47ec-9fa2-16fbf5ad953c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

