### PR TITLE
[Maintenance] Refresh catalog after Bifrost merge

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -11,7 +11,7 @@
     "service_directory": "services",
     "content_digest": {
       "algorithm": "sha256",
-      "value": "759c8099552c99b6b77430b2c25eb75adaa79ac5c5aefb40943198cd3c3a5d9e",
+      "value": "bff7b5c679641fb8ee17c925bd0e2ba14d28b86e2db9c408f79e3fc39e6d6bd7",
       "input_paths": [
         "README.md",
         "skill.md",

--- a/docs/catalog.json
+++ b/docs/catalog.json
@@ -11,7 +11,7 @@
     "service_directory": "services",
     "content_digest": {
       "algorithm": "sha256",
-      "value": "759c8099552c99b6b77430b2c25eb75adaa79ac5c5aefb40943198cd3c3a5d9e",
+      "value": "bff7b5c679641fb8ee17c925bd0e2ba14d28b86e2db9c408f79e3fc39e6d6bd7",
       "input_paths": [
         "README.md",
         "skill.md",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Type of change

- [x] 🔧 Repository maintenance (README, CONTRIBUTING.md, templates, etc.)

---

## Linked issue

No new issue. This is a follow-up fix for stale generated artifacts after [#106](https://github.com/haoruilee/awesome-agent-native-services/pull/106) merged.

---

## What happened

`[New Service] Bifrost (#106)` landed on `main` with service dossiers and index rows, but `catalog.json` / `docs/catalog.json` still had the previous content digest. Both required workflows then failed on `main`:

- **Validate catalog and site** (`validate-generated-docs.yml`)
- **Deploy GitHub Pages** (`pages.yml`)

Failure:

```
Machine catalog artifacts are stale:
- catalog.json
- docs/catalog.json
Run: python3 scripts/build-machine-catalog.py
```

That blocks the machine-catalog contract check and prevents GitHub Pages from deploying.

## What this PR does

Regenerates the machine catalog from latest `origin/main` after the Bifrost merge.

- Ran `python3 scripts/build-machine-catalog.py`
- Ran `bash scripts/build-github-pages.sh` (no additional docs diffs)
- Only committed the regenerated artifacts: `catalog.json` and `docs/catalog.json`
- The change is the updated `content_digest` so it matches the Bifrost source files
- No service dossier, README, or classification edits

## Local verification

- `python3 scripts/build-machine-catalog.py --check` — Machine catalog is current: 190 services / 16 categories
- `python3 scripts/check-repository-health.py --local --freshness-max-days 45` — local links, inventory, research freshness, and service verification passed

Merging this unblocks `main` validate + GitHub Pages. Not merged by the agent.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0658bf5d-5507-4bf4-a391-9b62b70899c0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0658bf5d-5507-4bf4-a391-9b62b70899c0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

