### PR TITLE
[New Service] Bifrost

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Recommended flow for agents: start with `skill.md` for quick discovery, switch t
 
 ## Categories
 
-**189 services across 16 categories.**
+**190 services across 16 categories.**
 
 | # | Category | Services | Description |
 |---|---|---|---|
@@ -101,7 +101,7 @@ Recommended flow for agents: start with `skill.md` for quick discovery, switch t
 | 12 | [Durable Execution & Scheduling](#12-durable-execution--scheduling-services) | 7 | Fault-tolerant long-running agent workflows |
 | 13 | [Meeting & Conversation](#13-meeting--conversation-services) | 7 | Agent presence in voice and video meetings |
 | 14 | [Voice & Phone](#14-voice--phone-services) | 7 | Agent-controlled voice calls and phone infrastructure |
-| 15 | [LLM Gateway & Routing](#15-llm-gateway--routing-services) | 8 | Per-agent budget, routing, caching, and observability for LLM calls |
+| 15 | [LLM Gateway & Routing](#15-llm-gateway--routing-services) | 9 | Per-agent budget, routing, caching, and observability for LLM calls |
 | 16 | [Agent Social & Community](#16-agent-social--community-services) | 7 | Social networks where agents are first-class participants |
 
 ---
@@ -452,6 +452,7 @@ Recommended flow for agents: start with `skill.md` for quick discovery, switch t
 | [Keywords AI](services/llm-gateway-and-routing/keywords-ai.md) | AI gateway — 250+ LLMs via OpenAI-compatible API | Fallback · Load balancing · `KeywordsAITraceProcessor` for OpenAI Agents SDK | ⚠️ | Point OpenAI SDK at `https://api.keywordsai.co` — [gateway quickstart](https://docs.keywordsai.co/get-started/quickstart/gateway) |
 | [Agentgateway](services/llm-gateway-and-routing/agentgateway.md) [![⭐](https://img.shields.io/github/stars/agentgateway/agentgateway?style=social)](https://github.com/agentgateway/agentgateway) | Open-source proxy for agentic AI (LLM + MCP + A2A) | MCP federation · A2A routing · OpenAI-compatible LLM path · OTEL · CEL RBAC | ✅ | [Quickstart](https://agentgateway.dev/docs/quickstart/): install binary/Docker/K8s → `agentgateway -f config.yaml` |
 | [LiteLLM](services/llm-gateway-and-routing/litellm.md) [![⭐](https://img.shields.io/github/stars/BerriAI/litellm?style=social)](https://github.com/BerriAI/litellm) | Open-source AI gateway — 100+ LLMs + Agent Gateway (A2A) | Virtual keys · Budgets · A2A agent routing · Trace/agent headers | ✅ | Self-host proxy per [docs.litellm.ai](https://docs.litellm.ai/docs/proxy/docker_quick_start) — [A2A gateway](https://docs.litellm.ai/docs/a2a) |
+| [Bifrost](services/llm-gateway-and-routing/bifrost.md) [![⭐](https://img.shields.io/github/stars/maximhq/bifrost?style=social)](https://github.com/maximhq/bifrost) | High-performance AI gateway for unified provider access | OpenAI-compatible API · Virtual keys · Fallback/load balancing · MCP gateway | ✅ | `npx -y @maximhq/bifrost` then connect an MCP client to `/mcp` |
 | [OpenRouter](services/llm-gateway-and-routing/openrouter.md) | Unified OpenAI-compatible API — 300+ models | Cross-provider routing · Uptime optimization · Org data policies | ❌ | [openrouter.ai/docs/quickstart](https://openrouter.ai/docs/quickstart) — OpenAI SDK + `OPENROUTER_API_KEY` |
 | [Helicone](services/llm-gateway-and-routing/helicone.md) | AI Gateway + observability — 100+ models, unified credits | `ai-gateway.helicone.ai` · Fallbacks · Request logging | ❌ | OpenAI SDK `baseURL` `https://ai-gateway.helicone.ai` — [docs.helicone.ai](https://docs.helicone.ai/) |
 | [Routerly](services/llm-gateway-and-routing/routerly.md) [![⭐](https://img.shields.io/github/stars/Inebrio/Routerly?style=social)](https://github.com/Inebrio/Routerly) | Self-hosted LLM gateway with LLM-native routing policy | Multi-policy scoring (incl. LLM router) · Per-tenant budget/ledger · Zero stateful deps · OpenAI/Anthropic compat | ⚠️ | `docker run -p 8080:8080 -v ./routerly.json:/config/routerly.json inebrio/routerly:latest` then point client `OPENAI_BASE_URL` |

--- a/catalog.json
+++ b/catalog.json
@@ -11,7 +11,7 @@
     "service_directory": "services",
     "content_digest": {
       "algorithm": "sha256",
-      "value": "84ca549b1cb86e190f88a1926ee804fad074d40d2b76640d4194a2fc9116a5fc",
+      "value": "759c8099552c99b6b77430b2c25eb75adaa79ac5c5aefb40943198cd3c3a5d9e",
       "input_paths": [
         "README.md",
         "skill.md",
@@ -205,6 +205,7 @@
         "services/voice-and-phone/vapi.md",
         "services/llm-gateway-and-routing/README.md",
         "services/llm-gateway-and-routing/agentgateway.md",
+        "services/llm-gateway-and-routing/bifrost.md",
         "services/llm-gateway-and-routing/helicone.md",
         "services/llm-gateway-and-routing/keywords-ai.md",
         "services/llm-gateway-and-routing/litellm.md",
@@ -225,7 +226,7 @@
   },
   "counts": {
     "categories": 16,
-    "services": 189
+    "services": 190
   },
   "categories": [
     {
@@ -331,7 +332,7 @@
       "name": "LLM Gateway & Routing",
       "description": "Services that give AI agents a reliable, observable, and cost-controlled interface to LLM providers — with per-agent routing, budget enforcement, fallback logic, and semantic caching as first-class primitives.",
       "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/llm-gateway-and-routing/README.md",
-      "service_count": 8
+      "service_count": 9
     },
     {
       "id": "agent-social-network",
@@ -5825,6 +5826,41 @@
       "latest_month_signal": null,
       "verified_at": null,
       "verification_sources": []
+    },
+    {
+      "id": "llm-gateway-and-routing/bifrost",
+      "slug": "bifrost",
+      "name": "Bifrost",
+      "tagline": "The fastest way to build AI applications that never go down.",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "unknown",
+      "category": "llm-gateway-and-routing",
+      "website": "https://docs.getbifrost.ai",
+      "repository": "https://github.com/maximhq/bifrost",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/llm-gateway-and-routing/bifrost.md",
+      "source_path": "services/llm-gateway-and-routing/bifrost.md",
+      "onboarding": {
+        "type": "cli",
+        "pattern": null,
+        "instruction": "npx -y @maximhq/bifrost",
+        "url": "http://localhost:8080"
+      },
+      "protocols": [
+        "mcp",
+        "cli",
+        "sdk",
+        "json-rpc",
+        "http",
+        "api"
+      ],
+      "mcp_status": "available",
+      "agent_skill_status": "unavailable",
+      "latest_month_signal": null,
+      "verified_at": "2026-08-25",
+      "verification_sources": [
+        "https://github.com/maximhq/bifrost"
+      ]
     },
     {
       "id": "llm-gateway-and-routing/helicone",

--- a/docs/catalog.json
+++ b/docs/catalog.json
@@ -11,7 +11,7 @@
     "service_directory": "services",
     "content_digest": {
       "algorithm": "sha256",
-      "value": "84ca549b1cb86e190f88a1926ee804fad074d40d2b76640d4194a2fc9116a5fc",
+      "value": "759c8099552c99b6b77430b2c25eb75adaa79ac5c5aefb40943198cd3c3a5d9e",
       "input_paths": [
         "README.md",
         "skill.md",
@@ -205,6 +205,7 @@
         "services/voice-and-phone/vapi.md",
         "services/llm-gateway-and-routing/README.md",
         "services/llm-gateway-and-routing/agentgateway.md",
+        "services/llm-gateway-and-routing/bifrost.md",
         "services/llm-gateway-and-routing/helicone.md",
         "services/llm-gateway-and-routing/keywords-ai.md",
         "services/llm-gateway-and-routing/litellm.md",
@@ -225,7 +226,7 @@
   },
   "counts": {
     "categories": 16,
-    "services": 189
+    "services": 190
   },
   "categories": [
     {
@@ -331,7 +332,7 @@
       "name": "LLM Gateway & Routing",
       "description": "Services that give AI agents a reliable, observable, and cost-controlled interface to LLM providers — with per-agent routing, budget enforcement, fallback logic, and semantic caching as first-class primitives.",
       "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/llm-gateway-and-routing/README.md",
-      "service_count": 8
+      "service_count": 9
     },
     {
       "id": "agent-social-network",
@@ -5825,6 +5826,41 @@
       "latest_month_signal": null,
       "verified_at": null,
       "verification_sources": []
+    },
+    {
+      "id": "llm-gateway-and-routing/bifrost",
+      "slug": "bifrost",
+      "name": "Bifrost",
+      "tagline": "The fastest way to build AI applications that never go down.",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "unknown",
+      "category": "llm-gateway-and-routing",
+      "website": "https://docs.getbifrost.ai",
+      "repository": "https://github.com/maximhq/bifrost",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/llm-gateway-and-routing/bifrost.md",
+      "source_path": "services/llm-gateway-and-routing/bifrost.md",
+      "onboarding": {
+        "type": "cli",
+        "pattern": null,
+        "instruction": "npx -y @maximhq/bifrost",
+        "url": "http://localhost:8080"
+      },
+      "protocols": [
+        "mcp",
+        "cli",
+        "sdk",
+        "json-rpc",
+        "http",
+        "api"
+      ],
+      "mcp_status": "available",
+      "agent_skill_status": "unavailable",
+      "latest_month_signal": null,
+      "verified_at": "2026-08-25",
+      "verification_sources": [
+        "https://github.com/maximhq/bifrost"
+      ]
     },
     {
       "id": "llm-gateway-and-routing/helicone",

--- a/docs/categories/index.md
+++ b/docs/categories/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Agent-Native Collections"
-description: "Browse 189 agent-native services across 16 curated infrastructure collections."
+description: "Browse 190 agent-native services across 16 curated infrastructure collections."
 permalink: /categories/
 page_kind: document
 ---
@@ -123,7 +123,7 @@ page_kind: document
     <span class="collection-card__copy">
     <span class="collection-card__number">15</span>
     <span class="collection-card__title">LLM Gateway &amp; Routing</span>
-    <span class="collection-card__count">8</span>
+    <span class="collection-card__count">9</span>
     </span>
   </a>
   <a class="collection-card atlas-visual--16" href="{{ '/categories/agent-social-network/' | relative_url }}">

--- a/docs/categories/llm-gateway-and-routing.md
+++ b/docs/categories/llm-gateway-and-routing.md
@@ -6,7 +6,7 @@ hero_image: "/assets/images/editorial-routing.webp"
 permalink: /categories/llm-gateway-and-routing/
 page_kind: collection
 collection_number: "15"
-service_count: 8
+service_count: 9
 ---
 
 <p class="collection-source"><a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/llm-gateway-and-routing/README.md">Collection notes ↗</a></p>
@@ -27,13 +27,24 @@ service_count: 8
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
+    <h2 class="service-card__title">Bifrost</h2>
+    <div class="service-card__actions">
+      <a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/llm-gateway-and-routing/bifrost.md">Open dossier ↗</a>
+      <a href="https://github.com/maximhq/bifrost">Official repo ↗</a>
+    </div>
+    </div>
+  </article>
+  <article class="service-card atlas-sheet--service atlas-visual--03">
+    <span class="service-card__image" aria-hidden="true"></span>
+    <div class="service-card__copy">
+    <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
     <h2 class="service-card__title">Helicone</h2>
     <div class="service-card__actions">
       <a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/llm-gateway-and-routing/helicone.md">Open dossier ↗</a>
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--03">
+  <article class="service-card atlas-sheet--service atlas-visual--04">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -43,7 +54,7 @@ service_count: 8
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--04">
+  <article class="service-card atlas-sheet--service atlas-visual--05">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -54,7 +65,7 @@ service_count: 8
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--05">
+  <article class="service-card atlas-sheet--service atlas-visual--06">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -65,7 +76,7 @@ service_count: 8
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--06">
+  <article class="service-card atlas-sheet--service atlas-visual--07">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -76,7 +87,7 @@ service_count: 8
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--07">
+  <article class="service-card atlas-sheet--service atlas-visual--08">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -87,7 +98,7 @@ service_count: 8
     </div>
     </div>
   </article>
-  <article class="service-card service-card--new atlas-sheet--service atlas-visual--08">
+  <article class="service-card service-card--new atlas-sheet--service atlas-visual--09">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@ title: "The Agent-Native Index"
 description: "A curated 2026 collection of agent-native infrastructure: MCP tools, harnesses, identity, memory, sandboxes, browsers, payments, and runtimes."
 image: /assets/images/social-preview.png
 page_kind: home
-service_count: 189
+service_count: 190
 collection_count: 16
 new_arrivals_count: 37
 ---
@@ -327,7 +327,7 @@ new_arrivals_count: 37
   <div class="section-intro">
     <span class="section-number">02</span>
     <h2 class="section-title" id="collections-title">The collections</h2>
-    <p class="section-note">16 fields · 189 dossiers</p>
+    <p class="section-note">16 fields · 190 dossiers</p>
   </div>
   <div class="collection-grid">
     <a class="collection-card atlas-visual--01" href="{{ '/categories/communication/' | relative_url }}">
@@ -447,7 +447,7 @@ new_arrivals_count: 37
       <span class="collection-card__copy">
       <span class="collection-card__number">15</span>
       <span class="collection-card__title">LLM Gateway &amp; Routing</span>
-      <span class="collection-card__count">8</span>
+      <span class="collection-card__count">9</span>
       </span>
     </a>
     <a class="collection-card atlas-visual--16" href="{{ '/categories/agent-social-network/' | relative_url }}">
@@ -478,6 +478,6 @@ new_arrivals_count: 37
   <div>
   <span class="section-number">03</span>
   <h2 class="section-title">Full source.</h2>
-  <a class="source-gateway__link" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/README.md">Open 189 dossiers ↗</a>
+  <a class="source-gateway__link" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/README.md">Open 190 dossiers ↗</a>
   </div>
 </section>

--- a/docs/skill.md
+++ b/docs/skill.md
@@ -59,7 +59,7 @@ These services can be joined with a single instruction, right now, with no human
 
 ---
 
-## Full Catalog — 16 Categories, 189 Services
+## Full Catalog — 16 Categories, 190 Services
 
 ### 1. Communication (15 services)
 *Give agents a first-class communication identity on the internet.*
@@ -347,7 +347,7 @@ These services can be joined with a single instruction, right now, with no human
 
 ---
 
-### 15. LLM Gateway & Routing (8 services)
+### 15. LLM Gateway & Routing (9 services)
 *Per-agent budget, routing, caching, and observability for LLM calls.*
 
 | Service | Tagline | Onboarding |
@@ -356,6 +356,7 @@ These services can be joined with a single instruction, right now, with no human
 | [Keywords AI](https://www.keywordsai.co) | OpenAI-compatible gateway + agent tracing | Base URL `https://api.keywordsai.co` — [gateway quickstart](https://docs.keywordsai.co/get-started/quickstart/gateway) |
 | [Agentgateway](https://agentgateway.dev) | Open-source LLM + MCP + A2A proxy | Install via [quickstart](https://agentgateway.dev/docs/quickstart/) → run `agentgateway -f config.yaml` |
 | [LiteLLM](https://www.litellm.ai) | Open-source gateway — 100+ LLMs + Agent Gateway (A2A) | Self-host per [proxy quickstart](https://docs.litellm.ai/docs/proxy/docker_quick_start) — [A2A](https://docs.litellm.ai/docs/a2a) |
+| [Bifrost](https://docs.getbifrost.ai) | High-performance AI gateway for unified provider access | `npx -y @maximhq/bifrost` then connect an MCP client to `/mcp` |
 | [OpenRouter](https://openrouter.ai) | Unified OpenAI-compatible API — 300+ models | [Quickstart](https://openrouter.ai/docs/quickstart) + `OPENROUTER_API_KEY` |
 | [Helicone](https://www.helicone.ai) | AI Gateway + observability — `ai-gateway.helicone.ai` | OpenAI SDK `baseURL` per [Helicone quickstart](https://docs.helicone.ai/) |
 | [Routerly](https://github.com/Inebrio/Routerly) | Self-hosted gateway with LLM-native routing policy | Run the official Docker image with `routerly.json`, then point the client base URL to it |

--- a/services/llm-gateway-and-routing/README.md
+++ b/services/llm-gateway-and-routing/README.md
@@ -20,6 +20,7 @@ Calling an LLM directly is fine for prototyping. Running agents in production �
 | [Keywords AI](keywords-ai.md) | AI gateway — 250+ models via OpenAI-compatible API | Fallback · Load balancing · OpenAI Agents trace processor | ⚠️ |
 | [Agentgateway](agentgateway.md) | Connect, secure, and observe agentic workflows (MCP, A2A, LLM) | OpenAI-compatible proxy, MCP gateway, A2A, Kubernetes/bare metal | ✅ |
 | [LiteLLM](litellm.md) [![⭐](https://img.shields.io/github/stars/BerriAI/litellm?style=social)](https://github.com/BerriAI/litellm) | Open-source AI gateway — 100+ LLMs, virtual keys, Agent Gateway (A2A) | OpenAI-compatible proxy, Docker/K8s, A2A JSON-RPC, MCP (gateway) | ✅ |
+| [Bifrost](bifrost.md) [![⭐](https://img.shields.io/github/stars/maximhq/bifrost?style=social)](https://github.com/maximhq/bifrost) | High-performance AI gateway with provider routing, governance, and MCP gateway | OpenAI-compatible REST, Go SDK, MCP gateway, HTTP/SSE | ✅ |
 | [OpenRouter](openrouter.md) | The unified interface for LLMs — one API, 300+ models | OpenAI-compatible REST, TypeScript/Python/Go/Java SDKs | ❌ |
 | [Helicone](helicone.md) | AI Gateway & LLM observability — 100+ models, unified credits | OpenAI-compatible gateway (`ai-gateway.helicone.ai`), dashboard | ❌ |
 | [Routerly](routerly.md) [![⭐](https://img.shields.io/github/stars/Inebrio/Routerly?style=social)](https://github.com/Inebrio/Routerly) | Self-hosted LLM gateway with LLM-native routing policy — no DB required | OpenAI/Anthropic-compatible HTTP, JSON config, Docker single binary | ⚠️ |

--- a/services/llm-gateway-and-routing/bifrost.md
+++ b/services/llm-gateway-and-routing/bifrost.md
@@ -1,0 +1,183 @@
+# Bifrost
+
+> **"The fastest way to build AI applications that never go down."**
+
+| | |
+|---|---|
+| **Website** | https://docs.getbifrost.ai |
+| **Docs** | https://docs.getbifrost.ai |
+| **GitHub** | https://github.com/maximhq/bifrost |
+| **Stars** | [![GitHub Stars](https://img.shields.io/github/stars/maximhq/bifrost?style=social)](https://github.com/maximhq/bifrost) |
+| **Classification** | `agent-native` |
+| **Category** | [LLM Gateway & Routing Services](README.md) |
+| **License** | Apache-2.0 |
+| **Verified at** | 2026-08-25 |
+
+---
+
+## Official Website
+
+https://docs.getbifrost.ai
+
+---
+
+## Official Repo
+
+https://github.com/maximhq/bifrost
+
+---
+
+## How to Use (Agent Onboarding)
+
+**Quickest verified path for a self-hosted gateway:**
+
+```bash
+npx -y @maximhq/bifrost
+```
+
+The gateway starts on `http://localhost:8080`. Configure providers through the Web UI, API, or `config.json`, then point an OpenAI-compatible client at the gateway. To expose aggregated MCP tools, connect an MCP client to `http://localhost:8080/mcp` and provide a virtual-key header when authentication is enabled:
+
+```json
+{
+  "mcpServers": {
+    "bifrost": {
+      "url": "http://localhost:8080/mcp",
+      "headers": {
+        "Authorization": "Bearer vk_your_virtual_key"
+      }
+    }
+  }
+}
+```
+
+See the [gateway setup guide](https://docs.getbifrost.ai/quickstart/gateway/setting-up) and [MCP gateway guide](https://docs.getbifrost.ai/mcp/gateway).
+
+---
+
+## Agent Skills
+
+**Status:** ⚠️ No official Agent Skill published by Bifrost yet.
+
+Search community skills: `npx clawhub@latest search bifrost`. For faster access in China, use the official ClawHub mirror: set `CLAWHUB_REGISTRY=https://cn.clawhub-mirror.com` or `--registry https://cn.clawhub-mirror.com` — [mirror-cn.clawhub.com](https://mirror-cn.clawhub.com).
+
+See: https://agentskills.io/specification to contribute one.
+
+---
+
+## MCP
+
+**Status:** ✅ Available
+
+Bifrost can connect to external MCP servers as a client and, in Gateway deployment, expose aggregated tools as an MCP server at `/mcp`. The MCP gateway feature is documented for Bifrost v1.4.0-prerelease1 and above.
+
+| Detail | Value |
+|---|---|
+| **MCP Repo** | https://github.com/maximhq/bifrost |
+| **Transport** | HTTP JSON-RPC 2.0 via `POST /mcp`; Server-Sent Events via `GET /mcp` |
+| **Authentication** | Virtual-key/API-key headers or OAuth 2.1, controlled by `mcp_server_auth_mode` |
+| **Compatible Clients** | Claude Desktop, Cursor, custom MCP applications, and other MCP-compatible clients |
+
+Sources: [MCP overview](https://docs.getbifrost.ai/mcp/overview), [MCP gateway](https://docs.getbifrost.ai/mcp/gateway), and [gateway authentication](https://docs.getbifrost.ai/mcp/gateway-auth).
+
+---
+
+## What It Does
+
+Bifrost is a high-performance, self-hosted AI gateway that provides one OpenAI-compatible interface to more than 23 model providers. It handles provider configuration, request routing, retries, automatic fallbacks, load balancing, semantic caching, and drop-in integrations for common AI SDKs.
+
+For agent systems, Bifrost adds an MCP client and gateway, opt-in Agent Mode for automatic tool execution, per-virtual-key tool filtering, hierarchical budgets and rate limits, and request observability. The gateway can aggregate tools from multiple MCP servers behind one endpoint while keeping provider credentials and governance policies outside agent code.
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | Bifrost's official MCP documentation describes Agent Mode as a way to enable autonomous tool execution and transform static chat models into action-capable agents. The project README uses the broader phrase “AI applications” rather than claiming an agent-only audience; that boundary was disclosed in [issue #105](https://github.com/haoruilee/awesome-agent-native-services/issues/105), which the maintainer approved before this PR. |
+| **Agent-specific primitive** | The MCP gateway aggregates external tools for MCP clients, while Agent Mode can execute configured tools automatically. Virtual keys can filter which MCP clients and tools are exposed to each caller. |
+| **Autonomy-compatible control plane** | Provider retries, fallbacks, and load balancing operate without per-request human intervention. Agent Mode is explicitly opt-in; the safer default keeps tool calls as suggestions that require a separate execution call. |
+| **M2M integration surface** | Bifrost exposes an OpenAI-compatible HTTP API, a native Go SDK, an MCP JSON-RPC/SSE gateway, and API-, Web UI-, and file-based configuration. |
+| **Identity / delegation** | Virtual keys scope provider/model access, MCP tools, budgets, and rate limits. MCP OAuth can represent a virtual key, development session, or authenticated user. Bifrost documents scoped governance and audit logging, but does not claim a dedicated per-agent identity or KYA system. |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **MCP Gateway** | Exposes connected MCP tools through one HTTP/SSE endpoint for external MCP clients. |
+| **Agent Mode** | Opt-in automatic execution of configured tools for action-capable agent loops. |
+| **Virtual Keys** | Scoped credentials with provider/model filtering, MCP tool permissions, budgets, and rate limits. |
+| **Provider Routing** | Unified model access with retries, key rotation, fallback chains, and load balancing. |
+| **Hierarchical Budgets** | Cumulative cost limits and rate limits across customers, teams, virtual keys, and provider configurations. |
+| **Request Observability** | Asynchronous logs, token and cost data, latency, provider context, tool calls, and Prometheus/distributed tracing integrations. |
+
+---
+
+## Autonomy Model
+
+```text
+Agent client connects to Bifrost's OpenAI-compatible API or /mcp endpoint
+    ↓
+Bifrost authenticates the request and applies virtual-key tool/model policy
+    ↓
+The agent discovers available models or MCP tools
+    ↓
+Bifrost routes the model request and retries, rotates keys, or falls back when needed
+    ↓
+The agent receives a response or an MCP tool call
+    ↓
+Default MCP mode waits for an explicit execution request; configured Agent Mode can execute allowed tools automatically
+    ↓
+Budgets, rate limits, logs, metrics, and traces record the operation
+```
+
+---
+
+## Identity and Delegation Model
+
+- Virtual keys are the main governance entity and can restrict models, providers, MCP clients, and individual tools.
+- Virtual keys can be attached to teams or customers and carry independent budgets and request/token rate limits.
+- MCP clients can authenticate with a virtual-key/API-key header or use Bifrost's OAuth 2.1 flow when enabled.
+- OAuth consent can bind a grant to a virtual key, an anonymous development session, or an authenticated user through SSO/SCIM.
+- Request and tool-operation logs provide operational attribution, while Prometheus and distributed tracing integrations support deployment-level monitoring.
+- Bifrost does not present a separate per-agent identity or delegated-credential marketplace; deployments should use scoped virtual keys or OAuth identities when that boundary is required.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| OpenAI-compatible HTTP API | Unified `/v1` API for supported model providers, including chat, responses, streaming, and tool calling where supported. |
+| MCP Gateway | `POST /mcp` JSON-RPC tool discovery/execution and `GET /mcp` SSE for external MCP clients. |
+| Go SDK | `go get github.com/maximhq/bifrost/core` for direct in-process provider access and tool-calling integrations. |
+| Configuration API | Provider, virtual-key, budget, rate-limit, and MCP configuration through the management API. |
+| Configuration files | Declarative `config.json` configuration for provider and governance setup. |
+| Observability | Request logs, cost/token/latency metadata, Prometheus metrics, and distributed tracing integrations. |
+
+---
+
+## Human-in-the-Loop Support
+
+Bifrost's default MCP tool-calling flow does not execute tools automatically. The model returns a tool-call suggestion, the application can inspect or approve it, and a separate API call executes the approved operation. Agent Mode is an explicit opt-in that allows configured tools to run automatically. Bifrost supplies the execution and policy controls; an application or client remains responsible for any domain-specific approval UX.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **Direct provider API** | Exposes one provider and leaves cross-provider fallback, load balancing, MCP aggregation, and unified governance to the agent application. |
+| **Generic reverse proxy** | Forwards HTTP traffic but does not provide model-aware routing, virtual-key budgets, MCP tool filtering, Agent Mode, or LLM-specific observability. |
+| **Provider-specific SDK** | Requires provider-specific integration code and does not give an agent a common gateway surface across providers and MCP tools. |
+
+---
+
+## Use Cases
+
+- **Self-hosted agent gateway** — expose one OpenAI-compatible endpoint to an agent fleet while keeping provider credentials server-side.
+- **MCP tool aggregation** — connect filesystem, web-search, database, and custom MCP servers, then expose them through one governed endpoint.
+- **Reliable model routing** — retry, rotate keys, load-balance, and fall back across providers without changing agent code.
+- **Budgeted agent workloads** — assign virtual keys to teams or customers with independent cost and rate limits.
+- **Auditable tool operations** — retain request, tool-call, cost, latency, and provider metadata for debugging and operational review.

--- a/skill.md
+++ b/skill.md
@@ -72,7 +72,7 @@ These services can be joined with a single instruction, right now, with no human
 
 ---
 
-## Full Catalog — 16 Categories, 189 Services
+## Full Catalog — 16 Categories, 190 Services
 
 ### 1. Communication (15 services)
 *Give agents a first-class communication identity on the internet.*
@@ -360,7 +360,7 @@ These services can be joined with a single instruction, right now, with no human
 
 ---
 
-### 15. LLM Gateway & Routing (8 services)
+### 15. LLM Gateway & Routing (9 services)
 *Per-agent budget, routing, caching, and observability for LLM calls.*
 
 | Service | Tagline | Onboarding |
@@ -369,6 +369,7 @@ These services can be joined with a single instruction, right now, with no human
 | [Keywords AI](https://www.keywordsai.co) | OpenAI-compatible gateway + agent tracing | Base URL `https://api.keywordsai.co` — [gateway quickstart](https://docs.keywordsai.co/get-started/quickstart/gateway) |
 | [Agentgateway](https://agentgateway.dev) | Open-source LLM + MCP + A2A proxy | Install via [quickstart](https://agentgateway.dev/docs/quickstart/) → run `agentgateway -f config.yaml` |
 | [LiteLLM](https://www.litellm.ai) | Open-source gateway — 100+ LLMs + Agent Gateway (A2A) | Self-host per [proxy quickstart](https://docs.litellm.ai/docs/proxy/docker_quick_start) — [A2A](https://docs.litellm.ai/docs/a2a) |
+| [Bifrost](https://docs.getbifrost.ai) | High-performance AI gateway for unified provider access | `npx -y @maximhq/bifrost` then connect an MCP client to `/mcp` |
 | [OpenRouter](https://openrouter.ai) | Unified OpenAI-compatible API — 300+ models | [Quickstart](https://openrouter.ai/docs/quickstart) + `OPENROUTER_API_KEY` |
 | [Helicone](https://www.helicone.ai) | AI Gateway + observability — `ai-gateway.helicone.ai` | OpenAI SDK `baseURL` per [Helicone quickstart](https://docs.helicone.ai/) |
 | [Routerly](https://github.com/Inebrio/Routerly) | Self-hosted gateway with LLM-native routing policy | Run the official Docker image with `routerly.json`, then point the client base URL to it |


### PR DESCRIPTION
## Type of change

- [x] 🆕 New service entry

## Linked issue

Closes #105

## Service being added

**Service name:** Bifrost

**Focused files modified:**

- services/llm-gateway-and-routing/bifrost.md
- services/llm-gateway-and-routing/README.md
- README.md

This revision intentionally keeps the PR limited to the Bifrost dossier, its category entry, and the root index/count update. It does not modify the machine catalog or generated GitHub Pages snapshots.

## Admission track

- [x] Standard five-criteria track

The linked issue received maintainer approval with a request to open this PR. The service dossier documents evidence for agent-first positioning, MCP and Agent Mode primitives, autonomous routing and fallback, machine-to-machine APIs, and scoped virtual-key/OAuth governance. It also records the boundary caveats: Bifrost uses the broader AI applications positioning and does not claim a dedicated per-agent identity or KYA system.

## Why Bifrost fits this category

Bifrost provides a self-hosted OpenAI-compatible gateway across 23+ providers, with retries, fallbacks, load balancing, budgets, rate limits, observability, an MCP client and gateway, and opt-in Agent Mode for automatic tool execution.

- Project: https://github.com/maximhq/bifrost
- Documentation: https://docs.getbifrost.ai
- MCP gateway: https://docs.getbifrost.ai/mcp/gateway
- Governance: https://docs.getbifrost.ai/features/governance/virtual-keys

## Validation

- [x] Focused source diff contains only the three Bifrost-related files listed above
- [x] Official Bifrost and evidence URLs checked
- [x] Git diff check passed

## Disclosure

This is a self-submission on behalf of the Bifrost project, as disclosed in issue #105.