### PR TITLE
[New Service] August 26 OSS catalog additions

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,21 +83,21 @@ Recommended flow for agents: start with `skill.md` for quick discovery, switch t
 
 ## Categories
 
-**190 services across 16 categories.**
+**201 services across 16 categories.**
 
 | # | Category | Services | Description |
 |---|---|---|---|
 | 1 | [Communication](#1-communication-services) | 15 | Give agents a communication identity on the internet |
-| 2 | [Browser & Web Execution](#2-browser--web-execution-services) | 24 | Remote browser and web data extraction for agents |
-| 3 | [Tool Access & Integration](#3-tool-access--integration-services) | 17 | Runtime tool discovery, auth, and execution |
+| 2 | [Browser & Web Execution](#2-browser--web-execution-services) | 25 | Remote browser and web data extraction for agents |
+| 3 | [Tool Access & Integration](#3-tool-access--integration-services) | 19 | Runtime tool discovery, auth, and execution |
 | 4 | [Oversight & Approval](#4-oversight--approval-services) | 5 | Human-in-the-loop approval and escalation |
-| 5 | [Commerce & Payments](#5-commerce--payment-services) | 9 | Agent-native wallets, identity, and transactions |
-| 6 | [Agent Runtime & Infrastructure](#6-agent-runtime--infrastructure-services) | 27 | Execution, session isolation, secrets, and gateway |
-| 7 | [Agent Harnesses & Operator Surfaces](#7-agent-harnesses--operator-surfaces) | 9 | Durable agent-loop control and live operator visibility |
-| 8 | [Memory & State](#8-memory--state-services) | 17 | Persistent agent memory across sessions |
+| 5 | [Commerce & Payments](#5-commerce--payment-services) | 11 | Agent-native wallets, identity, and transactions |
+| 6 | [Agent Runtime & Infrastructure](#6-agent-runtime--infrastructure-services) | 28 | Execution, session isolation, secrets, and gateway |
+| 7 | [Agent Harnesses & Operator Surfaces](#7-agent-harnesses--operator-surfaces) | 10 | Durable agent-loop control and live operator visibility |
+| 8 | [Memory & State](#8-memory--state-services) | 19 | Persistent agent memory across sessions |
 | 9 | [Search & Web Intelligence](#9-search--web-intelligence-services) | 9 | LLM-optimized web search and content retrieval |
-| 10 | [Code Execution](#10-code-execution-services) | 10 | Secure sandboxes for AI-generated code |
-| 11 | [Observability & Tracing](#11-observability--tracing-services) | 11 | Agent trajectory tracing and evaluation |
+| 10 | [Code Execution](#10-code-execution-services) | 11 | Secure sandboxes for AI-generated code |
+| 11 | [Observability & Tracing](#11-observability--tracing-services) | 12 | Agent trajectory tracing and evaluation |
 | 12 | [Durable Execution & Scheduling](#12-durable-execution--scheduling-services) | 7 | Fault-tolerant long-running agent workflows |
 | 13 | [Meeting & Conversation](#13-meeting--conversation-services) | 7 | Agent presence in voice and video meetings |
 | 14 | [Voice & Phone](#14-voice--phone-services) | 7 | Agent-controlled voice calls and phone infrastructure |
@@ -166,6 +166,7 @@ Recommended flow for agents: start with `skill.md` for quick discovery, switch t
 | [CamoFox Browser](services/browser-and-web-execution/camofox.md) [![⭐](https://img.shields.io/github/stars/jo-inc/camofox-browser?style=social)](https://github.com/jo-inc/camofox-browser) | Stealth headless browser for AI agents | Stealth sessions · Server/CLI control · Credential-safe profiles · Screenshots/extraction | ⚠️ | `npm install -g camofox-browser` then start the browser server |
 | [Moli](services/browser-and-web-execution/moli.md) [![⭐](https://img.shields.io/github/stars/lexmount/moli?style=social)](https://github.com/lexmount/moli) | Structured-first browser engine for AI agents | Semantic tree · stable node IDs · CDP/WebDriver · screenshots · stdio MCP | ✅ | Build the Rust workspace, then run `moli fetch`, `moli serve`, or `moli mcp` |
 | [Kernel](services/browser-and-web-execution/kernel.md) [![⭐](https://img.shields.io/github/stars/kernel/kernel-images?style=social)](https://github.com/kernel/kernel-images) | you build agents. we give them the internet. | Sandboxed Chromium · managed auth · live view/replay · CLI + kernel-cli skill | ⚠️ | `brew install kernel/tap/kernel` or `npm install -g @onkernel/cli`, then `kernel browsers create -o json` |
+| [Stealth Browser MCP](services/browser-and-web-execution/stealth-browser-mcp.md) [![⭐](https://img.shields.io/github/stars/vibheksoni/stealth-browser-mcp?style=social)](https://github.com/vibheksoni/stealth-browser-mcp) | Stealth browser automation for MCP-compatible AI agents | nodriver + CDP · 97 MCP tools · dynamic network hooks · element cloning | ✅ | Clone [vibheksoni/stealth-browser-mcp](https://github.com/vibheksoni/stealth-browser-mcp), `pip install -r requirements.txt`, then `claude mcp add-json stealth-browser-mcp` |
 
 ---
 
@@ -196,6 +197,8 @@ Recommended flow for agents: start with `skill.md` for quick discovery, switch t
 | [OpenChatCut](services/tool-access-and-integration/openchatcut.md) [![⭐](https://img.shields.io/github/stars/0xsline/OpenChatCut?style=social)](https://github.com/0xsline/OpenChatCut) | Local-first agent-native video editor with editable timelines | Agent Skill · Streamable HTTP MCP · isolated drafts · EditorCore tools | ✅ | `npx skills add 0xsline/OpenChatCut`, then ask the agent: `Set up OpenChatCut` |
 | [Toolport](services/tool-access-and-integration/toolport.md) [![⭐](https://img.shields.io/github/stars/tsouth89/toolport?style=social)](https://github.com/tsouth89/toolport) | Every tool. One port. | Lazy MCP meta-tools · per-client profiles · tool integrity · keychain secrets | ✅ | Install from [GitHub Releases](https://github.com/tsouth89/toolport/releases/latest), add servers, then connect each AI client to `toolport-gateway` |
 | [SandBase CLI](services/tool-access-and-integration/sandbase-cli.md) [![⭐](https://img.shields.io/github/stars/sandbaseai/cli?style=social)](https://github.com/sandbaseai/cli) | Give your AI agent superpowers. One command. 2,000+ AI models. | Local MCP bridge · discover/inspect/run · client-scoped credentials · Agent Skill | ✅ | Immutable `v0.1.17` tarball: `npx -y https://github.com/sandbaseai/cli/releases/download/v0.1.17/sandbaseai-cli-0.1.17.tgz connect`, then `npx skills add sandbaseai/cli --skill sandbase` |
+| [ContextForge](services/tool-access-and-integration/contextforge.md) [![⭐](https://img.shields.io/github/stars/IBM/mcp-context-forge?style=social)](https://github.com/IBM/mcp-context-forge) | Registry and proxy that federates MCP, A2A, and REST/gRPC | Federated MCP · A2A routing · gRPC-to-MCP · UAID · OTEL | ✅ | `uvx --from mcp-contextforge-gateway mcpgateway --host 0.0.0.0 --port 4444` — or `docker pull ghcr.io/ibm/mcp-context-forge:latest` |
+| [MCP Gateway & Registry](services/tool-access-and-integration/mcp-gateway-registry.md) [![⭐](https://img.shields.io/github/stars/agentic-community/mcp-gateway-registry?style=social)](https://github.com/agentic-community/mcp-gateway-registry) | Unified Agent & MCP Server Registry – Gateway for AI Development Tools | IdP gateway · virtual MCP · A2A registry · 3LO egress · audit | ✅ | `git clone https://github.com/agentic-community/mcp-gateway-registry && ./build_and_run.sh --prebuilt` |
 
 ---
 
@@ -232,6 +235,8 @@ Recommended flow for agents: start with `skill.md` for quick discovery, switch t
 | [Coinbase CDP (x402)](services/commerce-and-payments/coinbase-x402.md) [![⭐](https://img.shields.io/github/stars/coinbase/x402?style=social)](https://github.com/coinbase/x402) | HTTP 402 payments for autonomous API clients | Facilitator verify/settle · Multi-language SDKs · Bazaar discovery | ⚠️ | [docs.cdp.coinbase.com/x402](https://docs.cdp.coinbase.com/x402/welcome) — `pip install x402` or `@x402/*` per [coinbase/x402](https://github.com/coinbase/x402) |
 | [CyMetica AI (EventTrader)](services/commerce-and-payments/cymetica-ai.md) | Agentically engineered financial platform with autonomous AI trading agents | A2A envelopes · MCP descriptor · prediction markets · market-making loops | ✅ | Read `https://cymetica.com/.well-known/agent.json` and `https://cymetica.com/.well-known/mcp.json` |
 | [SecondSign Core](services/commerce-and-payments/secondsign-core.md) [![⭐](https://img.shields.io/github/stars/Bestpart-Irene/secondsign-core?style=social)](https://github.com/Bestpart-Irene/secondsign-core) | Independent transaction co-signer for financial AI agents | Policy engine · mTLS gateway/approver · execute-once rail · hash-chained receipts | ⚠️ | `pip install secondsign-core` then `python examples/quickstart.py` (pre-1.0 evaluation) |
+| [UCP](services/commerce-and-payments/ucp.md) [![⭐](https://img.shields.io/github/stars/Universal-Commerce-Protocol/ucp?style=social)](https://github.com/Universal-Commerce-Protocol/ucp) | The common language for platforms, agents, and businesses | Capability profiles · checkout sessions · OAuth linking · AP2 payments | ⚠️ | Read [ucp.dev](https://ucp.dev) then `cargo install ucp-schema` — samples/SDKs under [Universal-Commerce-Protocol](https://github.com/orgs/Universal-Commerce-Protocol/repositories) |
+| [AP2](services/commerce-and-payments/ap2.md) [![⭐](https://img.shields.io/github/stars/google-agentic-commerce/AP2?style=social)](https://github.com/google-agentic-commerce/AP2) | An open protocol for the emerging Agent Economy | Checkout/payment mandates · VDC chain · A2A/UCP extension | ⚠️ | `uv pip install git+https://github.com/google-agentic-commerce/AP2.git@main` — last code push 2026-06-17 |
 
 ---
 
@@ -270,6 +275,7 @@ Recommended flow for agents: start with `skill.md` for quick discovery, switch t
 | [Polos](services/agent-runtime-and-infrastructure/polos.md) [![⭐](https://img.shields.io/github/stars/polos-dev/polos?style=social)](https://github.com/polos-dev/polos) | Open-source runtime for AI agents — sandbox + durable workflow + HITL | Docker/E2B sandbox · Durable steps with prompt cache · HTTP/cron/webhook/event triggers · Slack HITL | ⚠️ | `pip install polos` (or `npm install polos`) — see [README](https://github.com/polos-dev/polos) |
 | [Cloudflare Computer](services/agent-runtime-and-infrastructure/cloudflare-computer.md) [![⭐](https://img.shields.io/github/stars/cloudflare/computer?style=social)](https://github.com/cloudflare/computer) | Give your agent a computer | Durable Object workspace FS · runtime.exec backends · preview APIs | ⚠️ | `npm install @cloudflare/computer` then `withWorkspace` on a Durable Object — preview only |
 | [Agent Executor (AX)](services/agent-runtime-and-infrastructure/google-ax.md) [![⭐](https://img.shields.io/github/stars/google/ax?style=social)](https://github.com/google/ax) | An open source distributed agent runtime | Conversation resume · event log · isolated harnesses · `ax` CLI | ⚠️ | `go install github.com/google/ax/cmd/ax@latest` then `ax --input "…"` |
+| [Agent Substrate](services/agent-runtime-and-infrastructure/agent-substrate.md) [![⭐](https://img.shields.io/github/stars/agent-substrate/substrate?style=social)](https://github.com/agent-substrate/substrate) | High-density Kubernetes runtime for large-scale agent deployments | Actors · WorkerPools · suspend/resume · atenet routing | ⚠️ | `hack/install-ate-kind.sh --deploy-ate-system` then `kubectl ate create actor` — early-dev, not a supported Google product |
 
 ---
 
@@ -290,6 +296,7 @@ Recommended flow for agents: start with `skill.md` for quick discovery, switch t
 | [Codex HUD (anhannin)](services/agent-harnesses-and-control-planes/codex-hud-anhannin.md) [![⭐](https://img.shields.io/github/stars/anhannin/codex-hud?style=social)](https://github.com/anhannin/codex-hud) | Patched Codex status line for usage and session state | Model/project/git · rollout session · 5-hour and 7-day usage windows | ⚠️ | Clone [anhannin/codex-hud](https://github.com/anhannin/codex-hud), review the patch/install script, then run `Codex-HUD/install.sh` |
 | [Claude HUD](services/agent-harnesses-and-control-planes/claude-hud.md) [![⭐](https://img.shields.io/github/stars/jarrodwatts/claude-hud?style=social)](https://github.com/jarrodwatts/claude-hud) | A Claude Code plugin that shows what's happening | Context/usage bars · tools · subagents · todos · statusline | ⚠️ | `/plugin marketplace add jarrodwatts/claude-hud` then `/plugin install claude-hud` and `/claude-hud:setup` |
 | [LoopX](services/agent-harnesses-and-control-planes/loopx.md) [![⭐](https://img.shields.io/github/stars/huangruiteng/loopx?style=social)](https://github.com/huangruiteng/loopx) | The open, provider-neutral, stateful control plane for long-horizon agents | Objectives · gates · todos/evidence · quota · claims/leases | ⚠️ | `python3 -m pip install --upgrade loopx` then `loopx workflow-skills --install` and `loopx connect` |
+| [DeepSeek Harness (dsh)](services/agent-harnesses-and-control-planes/deepseek-harness.md) [![⭐](https://img.shields.io/github/stars/deepseek-ai/deepseek-harness?style=social)](https://github.com/deepseek-ai/deepseek-harness) | Everything is a Plugin. | Cordis plugins · session log · Trajectory · PTC/Code Mode | ⚠️ | `npx @deepseek-ai/dsh web` |
 
 ---
 
@@ -320,6 +327,8 @@ Recommended flow for agents: start with `skill.md` for quick discovery, switch t
 | [Hindsight](services/memory-and-state/hindsight.md) [![⭐](https://img.shields.io/github/stars/vectorize-io/hindsight?style=social)](https://github.com/vectorize-io/hindsight) | Agent Memory That Learns | `retain()` · `recall()` · `reflect()` · Dedicated memory banks | ⚠️ | `pip install hindsight-ai` then use retain/recall/reflect in the agent loop |
 | [agentmemory](services/memory-and-state/agentmemory.md) [![⭐](https://img.shields.io/github/stars/rohitg00/agentmemory?style=social)](https://github.com/rohitg00/agentmemory) | Your coding agent remembers everything. No more re-explaining. | Shared memory server · MCP/hooks · 17 skills · INSTALL_FOR_AGENTS.md | ✅ | Read https://raw.githubusercontent.com/rohitg00/agentmemory/main/INSTALL_FOR_AGENTS.md and follow the instructions |
 | [TencentDB Agent Memory](services/memory-and-state/tencentdb-agent-memory.md) [![⭐](https://img.shields.io/github/stars/TencentCloud/TencentDB-Agent-Memory?style=social)](https://github.com/TencentCloud/TencentDB-Agent-Memory) | Agents remember,Humans innovate. | Symbolic Mermaid canvas · L0–L3 layering · OpenClaw/Hermes plugins | ⚠️ | `openclaw plugins install @tencentdb-agent-memory/memory-tencentdb` then enable `memory-tencentdb` |
+| [MemPalace](services/memory-and-state/mempalace.md) [![⭐](https://img.shields.io/github/stars/MemPalace/mempalace?style=social)](https://github.com/MemPalace/mempalace) | The best-benchmarked open-source AI memory system. And it's free. | Verbatim drawers · wings/rooms · pluggable backends · 44 MCP tools | ✅ | `uv tool install mempalace` then `mempalace init` / `mine` / `search` |
+| [MemSearch](services/memory-and-state/memsearch.md) [![⭐](https://img.shields.io/github/stars/zilliztech/memsearch?style=social)](https://github.com/zilliztech/memsearch) | Cross-platform semantic memory for AI coding agents | Markdown + Milvus hybrid search · progressive recall · harness plugins | ⚠️ | `uv tool install "memsearch[onnx]"` or `/plugin marketplace add zilliztech/memsearch` |
 
 ---
 
@@ -361,6 +370,7 @@ Recommended flow for agents: start with `skill.md` for quick discovery, switch t
 | [AIO Sandbox](services/code-execution/agent-infra-sandbox.md) [![⭐](https://img.shields.io/github/stars/agent-infra/sandbox?style=social)](https://github.com/agent-infra/sandbox) | All-in-one Docker sandbox for AI agents | Browser + shell + files + VS Code + Jupyter + MCP · Shared filesystem | ✅ | `docker run -p 8080:8080 ghcr.io/agent-infra/sandbox:latest` — MCP `http://localhost:8080/mcp` |
 | [Agent Sandbox](services/code-execution/agent-sandbox.md) | The trusted runtime for untrusted code | Hosted code sessions · Dependency install · Files/artifacts API · URL onboarding | ⚠️ | Read https://agentsandbox.co/skill.md and follow the instructions |
 | [Riza](services/code-execution/riza.md) | AI writes code. Riza runs it. | Command Exec API · Tools API · Secrets · MCP · Self-hosting | ✅ | `uv add rizaio` then `riza.command.exec(...)` — [docs.riza.io](https://docs.riza.io/) |
+| [Agent Sandbox (Kubernetes SIG)](services/code-execution/kubernetes-agent-sandbox.md) [![⭐](https://img.shields.io/github/stars/kubernetes-sigs/agent-sandbox?style=social)](https://github.com/kubernetes-sigs/agent-sandbox) | Secure isolated execution layer for autonomous agents on Kubernetes | Sandbox CRD · WarmPool/Claim · RuntimeClass · Python/Go SDKs | ⚠️ | `pip install k8s-agent-sandbox` then `SandboxClient().create_sandbox(...)` — not hosted agentsandbox.co |
 
 ---
 
@@ -383,6 +393,7 @@ Recommended flow for agents: start with `skill.md` for quick discovery, switch t
 | [Galileo](services/observability-and-tracing/galileo.md) | Agent reliability platform — observability, evals, and IDE MCP | Signals (root-cause insights) · synthetic datasets · experiments · MCP tools | ✅ | Add MCP URL `https://api.galileo.ai/mcp/http/mcp` with `Galileo-API-Key` header — [setup docs](https://docs.galileo.ai/getting-started/mcp/setup-galileo-mcp) |
 | [Laminar](services/observability-and-tracing/laminar.md) [![⭐](https://img.shields.io/github/stars/lmnr-ai/lmnr?style=social)](https://github.com/lmnr-ai/lmnr) | Open-source observability for long-running agents | Agent debugger (rerun at step N) · Browser session replay · Signals · SQL over traces · Apache 2.0 self-host | ⚠️ | `pip install lmnr` then `Laminar.initialize()` — self-host: `git clone https://github.com/lmnr-ai/lmnr && docker compose up -d` |
 | [OpenLIT](services/observability-and-tracing/openlit.md) [![⭐](https://img.shields.io/github/stars/openlit/openlit?style=social)](https://github.com/openlit/openlit) | OpenTelemetry-native observability for LLMs and AI agents | Agent traces · Tool-call spans · Cost/token analytics | ✅ | `pip install openlit` then configure OpenTelemetry export |
+| [AgentSight](services/observability-and-tracing/agentsight.md) [![⭐](https://img.shields.io/github/stars/eunomia-bpf/agentsight?style=social)](https://github.com/eunomia-bpf/agentsight) | Lightweight system-level observability for AI Agents | eBPF `record` · session DBs · `top`/`vis` · OTLP GenAI | ⚠️ | `cargo install agentsight` then `agentsight top` or `sudo agentsight record -- claude` |
 
 ---
 

--- a/catalog.json
+++ b/catalog.json
@@ -11,7 +11,7 @@
     "service_directory": "services",
     "content_digest": {
       "algorithm": "sha256",
-      "value": "bff7b5c679641fb8ee17c925bd0e2ba14d28b86e2db9c408f79e3fc39e6d6bd7",
+      "value": "ecad0f3e36c634b61c8ed0f201333a037022db385a0aa71c0c23675fc85ae646",
       "input_paths": [
         "README.md",
         "skill.md",
@@ -54,6 +54,7 @@
         "services/browser-and-web-execution/opencli.md",
         "services/browser-and-web-execution/playwright-mcp.md",
         "services/browser-and-web-execution/skyvern.md",
+        "services/browser-and-web-execution/stealth-browser-mcp.md",
         "services/browser-and-web-execution/steel.md",
         "services/browser-and-web-execution/vessel-browser.md",
         "services/tool-access-and-integration/README.md",
@@ -61,9 +62,11 @@
         "services/tool-access-and-integration/arcade.md",
         "services/tool-access-and-integration/clawhub.md",
         "services/tool-access-and-integration/composio.md",
+        "services/tool-access-and-integration/contextforge.md",
         "services/tool-access-and-integration/framelink-figma-mcp.md",
         "services/tool-access-and-integration/github-mcp-server.md",
         "services/tool-access-and-integration/google-mcp-toolbox.md",
+        "services/tool-access-and-integration/mcp-gateway-registry.md",
         "services/tool-access-and-integration/mcpgateway.md",
         "services/tool-access-and-integration/nango.md",
         "services/tool-access-and-integration/obot.md",
@@ -82,6 +85,7 @@
         "services/oversight-and-approval/sondera-coding-agent-hooks.md",
         "services/commerce-and-payments/README.md",
         "services/commerce-and-payments/agentspay.md",
+        "services/commerce-and-payments/ap2.md",
         "services/commerce-and-payments/circle-agent-stack.md",
         "services/commerce-and-payments/coinbase-x402.md",
         "services/commerce-and-payments/cymetica-ai.md",
@@ -90,9 +94,11 @@
         "services/commerce-and-payments/payman-ai.md",
         "services/commerce-and-payments/secondsign-core.md",
         "services/commerce-and-payments/skyfire.md",
+        "services/commerce-and-payments/ucp.md",
         "services/agent-runtime-and-infrastructure/README.md",
         "services/agent-runtime-and-infrastructure/acpx.md",
         "services/agent-runtime-and-infrastructure/aembit.md",
+        "services/agent-runtime-and-infrastructure/agent-substrate.md",
         "services/agent-runtime-and-infrastructure/agentanycast.md",
         "services/agent-runtime-and-infrastructure/agentuity.md",
         "services/agent-runtime-and-infrastructure/amazon-bedrock-agentcore.md",
@@ -123,6 +129,7 @@
         "services/agent-harnesses-and-control-planes/claude-hud.md",
         "services/agent-harnesses-and-control-planes/codex-hud-anhannin.md",
         "services/agent-harnesses-and-control-planes/codex-hud-fwyc0573.md",
+        "services/agent-harnesses-and-control-planes/deepseek-harness.md",
         "services/agent-harnesses-and-control-planes/longhorizon-harness.md",
         "services/agent-harnesses-and-control-planes/loopx.md",
         "services/agent-harnesses-and-control-planes/oh-my-codex.md",
@@ -141,6 +148,8 @@
         "services/memory-and-state/memmy-agent.md",
         "services/memory-and-state/memoria.md",
         "services/memory-and-state/memos.md",
+        "services/memory-and-state/mempalace.md",
+        "services/memory-and-state/memsearch.md",
         "services/memory-and-state/memu.md",
         "services/memory-and-state/openviking.md",
         "services/memory-and-state/recall.md",
@@ -163,6 +172,7 @@
         "services/code-execution/coderunner.md",
         "services/code-execution/daytona.md",
         "services/code-execution/e2b.md",
+        "services/code-execution/kubernetes-agent-sandbox.md",
         "services/code-execution/opensandbox.md",
         "services/code-execution/riza.md",
         "services/code-execution/runloop.md",
@@ -172,6 +182,7 @@
         "services/observability-and-tracing/agent-trace.md",
         "services/observability-and-tracing/agentevals.md",
         "services/observability-and-tracing/agentops.md",
+        "services/observability-and-tracing/agentsight.md",
         "services/observability-and-tracing/braintrust.md",
         "services/observability-and-tracing/galileo.md",
         "services/observability-and-tracing/laminar.md",
@@ -226,7 +237,7 @@
   },
   "counts": {
     "categories": 16,
-    "services": 190
+    "services": 201
   },
   "categories": [
     {
@@ -241,14 +252,14 @@
       "name": "Browser & Web Execution",
       "description": "Services that give AI agents a remote, managed browser runtime — so agents can navigate, interact with, and extract data from the web as an autonomous actor, without any human operating a browser on their behalf.",
       "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/browser-and-web-execution/README.md",
-      "service_count": 24
+      "service_count": 25
     },
     {
       "id": "tool-access-and-integration",
       "name": "Tool Access & Integration",
       "description": "Services that let AI agents discover, authenticate, and invoke external tools at runtime — without a human pre-configuring credentials or selecting which integrations to activate.",
       "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/README.md",
-      "service_count": 17
+      "service_count": 19
     },
     {
       "id": "oversight-and-approval",
@@ -262,28 +273,28 @@
       "name": "Commerce & Payments",
       "description": "Services that give AI agents a verified financial identity and the ability to transact in the real economy — paying for services, moving money, and being recognized as a legitimate, accountable economic actor.",
       "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/commerce-and-payments/README.md",
-      "service_count": 9
+      "service_count": 11
     },
     {
       "id": "agent-runtime-and-infrastructure",
       "name": "Agent Runtime & Infrastructure",
       "description": "Services that provide the secure deployment substrate, session isolation, secret management, identity, gateway, and observability required to run AI agents reliably in production — the \"operating system layer\" for autonomous agents.",
       "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/README.md",
-      "service_count": 27
+      "service_count": 28
     },
     {
       "id": "agent-harnesses-and-control-planes",
       "name": "Agent Harnesses & Operator Surfaces",
       "description": "Systems purpose-built around running agents: either harnesses that add durable work state, orchestration, verification, and policy, or operator surfaces that expose live agent state and bounded session controls.",
       "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/README.md",
-      "service_count": 9
+      "service_count": 10
     },
     {
       "id": "memory-and-state",
       "name": "Memory & State",
       "description": "Services that give AI agents persistent, queryable memory across sessions — treating memory as infrastructure rather than application logic, and managing the full lifecycle of what agents remember, forget, and retrieve.",
       "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/README.md",
-      "service_count": 17
+      "service_count": 19
     },
     {
       "id": "search-and-web-intelligence",
@@ -297,14 +308,14 @@
       "name": "Code Execution",
       "description": "Services that give AI agents a secure, isolated runtime for executing generated code — without human-side sandbox setup, without risking the host environment, and with output formatted for direct LLM consumption.",
       "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/README.md",
-      "service_count": 10
+      "service_count": 11
     },
     {
       "id": "observability-and-tracing",
       "name": "Observability & Tracing",
       "description": "Services that give teams structured visibility into agent execution — capturing the full trajectory of an agent's reasoning, tool calls, memory accesses, and outputs in a semantic format that humans can inspect and improve upon.",
       "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/observability-and-tracing/README.md",
-      "service_count": 11
+      "service_count": 12
     },
     {
       "id": "durable-execution-and-scheduling",
@@ -1521,6 +1532,40 @@
       "verification_sources": []
     },
     {
+      "id": "browser-and-web-execution/stealth-browser-mcp",
+      "slug": "stealth-browser-mcp",
+      "name": "Stealth Browser MCP",
+      "tagline": "Stealth browser automation for MCP-compatible AI agents.",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "browser-and-web-execution",
+      "website": "https://github.com/vibheksoni/stealth-browser-mcp",
+      "repository": "https://github.com/vibheksoni/stealth-browser-mcp",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/browser-and-web-execution/stealth-browser-mcp.md",
+      "source_path": "services/browser-and-web-execution/stealth-browser-mcp.md",
+      "onboarding": {
+        "type": "mcp",
+        "pattern": "MCP",
+        "instruction": "git clone https://github.com/vibheksoni/stealth-browser-mcp.git\ncd stealth-browser-mcp\npython -m venv venv\nsource venv/bin/activate\npip install -r requirements.txt",
+        "url": "https://github.com/vibheksoni/stealth-browser-mcp.git"
+      },
+      "protocols": [
+        "agent-skill",
+        "mcp",
+        "cli",
+        "stdio",
+        "http"
+      ],
+      "mcp_status": "available",
+      "agent_skill_status": "available",
+      "latest_month_signal": "Last GitHub push 2026-07-24 (repo metadata). Quieter than neighboring browser rows — verify master before depending on a weekly release cadence",
+      "verified_at": "2026-08-25",
+      "verification_sources": [
+        "https://api.github.com/repos/vibheksoni/stealth-browser-mcp"
+      ]
+    },
+    {
       "id": "browser-and-web-execution/steel",
       "slug": "steel",
       "name": "Steel",
@@ -1702,6 +1747,45 @@
       "verification_sources": []
     },
     {
+      "id": "tool-access-and-integration/contextforge",
+      "slug": "contextforge",
+      "name": "ContextForge",
+      "tagline": "An open source registry and proxy that federates MCP, A2A, and REST/gRPC APIs with centralized governance, discovery, and observability. Optimizes Agent & Tool calling, and supports plugins.",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "tool-access-and-integration",
+      "website": "https://ibm.github.io/mcp-context-forge/",
+      "repository": "https://github.com/IBM/mcp-context-forge",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/contextforge.md",
+      "source_path": "services/tool-access-and-integration/contextforge.md",
+      "onboarding": {
+        "type": "mcp",
+        "pattern": "CLI + MCP gateway",
+        "instruction": "# Generate secrets, then start the gateway (official README TLDR)\npython3 -m mcpgateway.scripts.init_secrets\nexport JWT_SECRET_KEY=\"$(grep '^JWT_SECRET_KEY=' .env.secrets | cut -d= -f2)\"\nexport AUTH_ENCRYPTION_SECRET=\"$(grep '^AUTH_ENCRYPTION_SECRET=' .env.secrets | cut -d= -f2)\"\nJWT_SECRET_KEY=\"$JWT_SECRET_KEY\" \\\nAUTH_ENCRYPTION_SECRET=\"$AUTH_ENCRYPTION_SECRET\" \\\nMCPGATEWAY_UI_ENABLED=true \\\nMCPGATEWAY_ADMIN_API_ENABLED=true \\\nPLATFORM_ADMIN_EMAIL=admin@example.com \\\nuvx --from mcp-contextforge-gateway mcpgateway --host 0.0.0.0 --port 4444",
+        "url": "http://localhost:4444"
+      },
+      "protocols": [
+        "mcp",
+        "rest",
+        "grpc",
+        "websocket",
+        "cli",
+        "a2a",
+        "json-rpc",
+        "stdio",
+        "http",
+        "api"
+      ],
+      "mcp_status": "available",
+      "agent_skill_status": "unavailable",
+      "latest_month_signal": "Last GitHub push 2026-08-25 (repo metadata); PyPI mcp-contextforge-gateway; image ghcr.io/ibm/mcp-context-forge",
+      "verified_at": "2026-08-25",
+      "verification_sources": [
+        "https://api.github.com/repos/IBM/mcp-context-forge"
+      ]
+    },
+    {
       "id": "tool-access-and-integration/framelink-figma-mcp",
       "slug": "framelink-figma-mcp",
       "name": "Framelink MCP for Figma",
@@ -1791,6 +1875,43 @@
       "latest_month_signal": null,
       "verified_at": null,
       "verification_sources": []
+    },
+    {
+      "id": "tool-access-and-integration/mcp-gateway-registry",
+      "slug": "mcp-gateway-registry",
+      "name": "MCP Gateway & Registry",
+      "tagline": "Unified Agent & MCP Server Registry – Gateway for AI Development Tools",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "tool-access-and-integration",
+      "website": "https://agentic-community.github.io/mcp-gateway-registry/",
+      "repository": "https://github.com/agentic-community/mcp-gateway-registry",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/mcp-gateway-registry.md",
+      "source_path": "services/tool-access-and-integration/mcp-gateway-registry.md",
+      "onboarding": {
+        "type": "mcp",
+        "pattern": "CLI + MCP gateway",
+        "instruction": "git clone https://github.com/agentic-community/mcp-gateway-registry.git\ncd mcp-gateway-registry\ncp .env.example .env\n# Set required secrets (KEYCLOAK_ADMIN_PASSWORD, SECRET_KEY, …) — see docs/configuration.md\n./build_and_run.sh --prebuilt",
+        "url": "https://github.com/agentic-community/mcp-gateway-registry.git"
+      },
+      "protocols": [
+        "agent-skill",
+        "mcp",
+        "rest",
+        "cli",
+        "a2a",
+        "openapi",
+        "http",
+        "api"
+      ],
+      "mcp_status": "available",
+      "agent_skill_status": "available",
+      "latest_month_signal": "Last GitHub push 2026-08-25 (repo metadata)",
+      "verified_at": "2026-08-25",
+      "verification_sources": [
+        "https://api.github.com/repos/agentic-community/mcp-gateway-registry"
+      ]
     },
     {
       "id": "tool-access-and-integration/mcpgateway",
@@ -2299,6 +2420,38 @@
       "verification_sources": []
     },
     {
+      "id": "commerce-and-payments/ap2",
+      "slug": "ap2",
+      "name": "Agent Payments Protocol (AP2)",
+      "tagline": "An open protocol for the emerging Agent Economy.",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "commerce-and-payments",
+      "website": "https://ap2-protocol.org",
+      "repository": "https://github.com/google-agentic-commerce/AP2",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/commerce-and-payments/ap2.md",
+      "source_path": "services/commerce-and-payments/ap2.md",
+      "onboarding": {
+        "type": "sdk",
+        "pattern": "SDK + scenario samples",
+        "instruction": "# Types package (PyPI later; official install is from git)\nuv pip install git+https://github.com/google-agentic-commerce/AP2.git@main",
+        "url": "https://github.com/google-agentic-commerce/AP2.git@main"
+      },
+      "protocols": [
+        "sdk",
+        "a2a",
+        "http"
+      ],
+      "mcp_status": "unknown",
+      "agent_skill_status": "unavailable",
+      "latest_month_signal": "Last *code* push 2026-06-17 (repo metadata); docs/site still served. Quieter than neighboring commerce repos — disclose before treating samples as weekly-fresh",
+      "verified_at": "2026-08-25",
+      "verification_sources": [
+        "https://api.github.com/repos/google-agentic-commerce/AP2"
+      ]
+    },
+    {
       "id": "commerce-and-payments/circle-agent-stack",
       "slug": "circle-agent-stack",
       "name": "Circle Agent Stack",
@@ -2544,6 +2697,42 @@
       "verification_sources": []
     },
     {
+      "id": "commerce-and-payments/ucp",
+      "slug": "ucp",
+      "name": "Universal Commerce Protocol (UCP)",
+      "tagline": "The common language for platforms, agents, and businesses.",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "commerce-and-payments",
+      "website": "https://ucp.dev",
+      "repository": "https://github.com/Universal-Commerce-Protocol/ucp",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/commerce-and-payments/ucp.md",
+      "source_path": "services/commerce-and-payments/ucp.md",
+      "onboarding": {
+        "type": "sdk",
+        "pattern": "SDK + protocol spec",
+        "instruction": "# Schema tool agents use to resolve ucp_* annotations at runtime\ncargo install ucp-schema\n\n# Spec + docs checkout\ngit clone https://github.com/Universal-Commerce-Protocol/ucp.git",
+        "url": "https://github.com/Universal-Commerce-Protocol/ucp.git"
+      },
+      "protocols": [
+        "mcp",
+        "rest",
+        "cli",
+        "sdk",
+        "a2a",
+        "json-rpc",
+        "http"
+      ],
+      "mcp_status": "available",
+      "agent_skill_status": "unavailable",
+      "latest_month_signal": "Last GitHub push 2026-08-25 (repo metadata); spec + docs repo",
+      "verified_at": "2026-08-25",
+      "verification_sources": [
+        "https://api.github.com/repos/Universal-Commerce-Protocol/ucp"
+      ]
+    },
+    {
       "id": "agent-runtime-and-infrastructure/acpx",
       "slug": "acpx",
       "name": "acpx",
@@ -2603,6 +2792,39 @@
       "latest_month_signal": null,
       "verified_at": null,
       "verification_sources": []
+    },
+    {
+      "id": "agent-runtime-and-infrastructure/agent-substrate",
+      "slug": "agent-substrate",
+      "name": "Agent Substrate",
+      "tagline": "A performant, high density runtime environment for large scale agent deployments.",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "agent-runtime-and-infrastructure",
+      "website": "https://github.com/agent-substrate/substrate",
+      "repository": "https://github.com/agent-substrate/substrate",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/agent-substrate.md",
+      "source_path": "services/agent-runtime-and-infrastructure/agent-substrate.md",
+      "onboarding": {
+        "type": "cli",
+        "pattern": "CLI + Kubernetes control plane",
+        "instruction": "# Local kind path from the official README (development only)\nhack/create-kind-cluster.sh\nhack/install-ate-kind.sh --deploy-ate-system\nhack/install-ate-kind.sh --deploy-demo-counter\ngo install ./cmd/kubectl-ate\n\nkubectl ate create atespace demo\nkubectl ate create actor my-counter-1 -a demo --template=ate-demo-counter/counter\nkubectl port-forward -n ate-system svc/atenet-router 8000:80",
+        "url": null
+      },
+      "protocols": [
+        "grpc",
+        "cli",
+        "http",
+        "api"
+      ],
+      "mcp_status": "unknown",
+      "agent_skill_status": "unavailable",
+      "latest_month_signal": "Last GitHub push 2026-08-25 (repo metadata); early development, APIs expected to change",
+      "verified_at": "2026-08-25",
+      "verification_sources": [
+        "https://api.github.com/repos/agent-substrate/substrate"
+      ]
     },
     {
       "id": "agent-runtime-and-infrastructure/agentanycast",
@@ -3486,6 +3708,40 @@
       ]
     },
     {
+      "id": "agent-harnesses-and-control-planes/deepseek-harness",
+      "slug": "deepseek-harness",
+      "name": "DeepSeek Harness (dsh)",
+      "tagline": "Everything is a Plugin.",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "agent-harnesses-and-control-planes",
+      "website": "https://deepseek.com/harness",
+      "repository": "https://github.com/deepseek-ai/deepseek-harness",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/deepseek-harness.md",
+      "source_path": "services/agent-harnesses-and-control-planes/deepseek-harness.md",
+      "onboarding": {
+        "type": "cli",
+        "pattern": "CLI + Web UI (developer preview)",
+        "instruction": "npx @deepseek-ai/dsh web",
+        "url": "http://127.0.0.1:3080"
+      },
+      "protocols": [
+        "cli",
+        "sdk",
+        "acp",
+        "json-rpc",
+        "http"
+      ],
+      "mcp_status": "unavailable",
+      "agent_skill_status": "unavailable",
+      "latest_month_signal": "Last GitHub push 2026-08-21 (repo metadata); developer-preview release with public Web UI entry (npx @deepseek-ai/dsh web)",
+      "verified_at": "2026-08-25",
+      "verification_sources": [
+        "https://api.github.com/repos/deepseek-ai/deepseek-harness"
+      ]
+    },
+    {
       "id": "agent-harnesses-and-control-planes/longhorizon-harness",
       "slug": "longhorizon-harness",
       "name": "LongHorizon-Harness",
@@ -4030,6 +4286,73 @@
       "latest_month_signal": null,
       "verified_at": null,
       "verification_sources": []
+    },
+    {
+      "id": "memory-and-state/mempalace",
+      "slug": "mempalace",
+      "name": "MemPalace",
+      "tagline": "The best-benchmarked open-source AI memory system. And it's free.",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "memory-and-state",
+      "website": "https://mempalaceofficial.com",
+      "repository": "https://github.com/MemPalace/mempalace",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/mempalace.md",
+      "source_path": "services/memory-and-state/mempalace.md",
+      "onboarding": {
+        "type": "mcp",
+        "pattern": "CLI + MCP",
+        "instruction": "uv tool install mempalace\nmempalace init ~/projects/myapp\nmempalace mine ~/projects/myapp\nmempalace search \"why did we switch to GraphQL\"\nmempalace wake-up",
+        "url": null
+      },
+      "protocols": [
+        "mcp",
+        "cli",
+        "stdio",
+        "http",
+        "api"
+      ],
+      "mcp_status": "available",
+      "agent_skill_status": "unavailable",
+      "latest_month_signal": "Last GitHub push 2026-08-25 (repo metadata); default branch develop; PyPI package mempalace",
+      "verified_at": "2026-08-25",
+      "verification_sources": [
+        "https://api.github.com/repos/MemPalace/mempalace"
+      ]
+    },
+    {
+      "id": "memory-and-state/memsearch",
+      "slug": "memsearch",
+      "name": "MemSearch",
+      "tagline": "Cross-platform semantic memory for AI coding agents.",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "memory-and-state",
+      "website": "https://zilliztech.github.io/memsearch/",
+      "repository": "https://github.com/zilliztech/memsearch",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/memsearch.md",
+      "source_path": "services/memory-and-state/memsearch.md",
+      "onboarding": {
+        "type": "cli",
+        "pattern": "CLI + platform plugins",
+        "instruction": "# CLI / library (ONNX embeddings, no API key)\nuv tool install \"memsearch[onnx]\"\n\nmemsearch index ./memory/\nmemsearch search \"how to configure Redis?\" --top-k 5",
+        "url": null
+      },
+      "protocols": [
+        "agent-skill",
+        "mcp",
+        "cli",
+        "api"
+      ],
+      "mcp_status": "available",
+      "agent_skill_status": "available",
+      "latest_month_signal": "Last GitHub push 2026-08-23 (repo metadata); DeepSeek Harness plugin documented",
+      "verified_at": "2026-08-25",
+      "verification_sources": [
+        "https://api.github.com/repos/zilliztech/memsearch"
+      ]
     },
     {
       "id": "memory-and-state/memu",
@@ -4669,6 +4992,38 @@
       "verification_sources": []
     },
     {
+      "id": "code-execution/kubernetes-agent-sandbox",
+      "slug": "kubernetes-agent-sandbox",
+      "name": "Agent Sandbox (Kubernetes SIG)",
+      "tagline": "Agent Sandbox provides a secure and isolated execution layer to safely deploy autonomous AI agents on Kubernetes that generate and run untrusted code at scale.",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "code-execution",
+      "website": "https://agent-sandbox.sigs.k8s.io",
+      "repository": "https://github.com/kubernetes-sigs/agent-sandbox",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/kubernetes-agent-sandbox.md",
+      "source_path": "services/code-execution/kubernetes-agent-sandbox.md",
+      "onboarding": {
+        "type": "sdk",
+        "pattern": "SDK + Kubernetes CRDs",
+        "instruction": "pip install k8s-agent-sandbox",
+        "url": "https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/python/agentic-sandbox-client/README.md"
+      },
+      "protocols": [
+        "sdk",
+        "http",
+        "api"
+      ],
+      "mcp_status": "unavailable",
+      "agent_skill_status": "unavailable",
+      "latest_month_signal": "Last GitHub push 2026-08-25 (repo metadata); Python package k8s-agent-sandbox; SIG Apps CRD",
+      "verified_at": "2026-08-25",
+      "verification_sources": [
+        "https://api.github.com/repos/kubernetes-sigs/agent-sandbox"
+      ]
+    },
+    {
       "id": "code-execution/opensandbox",
       "slug": "opensandbox",
       "name": "OpenSandbox",
@@ -4916,6 +5271,37 @@
       "latest_month_signal": null,
       "verified_at": null,
       "verification_sources": []
+    },
+    {
+      "id": "observability-and-tracing/agentsight",
+      "slug": "agentsight",
+      "name": "AgentSight",
+      "tagline": "lightweight system-level observability for AI Agents",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "observability-and-tracing",
+      "website": "https://eunomia.dev/agentsight/",
+      "repository": "https://github.com/eunomia-bpf/agentsight",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/observability-and-tracing/agentsight.md",
+      "source_path": "services/observability-and-tracing/agentsight.md",
+      "onboarding": {
+        "type": "cli",
+        "pattern": "CLI wrapper (operator-surface track)",
+        "instruction": "cargo install agentsight\n# or: brew tap eunomia-bpf/tap && brew install eunomia-bpf/tap/agentsight\n\nagentsight top\nsudo agentsight record -- claude",
+        "url": null
+      },
+      "protocols": [
+        "cli",
+        "http"
+      ],
+      "mcp_status": "unknown",
+      "agent_skill_status": "unavailable",
+      "latest_month_signal": "Last GitHub push 2026-08-25 (repo metadata); docs updated 2026-08-24",
+      "verified_at": "2026-08-25",
+      "verification_sources": [
+        "https://api.github.com/repos/eunomia-bpf/agentsight"
+      ]
     },
     {
       "id": "observability-and-tracing/braintrust",

--- a/docs/catalog.json
+++ b/docs/catalog.json
@@ -11,7 +11,7 @@
     "service_directory": "services",
     "content_digest": {
       "algorithm": "sha256",
-      "value": "bff7b5c679641fb8ee17c925bd0e2ba14d28b86e2db9c408f79e3fc39e6d6bd7",
+      "value": "ecad0f3e36c634b61c8ed0f201333a037022db385a0aa71c0c23675fc85ae646",
       "input_paths": [
         "README.md",
         "skill.md",
@@ -54,6 +54,7 @@
         "services/browser-and-web-execution/opencli.md",
         "services/browser-and-web-execution/playwright-mcp.md",
         "services/browser-and-web-execution/skyvern.md",
+        "services/browser-and-web-execution/stealth-browser-mcp.md",
         "services/browser-and-web-execution/steel.md",
         "services/browser-and-web-execution/vessel-browser.md",
         "services/tool-access-and-integration/README.md",
@@ -61,9 +62,11 @@
         "services/tool-access-and-integration/arcade.md",
         "services/tool-access-and-integration/clawhub.md",
         "services/tool-access-and-integration/composio.md",
+        "services/tool-access-and-integration/contextforge.md",
         "services/tool-access-and-integration/framelink-figma-mcp.md",
         "services/tool-access-and-integration/github-mcp-server.md",
         "services/tool-access-and-integration/google-mcp-toolbox.md",
+        "services/tool-access-and-integration/mcp-gateway-registry.md",
         "services/tool-access-and-integration/mcpgateway.md",
         "services/tool-access-and-integration/nango.md",
         "services/tool-access-and-integration/obot.md",
@@ -82,6 +85,7 @@
         "services/oversight-and-approval/sondera-coding-agent-hooks.md",
         "services/commerce-and-payments/README.md",
         "services/commerce-and-payments/agentspay.md",
+        "services/commerce-and-payments/ap2.md",
         "services/commerce-and-payments/circle-agent-stack.md",
         "services/commerce-and-payments/coinbase-x402.md",
         "services/commerce-and-payments/cymetica-ai.md",
@@ -90,9 +94,11 @@
         "services/commerce-and-payments/payman-ai.md",
         "services/commerce-and-payments/secondsign-core.md",
         "services/commerce-and-payments/skyfire.md",
+        "services/commerce-and-payments/ucp.md",
         "services/agent-runtime-and-infrastructure/README.md",
         "services/agent-runtime-and-infrastructure/acpx.md",
         "services/agent-runtime-and-infrastructure/aembit.md",
+        "services/agent-runtime-and-infrastructure/agent-substrate.md",
         "services/agent-runtime-and-infrastructure/agentanycast.md",
         "services/agent-runtime-and-infrastructure/agentuity.md",
         "services/agent-runtime-and-infrastructure/amazon-bedrock-agentcore.md",
@@ -123,6 +129,7 @@
         "services/agent-harnesses-and-control-planes/claude-hud.md",
         "services/agent-harnesses-and-control-planes/codex-hud-anhannin.md",
         "services/agent-harnesses-and-control-planes/codex-hud-fwyc0573.md",
+        "services/agent-harnesses-and-control-planes/deepseek-harness.md",
         "services/agent-harnesses-and-control-planes/longhorizon-harness.md",
         "services/agent-harnesses-and-control-planes/loopx.md",
         "services/agent-harnesses-and-control-planes/oh-my-codex.md",
@@ -141,6 +148,8 @@
         "services/memory-and-state/memmy-agent.md",
         "services/memory-and-state/memoria.md",
         "services/memory-and-state/memos.md",
+        "services/memory-and-state/mempalace.md",
+        "services/memory-and-state/memsearch.md",
         "services/memory-and-state/memu.md",
         "services/memory-and-state/openviking.md",
         "services/memory-and-state/recall.md",
@@ -163,6 +172,7 @@
         "services/code-execution/coderunner.md",
         "services/code-execution/daytona.md",
         "services/code-execution/e2b.md",
+        "services/code-execution/kubernetes-agent-sandbox.md",
         "services/code-execution/opensandbox.md",
         "services/code-execution/riza.md",
         "services/code-execution/runloop.md",
@@ -172,6 +182,7 @@
         "services/observability-and-tracing/agent-trace.md",
         "services/observability-and-tracing/agentevals.md",
         "services/observability-and-tracing/agentops.md",
+        "services/observability-and-tracing/agentsight.md",
         "services/observability-and-tracing/braintrust.md",
         "services/observability-and-tracing/galileo.md",
         "services/observability-and-tracing/laminar.md",
@@ -226,7 +237,7 @@
   },
   "counts": {
     "categories": 16,
-    "services": 190
+    "services": 201
   },
   "categories": [
     {
@@ -241,14 +252,14 @@
       "name": "Browser & Web Execution",
       "description": "Services that give AI agents a remote, managed browser runtime — so agents can navigate, interact with, and extract data from the web as an autonomous actor, without any human operating a browser on their behalf.",
       "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/browser-and-web-execution/README.md",
-      "service_count": 24
+      "service_count": 25
     },
     {
       "id": "tool-access-and-integration",
       "name": "Tool Access & Integration",
       "description": "Services that let AI agents discover, authenticate, and invoke external tools at runtime — without a human pre-configuring credentials or selecting which integrations to activate.",
       "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/README.md",
-      "service_count": 17
+      "service_count": 19
     },
     {
       "id": "oversight-and-approval",
@@ -262,28 +273,28 @@
       "name": "Commerce & Payments",
       "description": "Services that give AI agents a verified financial identity and the ability to transact in the real economy — paying for services, moving money, and being recognized as a legitimate, accountable economic actor.",
       "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/commerce-and-payments/README.md",
-      "service_count": 9
+      "service_count": 11
     },
     {
       "id": "agent-runtime-and-infrastructure",
       "name": "Agent Runtime & Infrastructure",
       "description": "Services that provide the secure deployment substrate, session isolation, secret management, identity, gateway, and observability required to run AI agents reliably in production — the \"operating system layer\" for autonomous agents.",
       "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/README.md",
-      "service_count": 27
+      "service_count": 28
     },
     {
       "id": "agent-harnesses-and-control-planes",
       "name": "Agent Harnesses & Operator Surfaces",
       "description": "Systems purpose-built around running agents: either harnesses that add durable work state, orchestration, verification, and policy, or operator surfaces that expose live agent state and bounded session controls.",
       "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/README.md",
-      "service_count": 9
+      "service_count": 10
     },
     {
       "id": "memory-and-state",
       "name": "Memory & State",
       "description": "Services that give AI agents persistent, queryable memory across sessions — treating memory as infrastructure rather than application logic, and managing the full lifecycle of what agents remember, forget, and retrieve.",
       "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/README.md",
-      "service_count": 17
+      "service_count": 19
     },
     {
       "id": "search-and-web-intelligence",
@@ -297,14 +308,14 @@
       "name": "Code Execution",
       "description": "Services that give AI agents a secure, isolated runtime for executing generated code — without human-side sandbox setup, without risking the host environment, and with output formatted for direct LLM consumption.",
       "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/README.md",
-      "service_count": 10
+      "service_count": 11
     },
     {
       "id": "observability-and-tracing",
       "name": "Observability & Tracing",
       "description": "Services that give teams structured visibility into agent execution — capturing the full trajectory of an agent's reasoning, tool calls, memory accesses, and outputs in a semantic format that humans can inspect and improve upon.",
       "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/observability-and-tracing/README.md",
-      "service_count": 11
+      "service_count": 12
     },
     {
       "id": "durable-execution-and-scheduling",
@@ -1521,6 +1532,40 @@
       "verification_sources": []
     },
     {
+      "id": "browser-and-web-execution/stealth-browser-mcp",
+      "slug": "stealth-browser-mcp",
+      "name": "Stealth Browser MCP",
+      "tagline": "Stealth browser automation for MCP-compatible AI agents.",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "browser-and-web-execution",
+      "website": "https://github.com/vibheksoni/stealth-browser-mcp",
+      "repository": "https://github.com/vibheksoni/stealth-browser-mcp",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/browser-and-web-execution/stealth-browser-mcp.md",
+      "source_path": "services/browser-and-web-execution/stealth-browser-mcp.md",
+      "onboarding": {
+        "type": "mcp",
+        "pattern": "MCP",
+        "instruction": "git clone https://github.com/vibheksoni/stealth-browser-mcp.git\ncd stealth-browser-mcp\npython -m venv venv\nsource venv/bin/activate\npip install -r requirements.txt",
+        "url": "https://github.com/vibheksoni/stealth-browser-mcp.git"
+      },
+      "protocols": [
+        "agent-skill",
+        "mcp",
+        "cli",
+        "stdio",
+        "http"
+      ],
+      "mcp_status": "available",
+      "agent_skill_status": "available",
+      "latest_month_signal": "Last GitHub push 2026-07-24 (repo metadata). Quieter than neighboring browser rows — verify master before depending on a weekly release cadence",
+      "verified_at": "2026-08-25",
+      "verification_sources": [
+        "https://api.github.com/repos/vibheksoni/stealth-browser-mcp"
+      ]
+    },
+    {
       "id": "browser-and-web-execution/steel",
       "slug": "steel",
       "name": "Steel",
@@ -1702,6 +1747,45 @@
       "verification_sources": []
     },
     {
+      "id": "tool-access-and-integration/contextforge",
+      "slug": "contextforge",
+      "name": "ContextForge",
+      "tagline": "An open source registry and proxy that federates MCP, A2A, and REST/gRPC APIs with centralized governance, discovery, and observability. Optimizes Agent & Tool calling, and supports plugins.",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "tool-access-and-integration",
+      "website": "https://ibm.github.io/mcp-context-forge/",
+      "repository": "https://github.com/IBM/mcp-context-forge",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/contextforge.md",
+      "source_path": "services/tool-access-and-integration/contextforge.md",
+      "onboarding": {
+        "type": "mcp",
+        "pattern": "CLI + MCP gateway",
+        "instruction": "# Generate secrets, then start the gateway (official README TLDR)\npython3 -m mcpgateway.scripts.init_secrets\nexport JWT_SECRET_KEY=\"$(grep '^JWT_SECRET_KEY=' .env.secrets | cut -d= -f2)\"\nexport AUTH_ENCRYPTION_SECRET=\"$(grep '^AUTH_ENCRYPTION_SECRET=' .env.secrets | cut -d= -f2)\"\nJWT_SECRET_KEY=\"$JWT_SECRET_KEY\" \\\nAUTH_ENCRYPTION_SECRET=\"$AUTH_ENCRYPTION_SECRET\" \\\nMCPGATEWAY_UI_ENABLED=true \\\nMCPGATEWAY_ADMIN_API_ENABLED=true \\\nPLATFORM_ADMIN_EMAIL=admin@example.com \\\nuvx --from mcp-contextforge-gateway mcpgateway --host 0.0.0.0 --port 4444",
+        "url": "http://localhost:4444"
+      },
+      "protocols": [
+        "mcp",
+        "rest",
+        "grpc",
+        "websocket",
+        "cli",
+        "a2a",
+        "json-rpc",
+        "stdio",
+        "http",
+        "api"
+      ],
+      "mcp_status": "available",
+      "agent_skill_status": "unavailable",
+      "latest_month_signal": "Last GitHub push 2026-08-25 (repo metadata); PyPI mcp-contextforge-gateway; image ghcr.io/ibm/mcp-context-forge",
+      "verified_at": "2026-08-25",
+      "verification_sources": [
+        "https://api.github.com/repos/IBM/mcp-context-forge"
+      ]
+    },
+    {
       "id": "tool-access-and-integration/framelink-figma-mcp",
       "slug": "framelink-figma-mcp",
       "name": "Framelink MCP for Figma",
@@ -1791,6 +1875,43 @@
       "latest_month_signal": null,
       "verified_at": null,
       "verification_sources": []
+    },
+    {
+      "id": "tool-access-and-integration/mcp-gateway-registry",
+      "slug": "mcp-gateway-registry",
+      "name": "MCP Gateway & Registry",
+      "tagline": "Unified Agent & MCP Server Registry – Gateway for AI Development Tools",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "tool-access-and-integration",
+      "website": "https://agentic-community.github.io/mcp-gateway-registry/",
+      "repository": "https://github.com/agentic-community/mcp-gateway-registry",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/mcp-gateway-registry.md",
+      "source_path": "services/tool-access-and-integration/mcp-gateway-registry.md",
+      "onboarding": {
+        "type": "mcp",
+        "pattern": "CLI + MCP gateway",
+        "instruction": "git clone https://github.com/agentic-community/mcp-gateway-registry.git\ncd mcp-gateway-registry\ncp .env.example .env\n# Set required secrets (KEYCLOAK_ADMIN_PASSWORD, SECRET_KEY, …) — see docs/configuration.md\n./build_and_run.sh --prebuilt",
+        "url": "https://github.com/agentic-community/mcp-gateway-registry.git"
+      },
+      "protocols": [
+        "agent-skill",
+        "mcp",
+        "rest",
+        "cli",
+        "a2a",
+        "openapi",
+        "http",
+        "api"
+      ],
+      "mcp_status": "available",
+      "agent_skill_status": "available",
+      "latest_month_signal": "Last GitHub push 2026-08-25 (repo metadata)",
+      "verified_at": "2026-08-25",
+      "verification_sources": [
+        "https://api.github.com/repos/agentic-community/mcp-gateway-registry"
+      ]
     },
     {
       "id": "tool-access-and-integration/mcpgateway",
@@ -2299,6 +2420,38 @@
       "verification_sources": []
     },
     {
+      "id": "commerce-and-payments/ap2",
+      "slug": "ap2",
+      "name": "Agent Payments Protocol (AP2)",
+      "tagline": "An open protocol for the emerging Agent Economy.",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "commerce-and-payments",
+      "website": "https://ap2-protocol.org",
+      "repository": "https://github.com/google-agentic-commerce/AP2",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/commerce-and-payments/ap2.md",
+      "source_path": "services/commerce-and-payments/ap2.md",
+      "onboarding": {
+        "type": "sdk",
+        "pattern": "SDK + scenario samples",
+        "instruction": "# Types package (PyPI later; official install is from git)\nuv pip install git+https://github.com/google-agentic-commerce/AP2.git@main",
+        "url": "https://github.com/google-agentic-commerce/AP2.git@main"
+      },
+      "protocols": [
+        "sdk",
+        "a2a",
+        "http"
+      ],
+      "mcp_status": "unknown",
+      "agent_skill_status": "unavailable",
+      "latest_month_signal": "Last *code* push 2026-06-17 (repo metadata); docs/site still served. Quieter than neighboring commerce repos — disclose before treating samples as weekly-fresh",
+      "verified_at": "2026-08-25",
+      "verification_sources": [
+        "https://api.github.com/repos/google-agentic-commerce/AP2"
+      ]
+    },
+    {
       "id": "commerce-and-payments/circle-agent-stack",
       "slug": "circle-agent-stack",
       "name": "Circle Agent Stack",
@@ -2544,6 +2697,42 @@
       "verification_sources": []
     },
     {
+      "id": "commerce-and-payments/ucp",
+      "slug": "ucp",
+      "name": "Universal Commerce Protocol (UCP)",
+      "tagline": "The common language for platforms, agents, and businesses.",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "commerce-and-payments",
+      "website": "https://ucp.dev",
+      "repository": "https://github.com/Universal-Commerce-Protocol/ucp",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/commerce-and-payments/ucp.md",
+      "source_path": "services/commerce-and-payments/ucp.md",
+      "onboarding": {
+        "type": "sdk",
+        "pattern": "SDK + protocol spec",
+        "instruction": "# Schema tool agents use to resolve ucp_* annotations at runtime\ncargo install ucp-schema\n\n# Spec + docs checkout\ngit clone https://github.com/Universal-Commerce-Protocol/ucp.git",
+        "url": "https://github.com/Universal-Commerce-Protocol/ucp.git"
+      },
+      "protocols": [
+        "mcp",
+        "rest",
+        "cli",
+        "sdk",
+        "a2a",
+        "json-rpc",
+        "http"
+      ],
+      "mcp_status": "available",
+      "agent_skill_status": "unavailable",
+      "latest_month_signal": "Last GitHub push 2026-08-25 (repo metadata); spec + docs repo",
+      "verified_at": "2026-08-25",
+      "verification_sources": [
+        "https://api.github.com/repos/Universal-Commerce-Protocol/ucp"
+      ]
+    },
+    {
       "id": "agent-runtime-and-infrastructure/acpx",
       "slug": "acpx",
       "name": "acpx",
@@ -2603,6 +2792,39 @@
       "latest_month_signal": null,
       "verified_at": null,
       "verification_sources": []
+    },
+    {
+      "id": "agent-runtime-and-infrastructure/agent-substrate",
+      "slug": "agent-substrate",
+      "name": "Agent Substrate",
+      "tagline": "A performant, high density runtime environment for large scale agent deployments.",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "agent-runtime-and-infrastructure",
+      "website": "https://github.com/agent-substrate/substrate",
+      "repository": "https://github.com/agent-substrate/substrate",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/agent-substrate.md",
+      "source_path": "services/agent-runtime-and-infrastructure/agent-substrate.md",
+      "onboarding": {
+        "type": "cli",
+        "pattern": "CLI + Kubernetes control plane",
+        "instruction": "# Local kind path from the official README (development only)\nhack/create-kind-cluster.sh\nhack/install-ate-kind.sh --deploy-ate-system\nhack/install-ate-kind.sh --deploy-demo-counter\ngo install ./cmd/kubectl-ate\n\nkubectl ate create atespace demo\nkubectl ate create actor my-counter-1 -a demo --template=ate-demo-counter/counter\nkubectl port-forward -n ate-system svc/atenet-router 8000:80",
+        "url": null
+      },
+      "protocols": [
+        "grpc",
+        "cli",
+        "http",
+        "api"
+      ],
+      "mcp_status": "unknown",
+      "agent_skill_status": "unavailable",
+      "latest_month_signal": "Last GitHub push 2026-08-25 (repo metadata); early development, APIs expected to change",
+      "verified_at": "2026-08-25",
+      "verification_sources": [
+        "https://api.github.com/repos/agent-substrate/substrate"
+      ]
     },
     {
       "id": "agent-runtime-and-infrastructure/agentanycast",
@@ -3486,6 +3708,40 @@
       ]
     },
     {
+      "id": "agent-harnesses-and-control-planes/deepseek-harness",
+      "slug": "deepseek-harness",
+      "name": "DeepSeek Harness (dsh)",
+      "tagline": "Everything is a Plugin.",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "agent-harnesses-and-control-planes",
+      "website": "https://deepseek.com/harness",
+      "repository": "https://github.com/deepseek-ai/deepseek-harness",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/deepseek-harness.md",
+      "source_path": "services/agent-harnesses-and-control-planes/deepseek-harness.md",
+      "onboarding": {
+        "type": "cli",
+        "pattern": "CLI + Web UI (developer preview)",
+        "instruction": "npx @deepseek-ai/dsh web",
+        "url": "http://127.0.0.1:3080"
+      },
+      "protocols": [
+        "cli",
+        "sdk",
+        "acp",
+        "json-rpc",
+        "http"
+      ],
+      "mcp_status": "unavailable",
+      "agent_skill_status": "unavailable",
+      "latest_month_signal": "Last GitHub push 2026-08-21 (repo metadata); developer-preview release with public Web UI entry (npx @deepseek-ai/dsh web)",
+      "verified_at": "2026-08-25",
+      "verification_sources": [
+        "https://api.github.com/repos/deepseek-ai/deepseek-harness"
+      ]
+    },
+    {
       "id": "agent-harnesses-and-control-planes/longhorizon-harness",
       "slug": "longhorizon-harness",
       "name": "LongHorizon-Harness",
@@ -4030,6 +4286,73 @@
       "latest_month_signal": null,
       "verified_at": null,
       "verification_sources": []
+    },
+    {
+      "id": "memory-and-state/mempalace",
+      "slug": "mempalace",
+      "name": "MemPalace",
+      "tagline": "The best-benchmarked open-source AI memory system. And it's free.",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "memory-and-state",
+      "website": "https://mempalaceofficial.com",
+      "repository": "https://github.com/MemPalace/mempalace",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/mempalace.md",
+      "source_path": "services/memory-and-state/mempalace.md",
+      "onboarding": {
+        "type": "mcp",
+        "pattern": "CLI + MCP",
+        "instruction": "uv tool install mempalace\nmempalace init ~/projects/myapp\nmempalace mine ~/projects/myapp\nmempalace search \"why did we switch to GraphQL\"\nmempalace wake-up",
+        "url": null
+      },
+      "protocols": [
+        "mcp",
+        "cli",
+        "stdio",
+        "http",
+        "api"
+      ],
+      "mcp_status": "available",
+      "agent_skill_status": "unavailable",
+      "latest_month_signal": "Last GitHub push 2026-08-25 (repo metadata); default branch develop; PyPI package mempalace",
+      "verified_at": "2026-08-25",
+      "verification_sources": [
+        "https://api.github.com/repos/MemPalace/mempalace"
+      ]
+    },
+    {
+      "id": "memory-and-state/memsearch",
+      "slug": "memsearch",
+      "name": "MemSearch",
+      "tagline": "Cross-platform semantic memory for AI coding agents.",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "memory-and-state",
+      "website": "https://zilliztech.github.io/memsearch/",
+      "repository": "https://github.com/zilliztech/memsearch",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/memsearch.md",
+      "source_path": "services/memory-and-state/memsearch.md",
+      "onboarding": {
+        "type": "cli",
+        "pattern": "CLI + platform plugins",
+        "instruction": "# CLI / library (ONNX embeddings, no API key)\nuv tool install \"memsearch[onnx]\"\n\nmemsearch index ./memory/\nmemsearch search \"how to configure Redis?\" --top-k 5",
+        "url": null
+      },
+      "protocols": [
+        "agent-skill",
+        "mcp",
+        "cli",
+        "api"
+      ],
+      "mcp_status": "available",
+      "agent_skill_status": "available",
+      "latest_month_signal": "Last GitHub push 2026-08-23 (repo metadata); DeepSeek Harness plugin documented",
+      "verified_at": "2026-08-25",
+      "verification_sources": [
+        "https://api.github.com/repos/zilliztech/memsearch"
+      ]
     },
     {
       "id": "memory-and-state/memu",
@@ -4669,6 +4992,38 @@
       "verification_sources": []
     },
     {
+      "id": "code-execution/kubernetes-agent-sandbox",
+      "slug": "kubernetes-agent-sandbox",
+      "name": "Agent Sandbox (Kubernetes SIG)",
+      "tagline": "Agent Sandbox provides a secure and isolated execution layer to safely deploy autonomous AI agents on Kubernetes that generate and run untrusted code at scale.",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "code-execution",
+      "website": "https://agent-sandbox.sigs.k8s.io",
+      "repository": "https://github.com/kubernetes-sigs/agent-sandbox",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/kubernetes-agent-sandbox.md",
+      "source_path": "services/code-execution/kubernetes-agent-sandbox.md",
+      "onboarding": {
+        "type": "sdk",
+        "pattern": "SDK + Kubernetes CRDs",
+        "instruction": "pip install k8s-agent-sandbox",
+        "url": "https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/python/agentic-sandbox-client/README.md"
+      },
+      "protocols": [
+        "sdk",
+        "http",
+        "api"
+      ],
+      "mcp_status": "unavailable",
+      "agent_skill_status": "unavailable",
+      "latest_month_signal": "Last GitHub push 2026-08-25 (repo metadata); Python package k8s-agent-sandbox; SIG Apps CRD",
+      "verified_at": "2026-08-25",
+      "verification_sources": [
+        "https://api.github.com/repos/kubernetes-sigs/agent-sandbox"
+      ]
+    },
+    {
       "id": "code-execution/opensandbox",
       "slug": "opensandbox",
       "name": "OpenSandbox",
@@ -4916,6 +5271,37 @@
       "latest_month_signal": null,
       "verified_at": null,
       "verification_sources": []
+    },
+    {
+      "id": "observability-and-tracing/agentsight",
+      "slug": "agentsight",
+      "name": "AgentSight",
+      "tagline": "lightweight system-level observability for AI Agents",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "observability-and-tracing",
+      "website": "https://eunomia.dev/agentsight/",
+      "repository": "https://github.com/eunomia-bpf/agentsight",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/observability-and-tracing/agentsight.md",
+      "source_path": "services/observability-and-tracing/agentsight.md",
+      "onboarding": {
+        "type": "cli",
+        "pattern": "CLI wrapper (operator-surface track)",
+        "instruction": "cargo install agentsight\n# or: brew tap eunomia-bpf/tap && brew install eunomia-bpf/tap/agentsight\n\nagentsight top\nsudo agentsight record -- claude",
+        "url": null
+      },
+      "protocols": [
+        "cli",
+        "http"
+      ],
+      "mcp_status": "unknown",
+      "agent_skill_status": "unavailable",
+      "latest_month_signal": "Last GitHub push 2026-08-25 (repo metadata); docs updated 2026-08-24",
+      "verified_at": "2026-08-25",
+      "verification_sources": [
+        "https://api.github.com/repos/eunomia-bpf/agentsight"
+      ]
     },
     {
       "id": "observability-and-tracing/braintrust",

--- a/docs/categories/agent-harnesses-and-control-planes.md
+++ b/docs/categories/agent-harnesses-and-control-planes.md
@@ -6,7 +6,7 @@ hero_image: "/assets/images/editorial-authority.webp"
 permalink: /categories/agent-harnesses-and-control-planes/
 page_kind: collection
 collection_number: "07"
-service_count: 9
+service_count: 10
 ---
 
 <p class="collection-source"><a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/README.md">Collection notes ↗</a></p>
@@ -60,6 +60,17 @@ service_count: 9
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
+    <h2 class="service-card__title">DeepSeek Harness (dsh)</h2>
+    <div class="service-card__actions">
+      <a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/deepseek-harness.md">Open dossier ↗</a>
+      <a href="https://github.com/deepseek-ai/deepseek-harness">Official repo ↗</a>
+    </div>
+    </div>
+  </article>
+  <article class="service-card service-card--new atlas-sheet--service atlas-visual--06">
+    <span class="service-card__image" aria-hidden="true"></span>
+    <div class="service-card__copy">
+    <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
     <h2 class="service-card__title">LongHorizon-Harness</h2>
     <div class="service-card__actions">
       <a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/longhorizon-harness.md">Open dossier ↗</a>
@@ -67,7 +78,7 @@ service_count: 9
     </div>
     </div>
   </article>
-  <article class="service-card service-card--new atlas-sheet--service atlas-visual--06">
+  <article class="service-card service-card--new atlas-sheet--service atlas-visual--07">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
@@ -78,7 +89,7 @@ service_count: 9
     </div>
     </div>
   </article>
-  <article class="service-card service-card--new atlas-sheet--service atlas-visual--07">
+  <article class="service-card service-card--new atlas-sheet--service atlas-visual--08">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
@@ -89,7 +100,7 @@ service_count: 9
     </div>
     </div>
   </article>
-  <article class="service-card service-card--new atlas-sheet--service atlas-visual--08">
+  <article class="service-card service-card--new atlas-sheet--service atlas-visual--09">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
@@ -100,7 +111,7 @@ service_count: 9
     </div>
     </div>
   </article>
-  <article class="service-card service-card--new atlas-sheet--service atlas-visual--09">
+  <article class="service-card service-card--new atlas-sheet--service atlas-visual--10">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>

--- a/docs/categories/agent-runtime-and-infrastructure.md
+++ b/docs/categories/agent-runtime-and-infrastructure.md
@@ -6,7 +6,7 @@ hero_image: "/assets/images/editorial-runtime.webp"
 permalink: /categories/agent-runtime-and-infrastructure/
 page_kind: collection
 collection_number: "06"
-service_count: 27
+service_count: 28
 ---
 
 <p class="collection-source"><a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/README.md">Collection notes ↗</a></p>
@@ -65,7 +65,18 @@ service_count: 27
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--06">
+  <article class="service-card service-card--new atlas-sheet--arrival atlas-visual--06">
+    <span class="service-card__image" aria-hidden="true"></span>
+    <div class="service-card__copy">
+    <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
+    <h2 class="service-card__title">Agent Substrate</h2>
+    <div class="service-card__actions">
+      <a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/agent-substrate.md">Open dossier ↗</a>
+      <a href="https://github.com/agent-substrate/substrate">Official repo ↗</a>
+    </div>
+    </div>
+  </article>
+  <article class="service-card atlas-sheet--arrival atlas-visual--07">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -76,7 +87,7 @@ service_count: 27
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--07">
+  <article class="service-card atlas-sheet--arrival atlas-visual--08">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -86,7 +97,7 @@ service_count: 27
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--08">
+  <article class="service-card atlas-sheet--arrival atlas-visual--09">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -97,7 +108,7 @@ service_count: 27
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--09">
+  <article class="service-card atlas-sheet--arrival atlas-visual--10">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -108,7 +119,7 @@ service_count: 27
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--10">
+  <article class="service-card atlas-sheet--arrival atlas-visual--11">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -119,7 +130,7 @@ service_count: 27
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--11">
+  <article class="service-card atlas-sheet--arrival atlas-visual--12">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -130,7 +141,7 @@ service_count: 27
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--12">
+  <article class="service-card atlas-sheet--arrival atlas-visual--13">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -141,7 +152,7 @@ service_count: 27
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--13">
+  <article class="service-card atlas-sheet--arrival atlas-visual--14">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -152,7 +163,7 @@ service_count: 27
     </div>
     </div>
   </article>
-  <article class="service-card service-card--new atlas-sheet--arrival atlas-visual--14">
+  <article class="service-card service-card--new atlas-sheet--arrival atlas-visual--15">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
@@ -163,7 +174,7 @@ service_count: 27
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--15">
+  <article class="service-card atlas-sheet--arrival atlas-visual--16">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -174,7 +185,7 @@ service_count: 27
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--16">
+  <article class="service-card atlas-sheet--service atlas-visual--01">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -185,7 +196,7 @@ service_count: 27
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--01">
+  <article class="service-card atlas-sheet--service atlas-visual--02">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -196,7 +207,7 @@ service_count: 27
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--02">
+  <article class="service-card atlas-sheet--service atlas-visual--03">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -206,7 +217,7 @@ service_count: 27
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--03">
+  <article class="service-card atlas-sheet--service atlas-visual--04">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -217,7 +228,7 @@ service_count: 27
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--04">
+  <article class="service-card atlas-sheet--service atlas-visual--05">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -228,7 +239,7 @@ service_count: 27
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--05">
+  <article class="service-card atlas-sheet--service atlas-visual--06">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -239,7 +250,7 @@ service_count: 27
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--06">
+  <article class="service-card atlas-sheet--service atlas-visual--07">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -250,7 +261,7 @@ service_count: 27
     </div>
     </div>
   </article>
-  <article class="service-card service-card--new atlas-sheet--service atlas-visual--07">
+  <article class="service-card service-card--new atlas-sheet--service atlas-visual--08">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
@@ -261,7 +272,7 @@ service_count: 27
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--08">
+  <article class="service-card atlas-sheet--service atlas-visual--09">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -272,7 +283,7 @@ service_count: 27
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--09">
+  <article class="service-card atlas-sheet--service atlas-visual--10">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -283,7 +294,7 @@ service_count: 27
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--10">
+  <article class="service-card atlas-sheet--service atlas-visual--11">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -294,7 +305,7 @@ service_count: 27
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--11">
+  <article class="service-card atlas-sheet--service atlas-visual--12">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>

--- a/docs/categories/browser-and-web-execution.md
+++ b/docs/categories/browser-and-web-execution.md
@@ -6,7 +6,7 @@ hero_image: "/assets/images/editorial-network.webp"
 permalink: /categories/browser-and-web-execution/
 page_kind: collection
 collection_number: "02"
-service_count: 24
+service_count: 25
 ---
 
 <p class="collection-source"><a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/browser-and-web-execution/README.md">Collection notes ↗</a></p>
@@ -243,7 +243,18 @@ service_count: 24
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--06">
+  <article class="service-card service-card--new atlas-sheet--service atlas-visual--06">
+    <span class="service-card__image" aria-hidden="true"></span>
+    <div class="service-card__copy">
+    <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
+    <h2 class="service-card__title">Stealth Browser MCP</h2>
+    <div class="service-card__actions">
+      <a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/browser-and-web-execution/stealth-browser-mcp.md">Open dossier ↗</a>
+      <a href="https://github.com/vibheksoni/stealth-browser-mcp">Official repo ↗</a>
+    </div>
+    </div>
+  </article>
+  <article class="service-card atlas-sheet--service atlas-visual--07">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -254,7 +265,7 @@ service_count: 24
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--07">
+  <article class="service-card atlas-sheet--service atlas-visual--08">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -265,7 +276,7 @@ service_count: 24
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--08">
+  <article class="service-card atlas-sheet--service atlas-visual--09">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>

--- a/docs/categories/code-execution.md
+++ b/docs/categories/code-execution.md
@@ -6,7 +6,7 @@ hero_image: "/assets/images/editorial-runtime.webp"
 permalink: /categories/code-execution/
 page_kind: collection
 collection_number: "10"
-service_count: 10
+service_count: 11
 ---
 
 <p class="collection-source"><a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/README.md">Collection notes ↗</a></p>
@@ -22,7 +22,18 @@ service_count: 10
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--02">
+  <article class="service-card service-card--new atlas-sheet--arrival atlas-visual--02">
+    <span class="service-card__image" aria-hidden="true"></span>
+    <div class="service-card__copy">
+    <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
+    <h2 class="service-card__title">Agent Sandbox (Kubernetes SIG)</h2>
+    <div class="service-card__actions">
+      <a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/kubernetes-agent-sandbox.md">Open dossier ↗</a>
+      <a href="https://github.com/kubernetes-sigs/agent-sandbox">Official repo ↗</a>
+    </div>
+    </div>
+  </article>
+  <article class="service-card atlas-sheet--arrival atlas-visual--03">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -33,7 +44,7 @@ service_count: 10
     </div>
     </div>
   </article>
-  <article class="service-card service-card--new atlas-sheet--arrival atlas-visual--03">
+  <article class="service-card service-card--new atlas-sheet--arrival atlas-visual--04">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
@@ -44,7 +55,7 @@ service_count: 10
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--04">
+  <article class="service-card atlas-sheet--arrival atlas-visual--05">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -55,7 +66,7 @@ service_count: 10
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--05">
+  <article class="service-card atlas-sheet--arrival atlas-visual--06">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -66,7 +77,7 @@ service_count: 10
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--06">
+  <article class="service-card atlas-sheet--arrival atlas-visual--07">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -77,7 +88,7 @@ service_count: 10
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--07">
+  <article class="service-card atlas-sheet--arrival atlas-visual--08">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -88,7 +99,7 @@ service_count: 10
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--08">
+  <article class="service-card atlas-sheet--arrival atlas-visual--09">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -99,7 +110,7 @@ service_count: 10
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--09">
+  <article class="service-card atlas-sheet--arrival atlas-visual--10">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -110,7 +121,7 @@ service_count: 10
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--10">
+  <article class="service-card atlas-sheet--arrival atlas-visual--11">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>

--- a/docs/categories/commerce-and-payments.md
+++ b/docs/categories/commerce-and-payments.md
@@ -6,13 +6,24 @@ hero_image: "/assets/images/editorial-authority.webp"
 permalink: /categories/commerce-and-payments/
 page_kind: collection
 collection_number: "05"
-service_count: 9
+service_count: 11
 ---
 
 <p class="collection-source"><a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/commerce-and-payments/README.md">Collection notes ↗</a></p>
 
 <div class="service-grid">
-  <article class="service-card atlas-sheet--service atlas-visual--01">
+  <article class="service-card service-card--new atlas-sheet--service atlas-visual--01">
+    <span class="service-card__image" aria-hidden="true"></span>
+    <div class="service-card__copy">
+    <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
+    <h2 class="service-card__title">Agent Payments Protocol (AP2)</h2>
+    <div class="service-card__actions">
+      <a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/commerce-and-payments/ap2.md">Open dossier ↗</a>
+      <a href="https://github.com/google-agentic-commerce/AP2">Official repo ↗</a>
+    </div>
+    </div>
+  </article>
+  <article class="service-card atlas-sheet--service atlas-visual--02">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -23,7 +34,7 @@ service_count: 9
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--02">
+  <article class="service-card atlas-sheet--service atlas-visual--03">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -33,7 +44,7 @@ service_count: 9
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--03">
+  <article class="service-card atlas-sheet--service atlas-visual--04">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -44,7 +55,7 @@ service_count: 9
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--04">
+  <article class="service-card atlas-sheet--service atlas-visual--05">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -54,7 +65,7 @@ service_count: 9
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--05">
+  <article class="service-card atlas-sheet--service atlas-visual--06">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -65,7 +76,7 @@ service_count: 9
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--06">
+  <article class="service-card atlas-sheet--service atlas-visual--07">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -76,7 +87,7 @@ service_count: 9
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--07">
+  <article class="service-card atlas-sheet--service atlas-visual--08">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -86,7 +97,7 @@ service_count: 9
     </div>
     </div>
   </article>
-  <article class="service-card service-card--new atlas-sheet--service atlas-visual--08">
+  <article class="service-card service-card--new atlas-sheet--service atlas-visual--09">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
@@ -97,13 +108,24 @@ service_count: 9
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--09">
+  <article class="service-card atlas-sheet--service atlas-visual--10">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
     <h2 class="service-card__title">Skyfire</h2>
     <div class="service-card__actions">
       <a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/commerce-and-payments/skyfire.md">Open dossier ↗</a>
+    </div>
+    </div>
+  </article>
+  <article class="service-card service-card--new atlas-sheet--service atlas-visual--11">
+    <span class="service-card__image" aria-hidden="true"></span>
+    <div class="service-card__copy">
+    <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
+    <h2 class="service-card__title">Universal Commerce Protocol (UCP)</h2>
+    <div class="service-card__actions">
+      <a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/commerce-and-payments/ucp.md">Open dossier ↗</a>
+      <a href="https://github.com/Universal-Commerce-Protocol/ucp">Official repo ↗</a>
     </div>
     </div>
   </article>

--- a/docs/categories/index.md
+++ b/docs/categories/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Agent-Native Collections"
-description: "Browse 190 agent-native services across 16 curated infrastructure collections."
+description: "Browse 201 agent-native services across 16 curated infrastructure collections."
 permalink: /categories/
 page_kind: document
 ---
@@ -19,7 +19,7 @@ page_kind: document
     <span class="collection-card__copy">
     <span class="collection-card__number">02</span>
     <span class="collection-card__title">Browser &amp; Web Execution</span>
-    <span class="collection-card__count">24</span>
+    <span class="collection-card__count">25</span>
     </span>
   </a>
   <a class="collection-card atlas-visual--03" href="{{ '/categories/tool-access-and-integration/' | relative_url }}">
@@ -27,7 +27,7 @@ page_kind: document
     <span class="collection-card__copy">
     <span class="collection-card__number">03</span>
     <span class="collection-card__title">Tool Access &amp; Integration</span>
-    <span class="collection-card__count">17</span>
+    <span class="collection-card__count">19</span>
     </span>
   </a>
   <a class="collection-card atlas-visual--04" href="{{ '/categories/oversight-and-approval/' | relative_url }}">
@@ -43,7 +43,7 @@ page_kind: document
     <span class="collection-card__copy">
     <span class="collection-card__number">05</span>
     <span class="collection-card__title">Commerce &amp; Payments</span>
-    <span class="collection-card__count">9</span>
+    <span class="collection-card__count">11</span>
     </span>
   </a>
   <a class="collection-card atlas-visual--06" href="{{ '/categories/agent-runtime-and-infrastructure/' | relative_url }}">
@@ -51,7 +51,7 @@ page_kind: document
     <span class="collection-card__copy">
     <span class="collection-card__number">06</span>
     <span class="collection-card__title">Agent Runtime &amp; Infrastructure</span>
-    <span class="collection-card__count">27</span>
+    <span class="collection-card__count">28</span>
     </span>
   </a>
   <a class="collection-card atlas-visual--07" href="{{ '/categories/agent-harnesses-and-control-planes/' | relative_url }}">
@@ -59,7 +59,7 @@ page_kind: document
     <span class="collection-card__copy">
     <span class="collection-card__number">07</span>
     <span class="collection-card__title">Agent Harnesses &amp; Operator Surfaces</span>
-    <span class="collection-card__count">9</span>
+    <span class="collection-card__count">10</span>
     </span>
   </a>
   <a class="collection-card atlas-visual--08" href="{{ '/categories/memory-and-state/' | relative_url }}">
@@ -67,7 +67,7 @@ page_kind: document
     <span class="collection-card__copy">
     <span class="collection-card__number">08</span>
     <span class="collection-card__title">Memory &amp; State</span>
-    <span class="collection-card__count">17</span>
+    <span class="collection-card__count">19</span>
     </span>
   </a>
   <a class="collection-card atlas-visual--09" href="{{ '/categories/search-and-web-intelligence/' | relative_url }}">
@@ -83,7 +83,7 @@ page_kind: document
     <span class="collection-card__copy">
     <span class="collection-card__number">10</span>
     <span class="collection-card__title">Code Execution</span>
-    <span class="collection-card__count">10</span>
+    <span class="collection-card__count">11</span>
     </span>
   </a>
   <a class="collection-card atlas-visual--11" href="{{ '/categories/observability-and-tracing/' | relative_url }}">
@@ -91,7 +91,7 @@ page_kind: document
     <span class="collection-card__copy">
     <span class="collection-card__number">11</span>
     <span class="collection-card__title">Observability &amp; Tracing</span>
-    <span class="collection-card__count">11</span>
+    <span class="collection-card__count">12</span>
     </span>
   </a>
   <a class="collection-card atlas-visual--12" href="{{ '/categories/durable-execution-and-scheduling/' | relative_url }}">

--- a/docs/categories/memory-and-state.md
+++ b/docs/categories/memory-and-state.md
@@ -6,7 +6,7 @@ hero_image: "/assets/images/editorial-memory.webp"
 permalink: /categories/memory-and-state/
 page_kind: collection
 collection_number: "08"
-service_count: 17
+service_count: 19
 ---
 
 <p class="collection-source"><a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/README.md">Collection notes ↗</a></p>
@@ -144,7 +144,29 @@ service_count: 17
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--13">
+  <article class="service-card service-card--new atlas-sheet--arrival atlas-visual--13">
+    <span class="service-card__image" aria-hidden="true"></span>
+    <div class="service-card__copy">
+    <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
+    <h2 class="service-card__title">MemPalace</h2>
+    <div class="service-card__actions">
+      <a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/mempalace.md">Open dossier ↗</a>
+      <a href="https://github.com/MemPalace/mempalace">Official repo ↗</a>
+    </div>
+    </div>
+  </article>
+  <article class="service-card service-card--new atlas-sheet--arrival atlas-visual--14">
+    <span class="service-card__image" aria-hidden="true"></span>
+    <div class="service-card__copy">
+    <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
+    <h2 class="service-card__title">MemSearch</h2>
+    <div class="service-card__actions">
+      <a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/memsearch.md">Open dossier ↗</a>
+      <a href="https://github.com/zilliztech/memsearch">Official repo ↗</a>
+    </div>
+    </div>
+  </article>
+  <article class="service-card atlas-sheet--arrival atlas-visual--15">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -155,7 +177,7 @@ service_count: 17
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--14">
+  <article class="service-card atlas-sheet--arrival atlas-visual--16">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -166,7 +188,7 @@ service_count: 17
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--15">
+  <article class="service-card atlas-sheet--service atlas-visual--01">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -177,7 +199,7 @@ service_count: 17
     </div>
     </div>
   </article>
-  <article class="service-card service-card--new atlas-sheet--arrival atlas-visual--16">
+  <article class="service-card service-card--new atlas-sheet--service atlas-visual--02">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
@@ -188,7 +210,7 @@ service_count: 17
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--01">
+  <article class="service-card atlas-sheet--service atlas-visual--03">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>

--- a/docs/categories/observability-and-tracing.md
+++ b/docs/categories/observability-and-tracing.md
@@ -6,7 +6,7 @@ hero_image: "/assets/images/editorial-memory.webp"
 permalink: /categories/observability-and-tracing/
 page_kind: collection
 collection_number: "11"
-service_count: 11
+service_count: 12
 ---
 
 <p class="collection-source"><a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/observability-and-tracing/README.md">Collection notes ↗</a></p>
@@ -45,7 +45,18 @@ service_count: 11
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--04">
+  <article class="service-card service-card--new atlas-sheet--service atlas-visual--04">
+    <span class="service-card__image" aria-hidden="true"></span>
+    <div class="service-card__copy">
+    <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
+    <h2 class="service-card__title">AgentSight</h2>
+    <div class="service-card__actions">
+      <a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/observability-and-tracing/agentsight.md">Open dossier ↗</a>
+      <a href="https://github.com/eunomia-bpf/agentsight">Official repo ↗</a>
+    </div>
+    </div>
+  </article>
+  <article class="service-card atlas-sheet--service atlas-visual--05">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -56,7 +67,7 @@ service_count: 11
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--05">
+  <article class="service-card atlas-sheet--service atlas-visual--06">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -67,7 +78,7 @@ service_count: 11
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--06">
+  <article class="service-card atlas-sheet--service atlas-visual--07">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -78,7 +89,7 @@ service_count: 11
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--07">
+  <article class="service-card atlas-sheet--service atlas-visual--08">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -89,7 +100,7 @@ service_count: 11
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--08">
+  <article class="service-card atlas-sheet--service atlas-visual--09">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -100,7 +111,7 @@ service_count: 11
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--09">
+  <article class="service-card atlas-sheet--service atlas-visual--10">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -111,7 +122,7 @@ service_count: 11
     </div>
     </div>
   </article>
-  <article class="service-card service-card--new atlas-sheet--service atlas-visual--10">
+  <article class="service-card service-card--new atlas-sheet--service atlas-visual--11">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
@@ -122,7 +133,7 @@ service_count: 11
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--11">
+  <article class="service-card atlas-sheet--service atlas-visual--12">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>

--- a/docs/categories/tool-access-and-integration.md
+++ b/docs/categories/tool-access-and-integration.md
@@ -6,7 +6,7 @@ hero_image: "/assets/images/editorial-network.webp"
 permalink: /categories/tool-access-and-integration/
 page_kind: collection
 collection_number: "03"
-service_count: 17
+service_count: 19
 ---
 
 <p class="collection-source"><a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/README.md">Collection notes ↗</a></p>
@@ -56,7 +56,18 @@ service_count: 17
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--05">
+  <article class="service-card service-card--new atlas-sheet--service atlas-visual--05">
+    <span class="service-card__image" aria-hidden="true"></span>
+    <div class="service-card__copy">
+    <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
+    <h2 class="service-card__title">ContextForge</h2>
+    <div class="service-card__actions">
+      <a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/contextforge.md">Open dossier ↗</a>
+      <a href="https://github.com/IBM/mcp-context-forge">Official repo ↗</a>
+    </div>
+    </div>
+  </article>
+  <article class="service-card atlas-sheet--service atlas-visual--06">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -67,7 +78,7 @@ service_count: 17
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--06">
+  <article class="service-card atlas-sheet--service atlas-visual--07">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -78,7 +89,7 @@ service_count: 17
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--07">
+  <article class="service-card atlas-sheet--service atlas-visual--08">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -88,7 +99,18 @@ service_count: 17
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--08">
+  <article class="service-card service-card--new atlas-sheet--service atlas-visual--09">
+    <span class="service-card__image" aria-hidden="true"></span>
+    <div class="service-card__copy">
+    <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
+    <h2 class="service-card__title">MCP Gateway &amp; Registry</h2>
+    <div class="service-card__actions">
+      <a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/mcp-gateway-registry.md">Open dossier ↗</a>
+      <a href="https://github.com/agentic-community/mcp-gateway-registry">Official repo ↗</a>
+    </div>
+    </div>
+  </article>
+  <article class="service-card atlas-sheet--service atlas-visual--10">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -99,7 +121,7 @@ service_count: 17
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--09">
+  <article class="service-card atlas-sheet--service atlas-visual--11">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -110,7 +132,7 @@ service_count: 17
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--10">
+  <article class="service-card atlas-sheet--service atlas-visual--12">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -121,7 +143,7 @@ service_count: 17
     </div>
     </div>
   </article>
-  <article class="service-card service-card--new atlas-sheet--service atlas-visual--11">
+  <article class="service-card service-card--new atlas-sheet--service atlas-visual--13">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
@@ -132,7 +154,7 @@ service_count: 17
     </div>
     </div>
   </article>
-  <article class="service-card service-card--new atlas-sheet--service atlas-visual--12">
+  <article class="service-card service-card--new atlas-sheet--service atlas-visual--14">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
@@ -143,7 +165,7 @@ service_count: 17
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--13">
+  <article class="service-card atlas-sheet--service atlas-visual--15">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -154,7 +176,7 @@ service_count: 17
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--14">
+  <article class="service-card atlas-sheet--service atlas-visual--16">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -165,7 +187,7 @@ service_count: 17
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--15">
+  <article class="service-card atlas-sheet--arrival atlas-visual--01">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -176,7 +198,7 @@ service_count: 17
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--16">
+  <article class="service-card atlas-sheet--arrival atlas-visual--02">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -187,7 +209,7 @@ service_count: 17
     </div>
     </div>
   </article>
-  <article class="service-card service-card--new atlas-sheet--arrival atlas-visual--01">
+  <article class="service-card service-card--new atlas-sheet--arrival atlas-visual--03">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,9 +3,9 @@ title: "The Agent-Native Index"
 description: "A curated 2026 collection of agent-native infrastructure: MCP tools, harnesses, identity, memory, sandboxes, browsers, payments, and runtimes."
 image: /assets/images/social-preview.png
 page_kind: home
-service_count: 190
+service_count: 201
 collection_count: 16
-new_arrivals_count: 37
+new_arrivals_count: 48
 ---
 
 <section id="new-arrivals" aria-labelledby="new-arrivals-title">
@@ -103,7 +103,63 @@ new_arrivals_count: 37
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--12" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/sandbase-cli.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--12" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/commerce-and-payments/ucp.md">
+      <span class="arrival-card__image" aria-hidden="true"></span>
+      <span class="arrival-card__copy">
+        <span class="arrival-card__category">Commerce &amp; Payments</span>
+        <strong class="arrival-card__name">Universal Commerce Protocol (UCP)</strong>
+        <span class="arrival-card__arrow" aria-hidden="true">↗</span>
+      </span>
+    </a>
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--13" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/agent-substrate.md">
+      <span class="arrival-card__image" aria-hidden="true"></span>
+      <span class="arrival-card__copy">
+        <span class="arrival-card__category">Agent Runtime &amp; Infrastructure</span>
+        <strong class="arrival-card__name">Agent Substrate</strong>
+        <span class="arrival-card__arrow" aria-hidden="true">↗</span>
+      </span>
+    </a>
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--14" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/observability-and-tracing/agentsight.md">
+      <span class="arrival-card__image" aria-hidden="true"></span>
+      <span class="arrival-card__copy">
+        <span class="arrival-card__category">Observability &amp; Tracing</span>
+        <strong class="arrival-card__name">AgentSight</strong>
+        <span class="arrival-card__arrow" aria-hidden="true">↗</span>
+      </span>
+    </a>
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--15" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/mempalace.md">
+      <span class="arrival-card__image" aria-hidden="true"></span>
+      <span class="arrival-card__copy">
+        <span class="arrival-card__category">Memory &amp; State</span>
+        <strong class="arrival-card__name">MemPalace</strong>
+        <span class="arrival-card__arrow" aria-hidden="true">↗</span>
+      </span>
+    </a>
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--16" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/kubernetes-agent-sandbox.md">
+      <span class="arrival-card__image" aria-hidden="true"></span>
+      <span class="arrival-card__copy">
+        <span class="arrival-card__category">Code Execution</span>
+        <strong class="arrival-card__name">Agent Sandbox (Kubernetes SIG)</strong>
+        <span class="arrival-card__arrow" aria-hidden="true">↗</span>
+      </span>
+    </a>
+    <a class="arrival-card atlas-sheet--service atlas-visual--01" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/contextforge.md">
+      <span class="arrival-card__image" aria-hidden="true"></span>
+      <span class="arrival-card__copy">
+        <span class="arrival-card__category">Tool Access &amp; Integration</span>
+        <strong class="arrival-card__name">ContextForge</strong>
+        <span class="arrival-card__arrow" aria-hidden="true">↗</span>
+      </span>
+    </a>
+    <a class="arrival-card atlas-sheet--service atlas-visual--02" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/mcp-gateway-registry.md">
+      <span class="arrival-card__image" aria-hidden="true"></span>
+      <span class="arrival-card__copy">
+        <span class="arrival-card__category">Tool Access &amp; Integration</span>
+        <strong class="arrival-card__name">MCP Gateway &amp; Registry</strong>
+        <span class="arrival-card__arrow" aria-hidden="true">↗</span>
+      </span>
+    </a>
+    <a class="arrival-card atlas-sheet--service atlas-visual--03" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/sandbase-cli.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Tool Access &amp; Integration</span>
@@ -111,7 +167,23 @@ new_arrivals_count: 37
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--13" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-social-network/agentgram.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--04" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/memsearch.md">
+      <span class="arrival-card__image" aria-hidden="true"></span>
+      <span class="arrival-card__copy">
+        <span class="arrival-card__category">Memory &amp; State</span>
+        <strong class="arrival-card__name">MemSearch</strong>
+        <span class="arrival-card__arrow" aria-hidden="true">↗</span>
+      </span>
+    </a>
+    <a class="arrival-card atlas-sheet--service atlas-visual--05" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/deepseek-harness.md">
+      <span class="arrival-card__image" aria-hidden="true"></span>
+      <span class="arrival-card__copy">
+        <span class="arrival-card__category">Agent Harnesses &amp; Operator Surfaces</span>
+        <strong class="arrival-card__name">DeepSeek Harness (dsh)</strong>
+        <span class="arrival-card__arrow" aria-hidden="true">↗</span>
+      </span>
+    </a>
+    <a class="arrival-card atlas-sheet--service atlas-visual--06" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-social-network/agentgram.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Agent Social &amp; Community</span>
@@ -119,7 +191,7 @@ new_arrivals_count: 37
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--14" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/toolport.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--07" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/toolport.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Tool Access &amp; Integration</span>
@@ -127,7 +199,7 @@ new_arrivals_count: 37
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--15" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/loopx.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--08" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/loopx.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Agent Harnesses &amp; Operator Surfaces</span>
@@ -135,7 +207,7 @@ new_arrivals_count: 37
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--16" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/cloudflare-computer.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--09" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/cloudflare-computer.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Agent Runtime &amp; Infrastructure</span>
@@ -143,7 +215,7 @@ new_arrivals_count: 37
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--01" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/oversight-and-approval/preloop.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--10" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/oversight-and-approval/preloop.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Oversight &amp; Approval</span>
@@ -151,7 +223,7 @@ new_arrivals_count: 37
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--02" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/claude-hud.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--11" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/claude-hud.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Agent Harnesses &amp; Operator Surfaces</span>
@@ -159,7 +231,7 @@ new_arrivals_count: 37
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--03" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/search-and-web-intelligence/agent-search-mcp.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--12" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/search-and-web-intelligence/agent-search-mcp.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Search &amp; Web Intelligence</span>
@@ -167,7 +239,7 @@ new_arrivals_count: 37
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--04" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/agentmemory.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--13" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/agentmemory.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Memory &amp; State</span>
@@ -175,7 +247,7 @@ new_arrivals_count: 37
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--05" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/google-ax.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--14" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/google-ax.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Agent Runtime &amp; Infrastructure</span>
@@ -183,7 +255,7 @@ new_arrivals_count: 37
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--06" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/voice-and-phone/patter.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--15" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/voice-and-phone/patter.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Voice &amp; Phone</span>
@@ -191,7 +263,7 @@ new_arrivals_count: 37
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--07" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/communication/atomic-mail.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--16" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/communication/atomic-mail.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Communication</span>
@@ -199,7 +271,7 @@ new_arrivals_count: 37
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--08" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/meeting-and-conversation/agentcall.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--01" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/meeting-and-conversation/agentcall.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Meeting &amp; Conversation</span>
@@ -207,7 +279,7 @@ new_arrivals_count: 37
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--09" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/communication/agentteam-email.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--02" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/communication/agentteam-email.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Communication</span>
@@ -215,7 +287,23 @@ new_arrivals_count: 37
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--10" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/tencentdb-agent-memory.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--03" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/browser-and-web-execution/stealth-browser-mcp.md">
+      <span class="arrival-card__image" aria-hidden="true"></span>
+      <span class="arrival-card__copy">
+        <span class="arrival-card__category">Browser &amp; Web Execution</span>
+        <strong class="arrival-card__name">Stealth Browser MCP</strong>
+        <span class="arrival-card__arrow" aria-hidden="true">↗</span>
+      </span>
+    </a>
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--04" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/commerce-and-payments/ap2.md">
+      <span class="arrival-card__image" aria-hidden="true"></span>
+      <span class="arrival-card__copy">
+        <span class="arrival-card__category">Commerce &amp; Payments</span>
+        <strong class="arrival-card__name">Agent Payments Protocol (AP2)</strong>
+        <span class="arrival-card__arrow" aria-hidden="true">↗</span>
+      </span>
+    </a>
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--05" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/tencentdb-agent-memory.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Memory &amp; State</span>
@@ -223,7 +311,7 @@ new_arrivals_count: 37
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--11" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/longhorizon-harness.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--06" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/longhorizon-harness.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Agent Harnesses &amp; Operator Surfaces</span>
@@ -231,7 +319,7 @@ new_arrivals_count: 37
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--12" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/search-and-web-intelligence/contextx.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--07" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/search-and-web-intelligence/contextx.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Search &amp; Web Intelligence</span>
@@ -239,7 +327,7 @@ new_arrivals_count: 37
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--13" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/qm.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--08" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/qm.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Agent Harnesses &amp; Operator Surfaces</span>
@@ -247,7 +335,7 @@ new_arrivals_count: 37
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--14" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/axern.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--09" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/axern.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Code Execution</span>
@@ -255,7 +343,7 @@ new_arrivals_count: 37
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--15" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-social-network/agent-chamber.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--10" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-social-network/agent-chamber.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Agent Social &amp; Community</span>
@@ -263,7 +351,7 @@ new_arrivals_count: 37
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--16" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/voice-and-phone/qwen-audio-agent.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--11" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/voice-and-phone/qwen-audio-agent.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Voice &amp; Phone</span>
@@ -271,7 +359,7 @@ new_arrivals_count: 37
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--01" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/llm-gateway-and-routing/sageroute.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--12" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/llm-gateway-and-routing/sageroute.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">LLM Gateway &amp; Routing</span>
@@ -279,7 +367,7 @@ new_arrivals_count: 37
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--02" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/observability-and-tracing/numbat.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--13" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/observability-and-tracing/numbat.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Observability &amp; Tracing</span>
@@ -287,7 +375,7 @@ new_arrivals_count: 37
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--03" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/memmy-agent.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--14" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/memmy-agent.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Memory &amp; State</span>
@@ -295,7 +383,7 @@ new_arrivals_count: 37
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--04" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/meeting-and-conversation/looped-meet.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--15" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/meeting-and-conversation/looped-meet.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Meeting &amp; Conversation</span>
@@ -303,7 +391,7 @@ new_arrivals_count: 37
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--05" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/durable-execution-and-scheduling/pi-dispatch.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--16" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/durable-execution-and-scheduling/pi-dispatch.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Durable Execution &amp; Scheduling</span>
@@ -327,7 +415,7 @@ new_arrivals_count: 37
   <div class="section-intro">
     <span class="section-number">02</span>
     <h2 class="section-title" id="collections-title">The collections</h2>
-    <p class="section-note">16 fields · 190 dossiers</p>
+    <p class="section-note">16 fields · 201 dossiers</p>
   </div>
   <div class="collection-grid">
     <a class="collection-card atlas-visual--01" href="{{ '/categories/communication/' | relative_url }}">
@@ -343,7 +431,7 @@ new_arrivals_count: 37
       <span class="collection-card__copy">
       <span class="collection-card__number">02</span>
       <span class="collection-card__title">Browser &amp; Web Execution</span>
-      <span class="collection-card__count">24</span>
+      <span class="collection-card__count">25</span>
       </span>
     </a>
     <a class="collection-card atlas-visual--03" href="{{ '/categories/tool-access-and-integration/' | relative_url }}">
@@ -351,7 +439,7 @@ new_arrivals_count: 37
       <span class="collection-card__copy">
       <span class="collection-card__number">03</span>
       <span class="collection-card__title">Tool Access &amp; Integration</span>
-      <span class="collection-card__count">17</span>
+      <span class="collection-card__count">19</span>
       </span>
     </a>
     <a class="collection-card atlas-visual--04" href="{{ '/categories/oversight-and-approval/' | relative_url }}">
@@ -367,7 +455,7 @@ new_arrivals_count: 37
       <span class="collection-card__copy">
       <span class="collection-card__number">05</span>
       <span class="collection-card__title">Commerce &amp; Payments</span>
-      <span class="collection-card__count">9</span>
+      <span class="collection-card__count">11</span>
       </span>
     </a>
     <a class="collection-card atlas-visual--06" href="{{ '/categories/agent-runtime-and-infrastructure/' | relative_url }}">
@@ -375,7 +463,7 @@ new_arrivals_count: 37
       <span class="collection-card__copy">
       <span class="collection-card__number">06</span>
       <span class="collection-card__title">Agent Runtime &amp; Infrastructure</span>
-      <span class="collection-card__count">27</span>
+      <span class="collection-card__count">28</span>
       </span>
     </a>
     <a class="collection-card atlas-visual--07" href="{{ '/categories/agent-harnesses-and-control-planes/' | relative_url }}">
@@ -383,7 +471,7 @@ new_arrivals_count: 37
       <span class="collection-card__copy">
       <span class="collection-card__number">07</span>
       <span class="collection-card__title">Agent Harnesses &amp; Operator Surfaces</span>
-      <span class="collection-card__count">9</span>
+      <span class="collection-card__count">10</span>
       </span>
     </a>
     <a class="collection-card atlas-visual--08" href="{{ '/categories/memory-and-state/' | relative_url }}">
@@ -391,7 +479,7 @@ new_arrivals_count: 37
       <span class="collection-card__copy">
       <span class="collection-card__number">08</span>
       <span class="collection-card__title">Memory &amp; State</span>
-      <span class="collection-card__count">17</span>
+      <span class="collection-card__count">19</span>
       </span>
     </a>
     <a class="collection-card atlas-visual--09" href="{{ '/categories/search-and-web-intelligence/' | relative_url }}">
@@ -407,7 +495,7 @@ new_arrivals_count: 37
       <span class="collection-card__copy">
       <span class="collection-card__number">10</span>
       <span class="collection-card__title">Code Execution</span>
-      <span class="collection-card__count">10</span>
+      <span class="collection-card__count">11</span>
       </span>
     </a>
     <a class="collection-card atlas-visual--11" href="{{ '/categories/observability-and-tracing/' | relative_url }}">
@@ -415,7 +503,7 @@ new_arrivals_count: 37
       <span class="collection-card__copy">
       <span class="collection-card__number">11</span>
       <span class="collection-card__title">Observability &amp; Tracing</span>
-      <span class="collection-card__count">11</span>
+      <span class="collection-card__count">12</span>
       </span>
     </a>
     <a class="collection-card atlas-visual--12" href="{{ '/categories/durable-execution-and-scheduling/' | relative_url }}">
@@ -478,6 +566,6 @@ new_arrivals_count: 37
   <div>
   <span class="section-number">03</span>
   <h2 class="section-title">Full source.</h2>
-  <a class="source-gateway__link" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/README.md">Open 190 dossiers ↗</a>
+  <a class="source-gateway__link" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/README.md">Open 201 dossiers ↗</a>
   </div>
 </section>

--- a/docs/skill.md
+++ b/docs/skill.md
@@ -59,7 +59,7 @@ These services can be joined with a single instruction, right now, with no human
 
 ---
 
-## Full Catalog — 16 Categories, 190 Services
+## Full Catalog — 16 Categories, 201 Services
 
 ### 1. Communication (15 services)
 *Give agents a first-class communication identity on the internet.*
@@ -84,7 +84,7 @@ These services can be joined with a single instruction, right now, with no human
 
 ---
 
-### 2. Browser & Web Execution (24 services)
+### 2. Browser & Web Execution (25 services)
 *Remote browser and web data extraction for agents.*
 
 | Service | Tagline | Onboarding |
@@ -113,10 +113,11 @@ These services can be joined with a single instruction, right now, with no human
 | [CamoFox Browser](https://github.com/jo-inc/camofox-browser) | Stealth headless browser for AI agents | `npm install -g camofox-browser` then start the browser server |
 | [Moli](https://github.com/lexmount/moli) | Structured-first browser engine for AI agents | Build the Rust workspace, then run `moli fetch`, `moli serve`, or `moli mcp` |
 | [Kernel](https://www.kernel.sh) | you build agents. we give them the internet. | `brew install kernel/tap/kernel` or `npm install -g @onkernel/cli`, then `kernel browsers create -o json` |
+| [Stealth Browser MCP](https://github.com/vibheksoni/stealth-browser-mcp) | Stealth browser automation for MCP-compatible AI agents | Clone repo → `pip install -r requirements.txt` → `claude mcp add-json stealth-browser-mcp` |
 
 ---
 
-### 3. Tool Access & Integration (17 services)
+### 3. Tool Access & Integration (19 services)
 *Runtime tool discovery, auth, and execution without human pre-configuration.*
 
 | Service | Tagline | Onboarding |
@@ -138,6 +139,8 @@ These services can be joined with a single instruction, right now, with no human
 | [OpenChatCut](https://github.com/0xsline/OpenChatCut) | Local-first agent-native video editor | `npx skills add 0xsline/OpenChatCut`, then ask the agent to set it up |
 | [Toolport](https://toolport.app) | Every tool. One port. | Install from GitHub Releases, add servers, connect each AI client to `toolport-gateway` |
 | [SandBase CLI](https://github.com/sandbaseai/cli) | Give your AI agent superpowers. One command. 2,000+ AI models. | GitHub `v0.1.17` tarball `connect`, then `npx skills add sandbaseai/cli --skill sandbase` |
+| [ContextForge](https://ibm.github.io/mcp-context-forge/) | Registry and proxy that federates MCP, A2A, and REST/gRPC | `uvx --from mcp-contextforge-gateway mcpgateway --host 0.0.0.0 --port 4444` |
+| [MCP Gateway & Registry](https://agentic-community.github.io/mcp-gateway-registry/) | Unified Agent & MCP Server Registry | `git clone https://github.com/agentic-community/mcp-gateway-registry && ./build_and_run.sh --prebuilt` |
 
 ---
 
@@ -154,7 +157,7 @@ These services can be joined with a single instruction, right now, with no human
 
 ---
 
-### 5. Commerce & Payments (9 services)
+### 5. Commerce & Payments (11 services)
 *Verified financial identity and real-economy transactions for agents.*
 
 | Service | Tagline | Onboarding |
@@ -168,10 +171,12 @@ These services can be joined with a single instruction, right now, with no human
 | [Nevermined](https://nevermined.io) | The payment layer AI agents actually need | `pip install payments-py` → x402 inline payments |
 | [Coinbase CDP (x402)](https://docs.cdp.coinbase.com/x402/welcome) | HTTP-native payments for autonomous API clients | [docs.cdp.coinbase.com/x402](https://docs.cdp.coinbase.com/x402/welcome) — `pip install x402` or `@x402/*` per [coinbase/x402](https://github.com/coinbase/x402) |
 | [SecondSign Core](https://github.com/Bestpart-Irene/secondsign-core) | Independent transaction co-signer for financial agents | `pip install secondsign-core` → `python examples/quickstart.py` (pre-1.0 evaluation) |
+| [UCP](https://ucp.dev) | The common language for platforms, agents, and businesses | Read [ucp.dev](https://ucp.dev) then `cargo install ucp-schema` |
+| [AP2](https://ap2-protocol.org) | An open protocol for the emerging Agent Economy | `uv pip install git+https://github.com/google-agentic-commerce/AP2.git@main` |
 
 ---
 
-### 6. Agent Runtime & Infrastructure (27 services)
+### 6. Agent Runtime & Infrastructure (28 services)
 *Secure execution, session isolation, secrets, identity, and gateway for production agents.*
 
 | Service | Tagline | Onboarding |
@@ -203,10 +208,11 @@ These services can be joined with a single instruction, right now, with no human
 | [Polos](https://github.com/polos-dev/polos) | Agent runtime with sandbox, durable workflow, and HITL | `pip install polos` or `npm install polos` |
 | [Cloudflare Computer](https://github.com/cloudflare/computer) | Give your agent a computer | `npm install @cloudflare/computer` then attach `withWorkspace` to a Durable Object (preview only) |
 | [Agent Executor (AX)](https://github.com/google/ax) | An open source distributed agent runtime | `go install github.com/google/ax/cmd/ax@latest` then `ax --input "…"` |
+| [Agent Substrate](https://github.com/agent-substrate/substrate) | High-density Kubernetes runtime for large-scale agent deployments | `hack/install-ate-kind.sh --deploy-ate-system` then `kubectl ate create actor` |
 
 ---
 
-### 7. Agent Harnesses & Operator Surfaces (9 services)
+### 7. Agent Harnesses & Operator Surfaces (10 services)
 *Durable agent-loop control, multi-agent orchestration, and live operator surfaces tied to concrete sessions.*
 
 | Service | Tagline | Onboarding |
@@ -220,10 +226,11 @@ These services can be joined with a single instruction, right now, with no human
 | [Codex HUD (anhannin)](https://github.com/anhannin/codex-hud) | Patched Codex status line for usage and session state | Review the patch/install script, then run `Codex-HUD/install.sh` and start a new session |
 | [Claude HUD](https://github.com/jarrodwatts/claude-hud) | A Claude Code plugin that shows what's happening | `/plugin marketplace add jarrodwatts/claude-hud` then `/plugin install claude-hud` and `/claude-hud:setup` |
 | [LoopX](https://huangruiteng.github.io/loopx/) | Stateful control plane for long-horizon agents | `python3 -m pip install --upgrade loopx` then `loopx workflow-skills --install` and `loopx connect` |
+| [DeepSeek Harness (dsh)](https://deepseek.com/harness) | Everything is a Plugin. | `npx @deepseek-ai/dsh web` |
 
 ---
 
-### 8. Memory & State (17 services)
+### 8. Memory & State (19 services)
 *Persistent, queryable memory across sessions — memory as infrastructure, not application logic.*
 
 | Service | Tagline | Onboarding |
@@ -245,6 +252,8 @@ These services can be joined with a single instruction, right now, with no human
 | [Hindsight](https://github.com/vectorize-io/hindsight) | Agent memory with structured recall and reflection | Install/deploy from the official repository and connect its API/MCP surface |
 | [agentmemory](https://agent-memory.dev) ⭐ | Your coding agent remembers everything | `Read https://raw.githubusercontent.com/rohitg00/agentmemory/main/INSTALL_FOR_AGENTS.md and follow the instructions` |
 | [TencentDB Agent Memory](https://github.com/TencentCloud/TencentDB-Agent-Memory) | Agents remember,Humans innovate. | `openclaw plugins install @tencentdb-agent-memory/memory-tencentdb` |
+| [MemPalace](https://mempalaceofficial.com) | The best-benchmarked open-source AI memory system. And it's free. | `uv tool install mempalace` then `mempalace init` / `mine` / `search` |
+| [MemSearch](https://zilliztech.github.io/memsearch/) | Cross-platform semantic memory for AI coding agents | `uv tool install "memsearch[onnx]"` or Claude Code `/plugin marketplace add zilliztech/memsearch` |
 
 ---
 
@@ -265,7 +274,7 @@ These services can be joined with a single instruction, right now, with no human
 
 ---
 
-### 10. Code Execution (10 services)
+### 10. Code Execution (11 services)
 *Secure isolated runtimes for AI-generated code with LLM-formatted output.*
 
 | Service | Tagline | Onboarding |
@@ -280,10 +289,11 @@ These services can be joined with a single instruction, right now, with no human
 | [AIO Sandbox](https://github.com/agent-infra/sandbox) | Browser + shell + VS Code + Jupyter + MCP in one Docker sandbox | `docker run -p 8080:8080 ghcr.io/agent-infra/sandbox:latest` — MCP `http://localhost:8080/mcp` |
 | [Riza](https://riza.io) | AI writes code. Riza runs it. | `uv add rizaio` → `riza.command.exec(...)` — [docs.riza.io](https://docs.riza.io) |
 | [Agent Sandbox](https://agentsandbox.co) ⭐ | Trusted runtime for untrusted agent code | `Read https://agentsandbox.co/skill.md and follow the instructions` or `pip install agentsandbox-sdk` |
+| [Agent Sandbox (Kubernetes SIG)](https://agent-sandbox.sigs.k8s.io) | Secure isolated execution layer for autonomous agents on Kubernetes | `pip install k8s-agent-sandbox` then `SandboxClient().create_sandbox(...)` |
 
 ---
 
-### 11. Observability & Tracing (11 services)
+### 11. Observability & Tracing (12 services)
 *Full trajectory tracing, evaluation datasets, and cost attribution for agent runs.*
 
 | Service | Tagline | Onboarding |
@@ -299,6 +309,7 @@ These services can be joined with a single instruction, right now, with no human
 | [Galileo](https://galileo.ai) | Agent reliability platform with observability and evals | Add MCP URL `https://api.galileo.ai/mcp/http/mcp` with a Galileo API key |
 | [Laminar](https://github.com/lmnr-ai/lmnr) | Open-source observability for long-running agents | `pip install lmnr` → `Laminar.initialize()` |
 | [OpenLIT](https://github.com/openlit/openlit) | OpenTelemetry-native observability for LLMs and agents | `pip install openlit` then configure OpenTelemetry export |
+| [AgentSight](https://eunomia.dev/agentsight/) | Lightweight system-level observability for AI Agents | `cargo install agentsight` then `agentsight top` or `sudo agentsight record -- claude` |
 
 ---
 

--- a/services/agent-harnesses-and-control-planes/README.md
+++ b/services/agent-harnesses-and-control-planes/README.md
@@ -37,6 +37,7 @@ Operator surfaces are an explicit narrow exception to the catalog's usual machin
 | [Codex HUD (anhannin)](codex-hud-anhannin.md) [![⭐](https://img.shields.io/github/stars/anhannin/codex-hud?style=social)](https://github.com/anhannin/codex-hud) | Patched Codex status line for usage and session state | Model/project/git · 5-hour and 7-day usage windows | `status_line_command` · rollout JSONL reader |
 | [Claude HUD](claude-hud.md) [![⭐](https://img.shields.io/github/stars/jarrodwatts/claude-hud?style=social)](https://github.com/jarrodwatts/claude-hud) | A Claude Code plugin that shows what's happening | Context/usage · tools · subagents · todos | Claude Code plugin · statusline stdin/stdout |
 | [LoopX](loopx.md) [![⭐](https://img.shields.io/github/stars/huangruiteng/loopx?style=social)](https://github.com/huangruiteng/loopx) | The open, provider-neutral, stateful control plane for long-horizon agents | Objectives · gates · evidence · quota · claims/leases | CLI · workflow skills · host adapters |
+| [DeepSeek Harness (dsh)](deepseek-harness.md) [![⭐](https://img.shields.io/github/stars/deepseek-ai/deepseek-harness?style=social)](https://github.com/deepseek-ai/deepseek-harness) | Everything is a Plugin. | Cordis plugins · session log · Trajectory · PTC/Code Mode | CLI · Web UI · ACP · JSON-RPC SDK |
 
 ## Criteria Reminder
 

--- a/services/agent-harnesses-and-control-planes/deepseek-harness.md
+++ b/services/agent-harnesses-and-control-planes/deepseek-harness.md
@@ -1,0 +1,175 @@
+# DeepSeek Harness (dsh)
+
+> **"Everything is a Plugin."**
+
+| | |
+|---|---|
+| **Website** | https://deepseek.com/harness |
+| **Docs** | https://deepseek.com/harness |
+| **GitHub** | https://github.com/deepseek-ai/deepseek-harness |
+| **Stars** | [![GitHub Stars](https://img.shields.io/github/stars/deepseek-ai/deepseek-harness?style=social)](https://github.com/deepseek-ai/deepseek-harness) |
+| **Classification** | `agent-native` |
+| **Category** | [Agent Harnesses & Operator Surfaces](README.md) |
+| **License** | MIT |
+| **Latest-month signal** | Last GitHub push 2026-08-21 ([repo metadata](https://api.github.com/repos/deepseek-ai/deepseek-harness)); developer-preview release with public Web UI entry (`npx @deepseek-ai/dsh web`) |
+| **Verified at** | 2026-08-25 |
+
+---
+
+## Official Website
+
+https://deepseek.com/harness
+
+---
+
+## Official Repo
+
+https://github.com/deepseek-ai/deepseek-harness
+
+---
+
+## How to Use (Agent Onboarding)
+
+**Interaction pattern:** `CLI` + Web UI (developer preview)
+
+```bash
+npx @deepseek-ai/dsh web
+```
+
+The official homepage and README both give that command as the fastest start. After Node.js is installed, it starts the Web UI at `http://127.0.0.1:3080` by default and opens a browser on a local launch. Pass `--no-open` to keep the server headless. From a checkout:
+
+```bash
+git clone https://github.com/deepseek-ai/deepseek-harness.git
+cd deepseek-harness
+pnpm install
+pnpm run build
+pnpm dsh web
+```
+
+The repository also documents an ACP automation server and a headless profile (`pnpm dsh --profile headless "task"`). There is no URL-onboarding document.
+
+---
+
+## Agent Skills
+
+**Status:** ⚠️ No official `npx skills add` package published yet.
+
+The harness treats Skills as a first-class plugin (`packages/skill/` — skill provider registry, local impl, catalog/loader tool). Community plugins use the [`dsh-plugin`](https://github.com/topics/dsh-plugin) GitHub topic.
+
+```bash
+npx clawhub@latest search deepseek-harness dsh
+```
+
+See: https://agentskills.io/specification to contribute one.
+
+---
+
+## MCP
+
+**Status:** ⚠️ Not published as a standalone MCP server.
+
+The primary machine surfaces are the `dsh` CLI, Web UI, JSON-RPC SDK, and an automation-only Agent Client Protocol (ACP) server. MCP clients can still sit beside dsh as ordinary tools; dsh itself is the harness, not an MCP product.
+
+| Detail | Value |
+|---|---|
+| **Primary interface** | `npx @deepseek-ai/dsh web` / `pnpm dsh` |
+| **Other machine surfaces** | ACP server, JSON-RPC SDK, session event log |
+| **Compatible clients** | Local Web UI, ACP hosts, any agent that can run the CLI |
+
+---
+
+## What It Does
+
+DeepSeek Harness (`dsh`) is DeepSeek AI's open-source agent harness. Official positioning is that a model is the agent's soul and the harness is what lets the agent understand its environment, use tools, and keep working in real scenes. Every agent capability — model, tools, skills, session, sandbox, storage, loop, scheduling, UI — is a Cordis plugin. Developers compose or replace those plugins in configuration without forking the harness.
+
+The product is a **developer preview**. The README warns there will be compatibility-breaking changes. The homepage lists four run modes: Standard (full coding agent), PTC (standard tools plus a Code Mode TypeScript program that batches tool calls), Minimal (persistent bash + `str_replace_editor` for model benchmarks), and Create (inspect the runtime, experiment with plugins, author new presets).
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | GitHub description: **"DeepSeek Harness: Everything is a Plugin."** — [repo](https://github.com/deepseek-ai/deepseek-harness). Homepage: **"Harness 让 Agent 在真实场景中持续工作"** / **"Agent = Model + Harness"** — [deepseek.com/harness](https://deepseek.com/harness) |
+| **Agent-specific primitive** | Cordis plugin seams for model, tools, skills, session, sandbox, storage, loop, scheduling, and UI; append-only session logs that record system prompts, chain-of-thought, tool calls, sub-agent dispatch, and context injection; Trajectory view for resume, fork, retrieve, and replay |
+| **Autonomy-compatible control plane** | Once a profile starts, the agent loop runs tools, skills, plans, goals, sub-agents, and workflows without per-action human confirmation. PTC mode lets the model compose multi-step tool work in one generated program |
+| **M2M integration surface** | `npx @deepseek-ai/dsh web`, source CLI, ACP server, JSON-RPC SDK, Python SDK, session event stream |
+| **Identity / delegation** | Sessions are the attributable unit. Official copy: everything the model sees is written to an append-only session log, and resume/fork/retrieve/replay share that event stream. The repo also has identity, credentials, and permission/ask-user plugins. dsh does not mint a separate payment or KYA identity |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **Cordis plugin** | Every agent capability is a loadable plugin; the kernel only loads, unloads, and resolves dependencies |
+| **Preset / profile** | Configuration-layer composition of plugins (Standard, PTC, Minimal, Create, or a custom preset) |
+| **Session event log** | Append-only record of model-visible inputs, tool results, sub-agent dispatch, and context injection |
+| **Trajectory view** | Operator/agent surface for inspecting, resuming, forking, and replaying the same event stream |
+| **PTC / Code Mode** | Model writes a TypeScript program that batches multiple tool calls |
+| **Skill / sub-agent / workflow plugins** | First-class plugin packages for skills, delegated sub-agents, and worker-thread workflows |
+| **ACP server** | Automation-only Agent Client Protocol surface for hosts that speak ACP |
+
+---
+
+## Autonomy Model
+
+```
+Operator or coding agent starts dsh (npx @deepseek-ai/dsh web or a headless profile)
+    -> Cordis loads the selected preset's plugins (model, tools, skills, sandbox, loop, UI)
+    -> Agent loop plans and calls tools / skills / sub-agents without per-step human clicks
+    -> Every model-visible event is appended to the session log
+    -> Trajectory view can resume, fork, retrieve, or replay from that log
+    -> Optional ask-user / approval plugins pause only when the preset enables them
+```
+
+Human setup is install + profile selection. The loop itself is autonomous inside a started session.
+
+---
+
+## Identity and Delegation Model
+
+- **Session identity:** Each run writes an append-only session log. Official docs treat that log as the shared source for resume, fork, retrieve, and replay.
+- **Plugin-scoped credentials:** Credential and authorization plugins sit beside env/`.env` providers. Secrets stay in operator-controlled config, not a minted per-agent wallet.
+- **Delegation:** Sub-agent plugins dispatch child agents; the parent session remains the audit root.
+- **No product-wide approval gate:** Interaction/approval plugins exist, but they are optional composition, not a required HITL product.
+- **Preview boundary:** Developer preview. Compatibility-breaking changes are expected; backends reject old on-disk formats.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| CLI / npm | `npx @deepseek-ai/dsh web`; source `pnpm dsh` |
+| Web UI | Local operator UI, default `http://127.0.0.1:3080` |
+| ACP | Automation-only Agent Client Protocol server |
+| JSON-RPC SDK | TypeScript client in `packages/sdk/` |
+| Python SDK | Bundled runtime under `python/` |
+| Session log | Append-only events; Trajectory resume/fork/replay |
+| Plugin topic | [`dsh-plugin`](https://github.com/topics/dsh-plugin) for community plugins |
+
+---
+
+## Human-in-the-Loop Support
+
+The Web UI and Trajectory view are operator surfaces: watch a run, inspect what the model saw, resume or fork a session. Optional interaction plugins can ask the user or require permission. After a profile starts, the agent does not wait for per-action confirmation unless those plugins are composed in.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **A raw model API** | Supplies tokens only. It has no plugin harness, session log, or trajectory replay |
+| **A generic chatbot UI** | Humans chat; it does not treat tools, skills, sandbox, loop, and scheduling as replaceable agent plugins |
+| **Agent Executor (AX)** | AX is a distributed harness *runtime* (isolated environments + event log). dsh is DeepSeek's plugin-composed coding harness and local control plane, not a K8s compute control plane |
+
+---
+
+## Use Cases
+
+- **Plugin-composed coding agents** — run Standard or PTC mode against a repo with file, shell, search, skills, and sub-agents
+- **Model benchmarking** — Minimal mode keeps only bash + `str_replace_editor`
+- **Custom harness research** — Create mode inspects the runtime and authors new presets without forking core
+- **Session replay** — recover, fork, or audit a run from the append-only event stream

--- a/services/agent-runtime-and-infrastructure/README.md
+++ b/services/agent-runtime-and-infrastructure/README.md
@@ -48,6 +48,7 @@ The services in this category were purpose-built to fill this gap.
 | [Polos](polos.md) [![⭐](https://img.shields.io/github/stars/polos-dev/polos?style=social)](https://github.com/polos-dev/polos) | Open-source runtime for AI agents — sandbox + durable workflow + HITL | Python/TS SDK · HTTP/webhook/cron/event triggers · Slack HITL · Docker/E2B sandbox | ⚠️ |
 | [Cloudflare Computer](cloudflare-computer.md) [![⭐](https://img.shields.io/github/stars/cloudflare/computer?style=social)](https://github.com/cloudflare/computer) | Give your agent a computer | `@cloudflare/computer` workspace FS + runtime.exec, preview only | ⚠️ |
 | [Agent Executor (AX)](google-ax.md) [![⭐](https://img.shields.io/github/stars/google/ax?style=social)](https://github.com/google/ax) | An open source distributed agent runtime | `ax` CLI, gRPC serve, conversation resume, event log | ⚠️ |
+| [Agent Substrate](agent-substrate.md) [![⭐](https://img.shields.io/github/stars/agent-substrate/substrate?style=social)](https://github.com/agent-substrate/substrate) | High-density Kubernetes runtime for large-scale agent deployments | `kubectl-ate`, ate-api-server gRPC, actors/WorkerPools, atenet | ⚠️ |
 
 
 

--- a/services/agent-runtime-and-infrastructure/agent-substrate.md
+++ b/services/agent-runtime-and-infrastructure/agent-substrate.md
@@ -1,0 +1,167 @@
+# Agent Substrate
+
+> **"A performant, high density runtime environment for large scale agent deployments."**
+
+| | |
+|---|---|
+| **Website** | https://github.com/agent-substrate/substrate |
+| **Docs** | https://github.com/agent-substrate/substrate#readme |
+| **GitHub** | https://github.com/agent-substrate/substrate |
+| **Stars** | [![GitHub Stars](https://img.shields.io/github/stars/agent-substrate/substrate?style=social)](https://github.com/agent-substrate/substrate) |
+| **Classification** | `agent-native` |
+| **Category** | [Agent Runtime & Infrastructure Services](README.md) |
+| **License** | Apache-2.0 |
+| **Latest-month signal** | Last GitHub push 2026-08-25 ([repo metadata](https://api.github.com/repos/agent-substrate/substrate)); early development, APIs expected to change |
+| **Verified at** | 2026-08-25 |
+
+---
+
+## Official Website
+
+No separate marketing site is listed on the repository (`homepage` is empty). The canonical entry is the GitHub README:
+
+https://github.com/agent-substrate/substrate
+
+---
+
+## Official Repo
+
+https://github.com/agent-substrate/substrate
+
+---
+
+## How to Use (Agent Onboarding)
+
+**Interaction pattern:** `CLI` + Kubernetes control plane
+
+```bash
+# Local kind path from the official README (development only)
+hack/create-kind-cluster.sh
+hack/install-ate-kind.sh --deploy-ate-system
+hack/install-ate-kind.sh --deploy-demo-counter
+go install ./cmd/kubectl-ate
+
+kubectl ate create atespace demo
+kubectl ate create actor my-counter-1 -a demo --template=ate-demo-counter/counter
+kubectl port-forward -n ate-system svc/atenet-router 8000:80
+```
+
+Then HTTP to the actor via the router `Host` header (see README). GKE bootstrap uses `go run ./tools/setup-gcp bootstrap` and `./hack/install-ate.sh --deploy-ate-system`.
+
+**This is not [Agent Executor (AX)](google-ax.md).** AX (`google/ax`) is a distributed *harness runtime*. Substrate is the Kubernetes *compute control plane* AX documents as a production-oriented deploy path. Do not collapse the two names.
+
+---
+
+## Agent Skills
+
+**Status:** ⚠️ No official Agent Skills package published.
+
+```bash
+npx clawhub@latest search agent-substrate
+```
+
+See: https://agentskills.io/specification to contribute one.
+
+---
+
+## MCP
+
+**Status:** ⚠️ Not a published MCP server.
+
+README compatibility notes say MCP *servers* can run as Substrate Actors (sandboxed durable tools). Substrate itself is `kubectl-ate` + ate-api-server, not an MCP product.
+
+---
+
+## What It Does
+
+Agent Substrate maps a large set of idle-heavy **actors** (agent-like applications) onto a smaller pool of ready **workers**. The control plane handles create/destroy, suspend/resume (official claim: sub-second), assignment of actors to workers, and inbound routing. Sandbox backends include microVMs and gVisor. Kubernetes owns pod provisioning and autoscaling; Substrate adds agent-specific scheduling so many stateful actors share few physical pods.
+
+Official README status (quote): **"NOTE: This is not an officially supported Google product. This project is not eligible for the Google Open Source Software Vulnerability Rewards Program."** Further: **"Agent Substrate is currently in early development. It is not ready for production use, and the APIs are almost guaranteed to change. We are not making any guarantees about backward compatibility at this stage."**
+
+It is framework-agnostic: OCI containers via gVisor, not an agent SDK. AX is listed as an ecosystem harness that can run on Substrate.
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | README: **"Agent Substrate delivers a performant, high density runtime environment for large scale agent deployments"** and **"The workloads it manages don't have to be literal AI agents, but those are the best example of the kind of applications it is designed for. It is not an SDK for building agents, but rather a system for running them at scale."** — [repo](https://github.com/agent-substrate/substrate) |
+| **Agent-specific primitive** | Actors, atespaces, ActorTemplates, WorkerPools; suspend/resume with RAM + filesystem snapshots; oversubscription of idle agents onto shared workers |
+| **Autonomy-compatible control plane** | After an atespace and template exist, `kubectl ate create actor` and the router send traffic without a human sitting in the pod. Request parking holds requests until a worker frees |
+| **M2M integration surface** | `kubectl-ate` CLI, ate-api-server gRPC, Kubernetes CRDs, HTTP via atenet router |
+| **Identity / delegation** | Actor DNS/Host routing (`*.actors.resources.substrate.ate.dev` in the demo). Authentication guide documents trusted JWT providers. Early-dev: do not treat this as a supported Google identity product |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **Actor** | Stateful application instance that can hibernate and teleport onto a worker |
+| **Atespace** | Namespace-like scope; required before creating actors |
+| **ActorTemplate** | Image/config used to materialize actors |
+| **WorkerPool / Worker** | Physical pod capacity actors multiplex onto |
+| **ate-api-server** | gRPC control plane for actor/worker lifecycle |
+| **atenet** | DNS + Envoy routing + proxy sidecars |
+| **atelet / ateom** | Node supervisor and in-pod checkpoint/restore (gVisor or microVM) |
+
+---
+
+## Autonomy Model
+
+```
+Operator provisions a cluster and installs ATE system components
+    -> Create an atespace and actor from a template
+    -> Router parks or forwards HTTP to the assigned worker
+    -> Idle actors suspend; inbound work resumes them onto any free worker
+    -> Snapshots keep RAM and filesystem across hibernation
+```
+
+The agent workload inside the actor runs its own loop. Substrate's job is density and lifecycle, not prompting.
+
+---
+
+## Identity and Delegation Model
+
+- **Actor identity:** Named actor + atespace, routed by Host/DNS.
+- **Human vs workload creds:** Docs include an authentication guide (JWT providers and human credentials). That is cluster/control-plane auth, not a consumer KYA wallet.
+- **Support status:** Not an officially supported Google product; not in Google's OSS VRP. Early development; APIs will change.
+- **AX relationship:** Substrate ≠ AX. AX is the harness; Substrate is the K8s multiplexed compute plane.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| CLI | `kubectl ate` (`go install ./cmd/kubectl-ate`) |
+| gRPC | `cmd/ateapi` lifecycle API |
+| Kubernetes | WorkerPool, ActorTemplate, and related CRs |
+| HTTP | atenet router (demo port-forward to `:8000`) |
+| Docs | Architecture, API guide, CLI README, threat model in-repo |
+
+---
+
+## Human-in-the-Loop Support
+
+Cluster bootstrap and template install are operator work. Actor traffic after create is machine-routed. Community meeting / Slack are human process, not a runtime approval gate.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **google/ax (Agent Executor)** | Harness runtime: conversations, event log, isolated harnesses. Not the K8s actor/worker multiplex control plane |
+| **A plain Kubernetes Deployment** | Replicated stateless pods. No actor teleport, RAM snapshot hibernation, or idle-agent oversubscription API |
+| **E2B / hosted sandboxes** | Per-session microVMs as a product API. Substrate is in-cluster density infrastructure for many long-lived actors |
+
+---
+
+## Use Cases
+
+- **High-density coding agents** — multiplex Claude Code / Codex-style environments onto a small worker pool (see repo demos)
+- **Stateful HTTP actors** — counter demo: increment state survives suspend/resume
+- **Sandboxed shell actors** — Alpine sandbox demo with filesystem persistence
+- **AX on Kubernetes** — production-oriented path documented by Agent Executor, implemented here

--- a/services/agent-runtime-and-infrastructure/google-ax.md
+++ b/services/agent-runtime-and-infrastructure/google-ax.md
@@ -51,7 +51,7 @@ ax serve --config ax.yaml
 ax --input "Hello agents!" --server localhost:8494
 ```
 
-Kubernetes on [Agent Substrate](https://github.com/agent-substrate/substrate) is the documented production-oriented deploy path (`manifests/README.md`). This catalog does **not** add Agent Substrate itself (open issue #101).
+Kubernetes on [Agent Substrate](agent-substrate.md) (`https://github.com/agent-substrate/substrate`) is the documented production-oriented deploy path (`manifests/README.md`). AX is the harness runtime; Substrate is the separate K8s compute control plane.
 
 ---
 

--- a/services/browser-and-web-execution/README.md
+++ b/services/browser-and-web-execution/README.md
@@ -39,6 +39,7 @@ The web was designed for humans sitting in front of browsers. AI agents that nee
 | [CamoFox Browser](camofox.md) [![⭐](https://img.shields.io/github/stars/jo-inc/camofox-browser?style=social)](https://github.com/jo-inc/camofox-browser) | Stealth headless browser for AI agents | CLI/server automation, browser profiles, screenshots/extraction | ⚠️ |
 | [Moli](moli.md) [![⭐](https://img.shields.io/github/stars/lexmount/moli?style=social)](https://github.com/lexmount/moli) | Structured-first browser engine for AI agents | Rust CLI, stdio MCP, CDP, WebDriver Classic/BiDi, semantic-tree output | ✅ |
 | [Kernel](kernel.md) [![⭐](https://img.shields.io/github/stars/kernel/kernel-images?style=social)](https://github.com/kernel/kernel-images) | you build agents. we give them the internet. | CLI, Playwright/CDP/computer-use, kernel-cli skill, hosted unikernel browsers | ⚠️ |
+| [Stealth Browser MCP](stealth-browser-mcp.md) [![⭐](https://img.shields.io/github/stars/vibheksoni/stealth-browser-mcp?style=social)](https://github.com/vibheksoni/stealth-browser-mcp) | Stealth browser automation for MCP-compatible AI agents | stdio/HTTP MCP, nodriver + CDP, dynamic hooks, in-repo skill | ✅ |
 
 
 

--- a/services/browser-and-web-execution/stealth-browser-mcp.md
+++ b/services/browser-and-web-execution/stealth-browser-mcp.md
@@ -1,0 +1,171 @@
+# Stealth Browser MCP
+
+> **"Stealth browser automation for MCP-compatible AI agents."**
+
+| | |
+|---|---|
+| **Website** | https://github.com/vibheksoni/stealth-browser-mcp |
+| **Docs** | https://github.com/vibheksoni/stealth-browser-mcp#readme |
+| **GitHub** | https://github.com/vibheksoni/stealth-browser-mcp |
+| **Stars** | [![GitHub Stars](https://img.shields.io/github/stars/vibheksoni/stealth-browser-mcp?style=social)](https://github.com/vibheksoni/stealth-browser-mcp) |
+| **Classification** | `agent-native` |
+| **Category** | [Browser & Web Execution Services](README.md) |
+| **License** | MIT |
+| **Latest-month signal** | Last GitHub push 2026-07-24 ([repo metadata](https://api.github.com/repos/vibheksoni/stealth-browser-mcp)). Quieter than neighboring browser rows — verify `master` before depending on a weekly release cadence |
+| **Verified at** | 2026-08-25 |
+
+---
+
+## Official Website
+
+No separate marketing site is listed. The GitHub README is the official entry:
+
+https://github.com/vibheksoni/stealth-browser-mcp
+
+---
+
+## Official Repo
+
+https://github.com/vibheksoni/stealth-browser-mcp
+
+---
+
+## How to Use (Agent Onboarding)
+
+**Interaction pattern:** `MCP`
+
+```bash
+git clone https://github.com/vibheksoni/stealth-browser-mcp.git
+cd stealth-browser-mcp
+python -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+Claude Code (macOS/Linux) from the official README:
+
+```bash
+claude mcp add-json stealth-browser-mcp '{
+  "type": "stdio",
+  "command": "/path/to/stealth-browser-mcp/venv/bin/python",
+  "args": ["/path/to/stealth-browser-mcp/src/server.py"]
+}'
+```
+
+Requires Python 3.10+ and Chrome, Chromium, or Microsoft Edge. Optional HTTP transport: `python src/server.py --transport http --host 127.0.0.1 --port 8000` with `STEALTH_BROWSER_MCP_AUTH_TOKEN` set. There is no URL-onboarding document.
+
+---
+
+## Agent Skills
+
+**Status:** ✅ Available in-repo (not `npx skills add`).
+
+The repository ships `skills/stealth-browser-mcp` for Codex-style skill clients. It covers tool order, state checks, pre-document CDP scripts, network debugging, and cleanup. Symlink that folder into the client skills directory if the host does not auto-load repo-local skills.
+
+---
+
+## MCP
+
+**Status:** ✅ Available — this project **is** the MCP server.
+
+| Detail | Value |
+|---|---|
+| **MCP Repo** | https://github.com/vibheksoni/stealth-browser-mcp |
+| **Transport** | stdio (recommended) or HTTP with optional bearer token |
+| **Compatible Clients** | Claude Code, Claude Desktop, Cursor, FastMCP installers |
+| **Tool surface** | Full 97 tools / minimal 20 / per-section disable flags |
+
+---
+
+## What It Does
+
+Stealth Browser MCP is a **local MCP browser** built on [nodriver](https://github.com/ultrafunkamsterdam/nodriver), Chrome DevTools Protocol, and FastMCP. Official copy: navigate Cloudflare challenges, anti-bot checks, and login walls with real Chrome-family browsers. It is not a generic Puppeteer wrapper and not a hosted cloud browser.
+
+Features the README actually claims: anti-bot resistance that has passed Cloudflare and Queue-It style checks in testing (results vary); 97 tools in 11 sections; pixel-accurate element cloning via CDP; network inspection; a restricted Python **dynamic hook** system to intercept, block, redirect, fulfill, or modify request/response flows; CDP/JavaScript execution for trusted local clients.
+
+**Distinctness vs catalog browsers:** [Browser MCP](browser-mcp.md) is a Puppeteer accessibility-tree server. [Playwright MCP](playwright-mcp.md) is Microsoft's Playwright tool surface (the README's own comparison table). [Browserbase](browserbase.md) / [Browser Use Cloud](browser-use-cloud.md) are hosted remote browsers. This project is a local stealth/anti-detect MCP with nodriver + CDP hooks.
+
+**Freshness:** last push 2026-07-24 at verification.
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | README: **"Stealth browser automation for MCP-compatible AI agents."** — [repo](https://github.com/vibheksoni/stealth-browser-mcp). GitHub description: AI-driven network hooks and pixel-perfect UI cloning via chat |
+| **Agent-specific primitive** | MCP tools for stealth sessions, CDP cloning, dynamic network hooks, instance state (`get_instance_state`) — not a human Selenium IDE |
+| **Autonomy-compatible control plane** | After the MCP server is running, the agent calls `spawn_browser`, `navigate`, hooks, and extractors without a human driving Chrome |
+| **M2M integration surface** | stdio/HTTP MCP, FastMCP, in-repo skill |
+| **Identity / delegation** | Trust model: the **MCP client/agent is the security principal**. Recommended deployment is local stdio. HTTP must use `STEALTH_BROWSER_MCP_AUTH_TOKEN` and must not be exposed unauthenticated. File uploads are limited to allowlisted dirs |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **`spawn_browser` / instance** | Stealth Chrome-family session with idle timeout and state inspection |
+| **CDP execution** | JavaScript, raw CDP, pre-document scripts |
+| **Element cloning** | Pixel-accurate CSS/DOM/events/assets extraction |
+| **Dynamic hooks** | Restricted Python interceptors on the request/response path |
+| **Network toolbox** | Headers, payloads, captured bodies for the agent |
+| **Modular sections** | Enable 20–97 tools; `--xpool-safe` disables `Runtime.enable` CDP tools |
+
+---
+
+## Autonomy Model
+
+```
+Operator installs Chrome + the stdio MCP server
+    -> Agent spawn_browser / navigate / interact via MCP tools
+    -> Optional hooks mutate or fulfill traffic in-process
+    -> Agent clones elements or reads captured network bodies
+    -> close_instance or idle reaper tears the browser down
+```
+
+No per-click human confirmation after the client is attached.
+
+---
+
+## Identity and Delegation Model
+
+- **Principal:** The connected MCP client. Treat it as full browser control (cookies, JS, hooks, local file upload from allowlisted paths).
+- **No cloud agent identity:** Local OS user + optional HTTP bearer token.
+- **Not authorization for third-party sites:** Stealth features may pass bot checks; they do not grant legal access to systems the operator may not use.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| MCP stdio | `venv/bin/python src/server.py` |
+| MCP HTTP | `--transport http` + `STEALTH_BROWSER_MCP_AUTH_TOKEN` |
+| Agent skill | `skills/stealth-browser-mcp` |
+| CLI flags | `--minimal`, `--disable-*`, `--list-sections`, `--debug` |
+
+---
+
+## Human-in-the-Loop Support
+
+None required for tool calls. Humans install the browser and decide which MCP client may attach. The README's NodeMaven block is a paid sponsor placement, not part of the protocol.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **Browser MCP / Playwright MCP** | Generic automation MCP. Official comparison: they lack nodriver stealth, CDP cloning, and the dynamic hook system |
+| **Browserbase / Browser Use Cloud** | Hosted remote browsers. This is a local anti-detect MCP, not a session cloud |
+| **Raw Puppeteer** | Library for developers, not an MCP tool surface with instance lifecycle and agent-oriented network hooks |
+
+---
+
+## Use Cases
+
+- **Bot-gated sites** — agent-driven Chrome where Playwright MCP is commonly blocked (upstream's point-in-time claim)
+- **UI cloning** — extract a component's CSS/DOM through chat
+- **API reverse engineering** — inspect captured request/response bodies via MCP tools
+- **Local trusted automation** — stdio-only deployment so the browser never leaves the operator machine

--- a/services/code-execution/README.md
+++ b/services/code-execution/README.md
@@ -30,6 +30,7 @@ Agent-native code execution services solve this with:
 | [AIO Sandbox](agent-infra-sandbox.md) [![⭐](https://img.shields.io/github/stars/agent-infra/sandbox?style=social)](https://github.com/agent-infra/sandbox) | All-in-one Docker sandbox — browser, shell, VS Code, Jupyter, MCP | Docker image, OpenAPI, Python/JS/Go SDKs, MCP HTTP | ✅ |
 | [Agent Sandbox](agent-sandbox.md) | The trusted runtime for untrusted code | REST API, Python SDK, URL onboarding (`skill.md`) | ⚠️ |
 | [Riza](riza.md) | AI writes code. Riza runs it. | REST API, Python/TypeScript/Go SDKs, MCP server, self-hosting | ✅ |
+| [Agent Sandbox (Kubernetes SIG)](kubernetes-agent-sandbox.md) [![⭐](https://img.shields.io/github/stars/kubernetes-sigs/agent-sandbox?style=social)](https://github.com/kubernetes-sigs/agent-sandbox) | Secure isolated execution layer for autonomous agents on Kubernetes | Sandbox CRD, WarmPool/Claim, Python/Go SDKs, RuntimeClass | ⚠️ |
 
 
 ---

--- a/services/code-execution/kubernetes-agent-sandbox.md
+++ b/services/code-execution/kubernetes-agent-sandbox.md
@@ -1,0 +1,184 @@
+# Agent Sandbox (Kubernetes SIG)
+
+> **"Agent Sandbox provides a secure and isolated execution layer to safely deploy autonomous AI agents on Kubernetes that generate and run untrusted code at scale."**
+
+| | |
+|---|---|
+| **Website** | https://agent-sandbox.sigs.k8s.io |
+| **Docs** | https://agent-sandbox.sigs.k8s.io/docs/ |
+| **GitHub** | https://github.com/kubernetes-sigs/agent-sandbox |
+| **Stars** | [![GitHub Stars](https://img.shields.io/github/stars/kubernetes-sigs/agent-sandbox?style=social)](https://github.com/kubernetes-sigs/agent-sandbox) |
+| **Classification** | `agent-native` |
+| **Category** | [Code Execution Services](README.md) |
+| **License** | Apache-2.0 |
+| **Latest-month signal** | Last GitHub push 2026-08-25 ([repo metadata](https://api.github.com/repos/kubernetes-sigs/agent-sandbox)); Python package `k8s-agent-sandbox`; SIG Apps CRD |
+| **Verified at** | 2026-08-25 |
+
+---
+
+## Official Website
+
+https://agent-sandbox.sigs.k8s.io
+
+---
+
+## Official Repo
+
+https://github.com/kubernetes-sigs/agent-sandbox
+
+---
+
+## How to Use (Agent Onboarding)
+
+**Interaction pattern:** `SDK` + Kubernetes CRDs
+
+This is **not** the hosted [Agent Sandbox](agent-sandbox.md) product at agentsandbox.co. It is also not [OpenSandbox](opensandbox.md), which can integrate this CRD as a backend.
+
+```bash
+pip install k8s-agent-sandbox
+```
+
+Official Python SDK ([client README](https://github.com/kubernetes-sigs/agent-sandbox/blob/main/clients/python/agentic-sandbox-client/README.md)):
+
+```python
+from k8s_agent_sandbox import SandboxClient
+
+client = SandboxClient()
+sandbox = client.create_sandbox(
+    warmpool="example-sandbox-pool",
+    namespace="default",
+)
+try:
+    result = sandbox.commands.run("echo 'Hello from Agent Sandbox!'")
+    print(result.stdout)
+finally:
+    sandbox.terminate()
+```
+
+Install the controller first (version tag from [releases](https://github.com/kubernetes-sigs/agent-sandbox/releases)):
+
+```bash
+export VERSION="vX.Y.Z"
+kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/download/${VERSION}/sandbox-with-extensions.yaml
+```
+
+The official quickstart lists **kubectl 1.28+** as a prerequisite ([quickstart](https://agent-sandbox.sigs.k8s.io/docs/use-cases/examples/quickstart/)). Strong isolation is optional and uses a Kubernetes `RuntimeClass` such as gVisor or Kata Containers; the project is a *sandbox orchestrator* and delegates isolation to those runtimes.
+
+---
+
+## Agent Skills
+
+**Status:** ⚠️ No official Agent Skills package published.
+
+```bash
+npx clawhub@latest search kubernetes-agent-sandbox
+```
+
+See: https://agentskills.io/specification to contribute one.
+
+---
+
+## MCP
+
+**Status:** ⚠️ Not published as a dedicated official MCP server.
+
+| Detail | Value |
+|---|---|
+| **Primary interface** | Kubernetes CRDs (`Sandbox`, `SandboxClaim`, `SandboxWarmPool`, `SandboxTemplate`) + Python/Go SDKs |
+| **Compatible clients** | Any agent that can call `k8s-agent-sandbox` or the Go client against a configured cluster |
+
+---
+
+## What It Does
+
+Kubernetes SIG Agent Sandbox (SIG Apps) is a declarative API for isolated, stateful, singleton workloads — the kind of long-running, identity-stable container AI agent runtimes and RL evaluators need. The core `Sandbox` CRD gives a stable hostname, persistent storage, and lifecycle (create, scheduled delete, pause, resume). Extensions add reusable templates, warm pools, and claim-based allocation.
+
+Official scope: it orchestrates sandboxes; it does **not** implement gVisor or Kata itself. Pods select those isolation backends through `RuntimeClass`. Homepage use cases include short-lived code execution, coding agents, computer-use desktops, CI, and always-on OpenClaw environments.
+
+**Distinctness:** this entry is the in-cluster CRD/controller. The catalog already lists hosted [Agent Sandbox](agent-sandbox.md) (`agentsandbox.co`) — a different product with URL onboarding. [OpenSandbox](opensandbox.md) is a separate sandbox runtime that can sit on Kubernetes and may consume this CRD; it is not this SIG project.
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | Homepage: **"Agent Sandbox provides a secure and isolated execution layer to safely deploy autonomous AI agents on Kubernetes that generate and run untrusted code at scale."** — [agent-sandbox.sigs.k8s.io](https://agent-sandbox.sigs.k8s.io). README: ideal for **"AI agent runtimes and reinforcement learning"** |
+| **Agent-specific primitive** | `Sandbox` / `SandboxClaim` / `SandboxWarmPool` CRDs; SDK `create_sandbox` + `commands.run`; warm-pool claims for low-latency agent start |
+| **Autonomy-compatible control plane** | After the controller and a warm pool exist, an agent creates a sandbox, runs commands, and terminates without a human `kubectl` per action |
+| **M2M integration surface** | Python `k8s-agent-sandbox`, Go `sigs.k8s.io/agent-sandbox/clients/go/sandbox`, Kubernetes API |
+| **Identity / delegation** | Each Sandbox has a stable hostname and network identity. `create_sandbox` can stamp claim labels and pod labels/annotations (for example a tenant `client-id` via the Downward API). RBAC on the cluster is the authorization plane |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **Sandbox CRD** | Single stateful pod with stable identity, storage, pause/resume, scheduled deletion |
+| **SandboxTemplate** | Reusable sandbox spec |
+| **SandboxWarmPool** | Pre-warmed sandboxes for fast claims |
+| **SandboxClaim** | Allocates a sandbox from a warm pool and hides template detail |
+| **RuntimeClass isolation** | Optional gVisor or Kata (or other) backend selected on the Pod spec |
+| **SandboxClient** | Python/Go clients: `create_sandbox`, `commands.run`, `terminate` |
+| **Sandbox router** | Reverse proxy / gateway path so clients do not port-forward each pod (required with some isolated runtimes) |
+
+---
+
+## Autonomy Model
+
+```
+Operator installs the controller and (optionally) a RuntimeClass + SandboxWarmPool
+    -> Agent authenticates to the cluster and constructs SandboxClient
+    -> client.create_sandbox(...) watches the claim until Ready
+    -> Agent runs commands inside the isolated pod
+    -> Agent terminates the sandbox (or the controller enforces scheduled deletion)
+```
+
+Warm pools make the claim path fast; custom env or volume templates force a cold start per official SDK notes.
+
+---
+
+## Identity and Delegation Model
+
+- **Sandbox identity:** Stable hostname and network identity per Sandbox object (`agents.x-k8s.io`).
+- **Claim vs pod metadata:** Labels on the `SandboxClaim`; optional `pod_labels` / `pod_annotations` on the running pod for in-sandbox tenant checks.
+- **Cluster RBAC:** The agent's kubeconfig or in-cluster service account is the delegated credential. This project does not mint a hosted API key.
+- **Isolation ≠ this controller:** Strong isolation is the RuntimeClass (gVisor/Kata). The SIG project orchestrates Pods that use those classes.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| Kubernetes API | `Sandbox`, `SandboxTemplate`, `SandboxClaim`, `SandboxWarmPool` |
+| Python SDK | `pip install k8s-agent-sandbox` — [PyPI](https://pypi.org/project/k8s-agent-sandbox/) |
+| Go SDK | `go get sigs.k8s.io/agent-sandbox/clients/go/sandbox@latest` |
+| Docs | https://agent-sandbox.sigs.k8s.io/docs/ |
+
+---
+
+## Human-in-the-Loop Support
+
+Cluster install, RuntimeClass, and warm-pool templates are operator work. Runtime command execution is SDK/API-driven. `kubectl` remains available for debug; it is not required per agent command.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **Hosted Agent Sandbox (agentsandbox.co)** | Different product: hosted sessions + `skill.md` URL onboarding. Not the Kubernetes SIG CRD |
+| **OpenSandbox** | Separate sandbox runtime. It may *integrate* this CRD; it is not the SIG controller |
+| **A Deployment or StatefulSet** | Generic workload APIs. They lack Sandbox claims, warm pools, and agent-oriented pause/resume |
+| **Local Docker only** | No cluster-wide Sandbox identity, warm-pool claims, or RuntimeClass orchestration API |
+
+---
+
+## Use Cases
+
+- **Untrusted code interpreters** — run generated code in isolated Kubernetes sandboxes
+- **Coding agents** — medium-lived sandboxes with persistent storage and a stable hostname
+- **RL / eval harnesses** — high-throughput warm-pool claims for isolated scoring environments
+- **Computer-use / OpenClaw** — GUI or always-on agent environments behind a Sandbox + RuntimeClass

--- a/services/commerce-and-payments/README.md
+++ b/services/commerce-and-payments/README.md
@@ -27,6 +27,8 @@ No legacy payment processor was designed with these requirements. The services i
 | [Nevermined](nevermined.md) | The payment layer AI agents actually need | HTTP x402 Protocol, REST API | ❌ |
 | [Coinbase CDP (x402)](coinbase-x402.md) [![⭐](https://img.shields.io/github/stars/coinbase/x402?style=social)](https://github.com/coinbase/x402) | HTTP-native x402 payments — facilitator, SDKs, Bazaar discovery | HTTP x402, TypeScript/Python/Go SDKs, CDP REST | ❌ |
 | [SecondSign Core](secondsign-core.md) [![⭐](https://img.shields.io/github/stars/Bestpart-Irene/secondsign-core?style=social)](https://github.com/Bestpart-Irene/secondsign-core) | Independent transaction co-signer for financial AI agents | Python API, mTLS gateway/approver channels, execute-once rail, hash-chained receipts | ⚠️ |
+| [UCP](ucp.md) [![⭐](https://img.shields.io/github/stars/Universal-Commerce-Protocol/ucp?style=social)](https://github.com/Universal-Commerce-Protocol/ucp) | The common language for platforms, agents, and businesses | REST/JSON-RPC, MCP, A2A, `ucp-schema`, checkout capabilities | ⚠️ |
+| [AP2](ap2.md) [![⭐](https://img.shields.io/github/stars/google-agentic-commerce/AP2?style=social)](https://github.com/google-agentic-commerce/AP2) | An open protocol for the emerging Agent Economy | VDC mandates, Python/Go/Android samples, A2A/UCP extension | ⚠️ |
 
 
 ---

--- a/services/commerce-and-payments/ap2.md
+++ b/services/commerce-and-payments/ap2.md
@@ -1,0 +1,167 @@
+# Agent Payments Protocol (AP2)
+
+> **"An open protocol for the emerging Agent Economy."**
+
+| | |
+|---|---|
+| **Website** | https://ap2-protocol.org |
+| **Docs** | https://ap2-protocol.org |
+| **GitHub** | https://github.com/google-agentic-commerce/AP2 |
+| **Stars** | [![GitHub Stars](https://img.shields.io/github/stars/google-agentic-commerce/AP2?style=social)](https://github.com/google-agentic-commerce/AP2) |
+| **Classification** | `agent-native` |
+| **Category** | [Commerce & Payment Services](README.md) |
+| **License** | Apache-2.0 |
+| **Latest-month signal** | Last *code* push 2026-06-17 ([repo metadata](https://api.github.com/repos/google-agentic-commerce/AP2)); docs/site still served. Quieter than neighboring commerce repos — disclose before treating samples as weekly-fresh |
+| **Verified at** | 2026-08-25 |
+
+---
+
+## Official Website
+
+https://ap2-protocol.org
+
+---
+
+## Official Repo
+
+https://github.com/google-agentic-commerce/AP2
+
+---
+
+## How to Use (Agent Onboarding)
+
+**Interaction pattern:** `SDK` + scenario samples
+
+```bash
+# Types package (PyPI later; official install is from git)
+uv pip install git+https://github.com/google-agentic-commerce/AP2.git@main
+```
+
+Run a documented scenario from the repo root (needs Python 3.11+, `uv`, and a Gemini/Vertex credential for the *samples*, not for the protocol itself):
+
+```bash
+cd AP2
+bash code/samples/python/scenarios/a2a/human-present/cards/run.sh
+```
+
+Other scenarios live under `code/samples/python/scenarios/`, `code/samples/go/scenarios/`, and `code/samples/android/scenarios/`. Spec and flows: [docs/](https://github.com/google-agentic-commerce/AP2/tree/main/docs). There is no URL-onboarding document.
+
+---
+
+## Agent Skills
+
+**Status:** ⚠️ No official Agent Skills package published.
+
+```bash
+npx clawhub@latest search ap2 agent-payments-protocol
+```
+
+See: https://agentskills.io/specification to contribute one.
+
+---
+
+## MCP
+
+**Status:** ⚠️ Extension surface, not a hosted MCP server.
+
+Official homepage: AP2 is an open extension for **A2A** and **UCP**, with MCP mentioned as a tool layer agents may already use ("Build agents with ADK (or any framework), equip with MCP (or any tool), collaborate via A2A, and use AP2 to secure payments"). AP2 itself is the mandate/credential protocol.
+
+---
+
+## What It Does
+
+Agent Payments Protocol (AP2) is an open protocol for **verifiable agent payments**. Today's rails assume a human clicked Buy. When an agent pays, merchants cannot answer authorization, authenticity, or accountability from that click model. AP2's answer is **verifiable digital credentials (VDCs)** — tamper-evident, cryptographically signed mandates:
+
+- **Checkout Mandate** — open (constraints before a cart exists) or closed (authorization of a finalized checkout), shared with the merchant.
+- **Payment Mandate** — open (budget / allowed instruments) or closed (amount bound to a finalized checkout), shared with the credential provider, networks, and merchant processor.
+
+Mandates chain into a non-repudiable audit trail for human-present and human-not-present transactions. Samples include human-not-present cards, human-not-present **x402**, digital payment credentials on Android, and human-present cards.
+
+This is the **mandate layer next to catalog x402**: x402 is HTTP 402 settlement; AP2 is proof of user intent the merchant and networks can verify. UCP documents AP2 as its secure-payment path.
+
+**Freshness:** `pushed_at` on the GitHub repo was 2026-06-17 at verification. Treat the spec and samples as the source of truth; do not infer weekly release cadence.
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | Homepage: **"Agent Payments Protocol (AP2) is an open protocol for the emerging Agent Economy"** and **"use AP2 to secure payments with gen AI agents"** — [ap2-protocol.org](https://ap2-protocol.org). GitHub: **"Building a Secure and Interoperable Future for AI-Driven Payments."** |
+| **Agent-specific primitive** | Open/closed Checkout and Payment **mandates** (VDCs). Trust is **"verifiable intent, not inferred action"** |
+| **Autonomy-compatible control plane** | Human-not-present samples show an agent completing a purchase inside mandate constraints without a per-SKU human click |
+| **M2M integration surface** | Python/Go/Android samples, Pydantic models + JSON schemas under `code/sdk/python/ap2/`, A2A/UCP extension |
+| **Identity / delegation** | Role-based architecture; mandates are signed credentials. Accountability is a first-class design goal (who is liable if the agent hallucinates a purchase) |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **Checkout Mandate (open/closed)** | Constraints or finalized-cart authorization shared with the merchant |
+| **Payment Mandate (open/closed)** | Instrument/budget constraints or bound payment authorization |
+| **VDC chain** | Linked, signed credentials forming the audit trail |
+| **Human-present / human-not-present flows** | Protocol modes, not product SKUs |
+| **x402 sample path** | Same mandate model over an x402 payment rail |
+
+---
+
+## Autonomy Model
+
+```
+User (or prior session) issues an open checkout/payment mandate with constraints
+    -> Shopping agent negotiates a cart with a merchant (A2A / UCP / sample servers)
+    -> Closed checkout mandate binds the finalized cart
+    -> Closed payment mandate authorizes the instrument/amount
+    -> Credential provider / PSP / merchant processor verify the chain
+    -> Human-not-present path completes without another click if mandates allow it
+```
+
+---
+
+## Identity and Delegation Model
+
+- **User remains in control:** Official principle. Mandates are the delegation artifact.
+- **Roles:** User, shopping agent, merchant, credential provider, networks, merchant payment processor — each sees the mandate types meant for them.
+- **Non-repudiation:** Cryptographic audit trail for disputes.
+- **Not a wallet product:** AP2 does not replace Skyfire/Circle wallets; it standardizes proof those rails can attach.
+- **Standardization path:** Homepage says spec work continues in FIDO Agentic Authentication and Payments working groups.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| Spec / docs | https://ap2-protocol.org and repo `docs/` |
+| Python types | `uv pip install git+https://github.com/google-agentic-commerce/AP2.git@main` |
+| Samples | `code/samples/python`, `go`, `android` + `run.sh` |
+| Web demo client | `code/web-client/` (Vite + React) |
+| Extensions | A2A, UCP; x402 sample |
+
+---
+
+## Human-in-the-Loop Support
+
+Human-present flows capture closed mandates at checkout time. Human-not-present flows use earlier open mandates (budget, allowed items). AP2 exists *because* inferred "the user would have clicked" is not enough. Optional UX in samples does not replace the credential chain.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **x402** | Pays an HTTP resource. It does not define checkout/payment mandates or merchant-verifiable user intent |
+| **UCP** | Commerce/checkout protocol. It *uses* AP2 for payments; it is not the mandate layer |
+| **Skyfire / Circle** | Hosted agent wallets and KYA. AP2 is an open credential protocol any compliant agent/merchant can speak |
+| **A card-on-file API** | Assumes a human merchant session. It cannot answer agent authorization / hallucination / liability |
+
+---
+
+## Use Cases
+
+- **Human-not-present shopping** — agent buys inside an open mandate's constraints
+- **Merchant verification** — prove the cart matches signed user intent
+- **x402 + mandates** — attach AP2 proof to an HTTP 402 settlement
+- **Dispute evidence** — replay the VDC chain instead of model logs alone

--- a/services/commerce-and-payments/ucp.md
+++ b/services/commerce-and-payments/ucp.md
@@ -1,0 +1,172 @@
+# Universal Commerce Protocol (UCP)
+
+> **"The common language for platforms, agents, and businesses."**
+
+| | |
+|---|---|
+| **Website** | https://ucp.dev |
+| **Docs** | https://ucp.dev |
+| **GitHub** | https://github.com/Universal-Commerce-Protocol/ucp |
+| **Stars** | [![GitHub Stars](https://img.shields.io/github/stars/Universal-Commerce-Protocol/ucp?style=social)](https://github.com/Universal-Commerce-Protocol/ucp) |
+| **Classification** | `agent-native` |
+| **Category** | [Commerce & Payment Services](README.md) |
+| **License** | Apache-2.0 |
+| **Latest-month signal** | Last GitHub push 2026-08-25 ([repo metadata](https://api.github.com/repos/Universal-Commerce-Protocol/ucp)); spec + docs repo |
+| **Verified at** | 2026-08-25 |
+
+---
+
+## Official Website
+
+https://ucp.dev
+
+---
+
+## Official Repo
+
+https://github.com/Universal-Commerce-Protocol/ucp
+
+---
+
+## How to Use (Agent Onboarding)
+
+**Interaction pattern:** `SDK` + protocol spec
+
+UCP is an **open checkout/commerce protocol**, not a wallet. Start from the public spec and samples:
+
+```bash
+# Schema tool agents use to resolve ucp_* annotations at runtime
+cargo install ucp-schema
+
+# Spec + docs checkout
+git clone https://github.com/Universal-Commerce-Protocol/ucp.git
+```
+
+Official next steps from the README:
+
+- Documentation and full spec: [ucp.dev](https://ucp.dev)
+- [Samples](https://github.com/Universal-Commerce-Protocol/samples)
+- [SDKs](https://github.com/orgs/Universal-Commerce-Protocol/repositories)
+- [Conformance tests](https://github.com/Universal-Commerce-Protocol/conformance)
+
+There is no URL-onboarding document and no hosted merchant wallet.
+
+---
+
+## Agent Skills
+
+**Status:** ⚠️ No official Agent Skills package published.
+
+```bash
+npx clawhub@latest search ucp universal-commerce-protocol
+```
+
+See: https://agentskills.io/specification to contribute one.
+
+---
+
+## MCP
+
+**Status:** ✅ Documented as a first-class transport — UCP is transport-agnostic.
+
+| Detail | Value |
+|---|---|
+| **Role** | Businesses can expose Capabilities via REST, MCP, or A2A |
+| **MCP product** | Not a single hosted MCP server; implementers publish their own capability endpoints |
+| **Related payments** | Built-in support for Agent Payments Protocol (AP2) on the payment path |
+
+---
+
+## What It Does
+
+The Universal Commerce Protocol is an open standard for **agentic commerce**: discovery, cart, identity linking, checkout, and order lifecycle across shopping (and, the homepage says, expanding into lodging and food). Official homepage copy: UCP provides building blocks so platforms, agents, and businesses share one standard instead of custom builds.
+
+Capabilities are modular (Checkout, Identity Linking, Order, Payment Token Exchange) with extensions (discounts, fulfillment). Businesses publish a profile of supported capabilities so platforms can discover them autonomously. Checkout sessions can run with or without a human present. Payments use existing rails plus AP2 mandates and verifiable credentials rather than inventing a new wallet.
+
+This is distinct from catalog x402, Skyfire, and Circle: those are payment/wallet or HTTP-402 settlement layers. UCP is the **checkout and commerce protocol** those rails can plug into.
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | Homepage: **"The common language for platforms, agents, and businesses."** — [ucp.dev](https://ucp.dev). README: **"Designed from the ground up to support AI agents acting on behalf of users to discover products, fill carts, and complete purchases securely."** — [repo](https://github.com/Universal-Commerce-Protocol/ucp) |
+| **Agent-specific primitive** | Capability profiles for autonomous discovery; checkout sessions with or without human intervention; OAuth identity linking (`dev.ucp.shopping.checkout` scope in the homepage sample); AP2 payment mandates |
+| **Autonomy-compatible control plane** | Agents can discover capabilities, build carts, and complete checkout when the merchant profile and mandates allow human-not-present flow |
+| **M2M integration surface** | REST and JSON-RPC transports; MCP and A2A support built-in; `ucp-schema` for operation-specific schemas; SDKs and conformance suite |
+| **Identity / delegation** | OAuth 2.0 identity linking so agents act without sharing user credentials; AP2 mandates and verifiable credentials for payment consent. Businesses stay Merchant of Record |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **Capability profile** | Business declares Checkout, Identity Linking, Order, and extensions for autonomous discovery |
+| **Checkout session** | Cart, tax, fulfillment, and `ready_for_complete` state across merchants |
+| **Identity Linking** | OAuth 2.0 authorization for an agent to act on a buyer's behalf |
+| **Order + webhooks** | Post-purchase status, shipment, returns |
+| **Payment token exchange** | PSP / credential-provider handshake; AP2-compatible |
+| **`ucp-schema`** | Resolves `ucp_*` annotations so agents see create/update/read field subsets |
+
+---
+
+## Autonomy Model
+
+```
+Agent discovers a business profile (supported Capabilities)
+    -> Optional OAuth identity link (scope such as dev.ucp.shopping.checkout)
+    -> Create/update checkout session (cart, fulfillment, totals)
+    -> Payment via AP2 mandate / token exchange when the profile requires it
+    -> Complete checkout; follow order webhooks
+```
+
+Human presence is a protocol option (embedded checkout UI, address delegation), not a requirement of every capability.
+
+---
+
+## Identity and Delegation Model
+
+- **Buyer vs agent:** Identity Linking uses OAuth so the agent does not hold the user's password.
+- **Merchant of Record:** Official homepage: businesses retain control and customer relationships.
+- **Payment consent:** AP2 mandates and verifiable credentials — cryptographic proof of user intent, not inferred clicks.
+- **Not a wallet:** UCP does not issue agent USDC wallets. It standardizes checkout and hands payment to AP2 / PSPs / credential providers.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| Spec / docs | https://ucp.dev and this repository's `source/` schemas |
+| REST / JSON-RPC | Documented transports |
+| MCP / A2A | Built-in support for agent frameworks |
+| Schema CLI | `cargo install ucp-schema` |
+| Samples / SDKs / conformance | Sister repos under [Universal-Commerce-Protocol](https://github.com/Universal-Commerce-Protocol) |
+
+---
+
+## Human-in-the-Loop Support
+
+Identity linking and some embedded checkout UIs need a human once (OAuth, address, or hosted checkout). Autonomous checkout is an explicit protocol goal when mandates and profiles allow it. Lodging and food specs are described on the homepage as coming soon — do not treat those industry payloads as shipped.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **x402 / Coinbase CDP** | HTTP 402 settlement for API calls. Not a cart/checkout/order protocol |
+| **Skyfire / Circle Agent Stack** | Agent wallets and KYA/payment execution. Not an open multi-merchant checkout language |
+| **AP2** | Mandate / verifiable-credential *payment* layer. UCP consumes AP2; it does not replace it |
+| **A generic Stripe Checkout** | Human-first hosted pay page. No capability profile, agent discovery, or transport-agnostic A2A/MCP surface |
+
+---
+
+## Use Cases
+
+- **Agent shopping** — discover a merchant profile, build a cart, complete checkout
+- **Platform embedding** — native or embedded business checkout without a per-merchant integration
+- **Post-purchase agents** — consume order webhooks for shipping and returns
+- **Schema-accurate tool calls** — `ucp-schema` so agents only send fields valid for the current operation

--- a/services/memory-and-state/README.md
+++ b/services/memory-and-state/README.md
@@ -41,6 +41,8 @@ Agent-native memory services solve this by providing:
 | [Hindsight](hindsight.md) [![⭐](https://img.shields.io/github/stars/vectorize-io/hindsight?style=social)](https://github.com/vectorize-io/hindsight) | Agent Memory That Learns | Python SDK, open-source memory service, cookbook examples | ⚠️ |
 | [agentmemory](agentmemory.md) [![⭐](https://img.shields.io/github/stars/rohitg00/agentmemory?style=social)](https://github.com/rohitg00/agentmemory) | Your coding agent remembers everything. No more re-explaining. | Local memory server, MCP, Skills, INSTALL_FOR_AGENTS.md | ✅ |
 | [TencentDB Agent Memory](tencentdb-agent-memory.md) [![⭐](https://img.shields.io/github/stars/TencentCloud/TencentDB-Agent-Memory?style=social)](https://github.com/TencentCloud/TencentDB-Agent-Memory) | Agents remember,Humans innovate. | OpenClaw plugin, Hermes Gateway, layered + symbolic memory | ⚠️ |
+| [MemPalace](mempalace.md) [![⭐](https://img.shields.io/github/stars/MemPalace/mempalace?style=social)](https://github.com/MemPalace/mempalace) | The best-benchmarked open-source AI memory system. And it's free. | CLI, stdio MCP, Python API, verbatim palace + graph | ✅ |
+| [MemSearch](memsearch.md) [![⭐](https://img.shields.io/github/stars/zilliztech/memsearch?style=social)](https://github.com/zilliztech/memsearch) | Cross-platform semantic memory for AI coding agents | CLI, Python API, Claude/Codex/DSH/OpenClaw/OpenCode plugins | ⚠️ |
 
 
 

--- a/services/memory-and-state/mempalace.md
+++ b/services/memory-and-state/mempalace.md
@@ -1,0 +1,190 @@
+# MemPalace
+
+> **"The best-benchmarked open-source AI memory system. And it's free."**
+
+| | |
+|---|---|
+| **Website** | https://mempalaceofficial.com |
+| **Docs** | https://mempalaceofficial.com/guide/getting-started.html |
+| **GitHub** | https://github.com/MemPalace/mempalace |
+| **Stars** | [![GitHub Stars](https://img.shields.io/github/stars/MemPalace/mempalace?style=social)](https://github.com/MemPalace/mempalace) |
+| **Classification** | `agent-native` |
+| **Category** | [Memory & State Services](README.md) |
+| **License** | MIT |
+| **Latest-month signal** | Last GitHub push 2026-08-25 ([repo metadata](https://api.github.com/repos/MemPalace/mempalace)); default branch `develop`; PyPI package `mempalace` |
+| **Verified at** | 2026-08-25 |
+
+---
+
+## Official Website
+
+https://mempalaceofficial.com
+
+The repository README is explicit: the only official sources are this [GitHub repository](https://github.com/MemPalace/mempalace), the [PyPI package](https://pypi.org/project/mempalace/), and docs at [mempalaceofficial.com](https://mempalaceofficial.com). Other domains are called impostors. A live fetch of the homepage can sit behind Cloudflare bot-check; use the GitHub README and the docs URLs the README publishes.
+
+---
+
+## Official Repo
+
+https://github.com/MemPalace/mempalace
+
+---
+
+## How to Use (Agent Onboarding)
+
+**Interaction pattern:** `CLI` + MCP
+
+```bash
+uv tool install mempalace
+mempalace init ~/projects/myapp
+mempalace mine ~/projects/myapp
+mempalace search "why did we switch to GraphQL"
+mempalace wake-up
+```
+
+`pipx install mempalace` is the documented alternative. Plain `pip install mempalace` is only for an activated virtualenv where you want `import mempalace`. Docker:
+
+```bash
+docker pull ghcr.io/mempalace/mempalace:latest
+```
+
+There is no URL-onboarding document.
+
+---
+
+## Agent Skills
+
+**Status:** ⚠️ No official `npx skills add` package published yet.
+
+MemPalace ships auto-save hooks for Claude Code, Codex CLI, and Cursor, plus an MCP tool surface agents call directly. That is hook/MCP integration, not a published Agent Skills package.
+
+```bash
+npx clawhub@latest search mempalace
+```
+
+See: https://agentskills.io/specification to contribute one.
+
+---
+
+## MCP
+
+**Status:** ✅ Available
+
+| Detail | Value |
+|---|---|
+| **MCP Repo** | https://github.com/MemPalace/mempalace |
+| **Transport** | stdio (CLI or `docker run -i … ghcr.io/mempalace/mempalace`) |
+| **Compatible Clients** | Claude Code, Codex, Cursor, and other stdio MCP clients |
+| **Tool count (upstream)** | README: 44 MCP tools covering palace reads/writes, knowledge-graph ops, cross-wing navigation, drawers, agent diaries, and coordination |
+
+Example Claude Code stdio config from the official README:
+
+```json
+{
+  "mcpServers": {
+    "mempalace": {
+      "command": "docker",
+      "args": [
+        "run", "-i", "--rm",
+        "-v", "mempalace-data:/data",
+        "-v", "/absolute/path/to/.claude/projects:/transcripts:ro",
+        "ghcr.io/mempalace/mempalace"
+      ]
+    }
+  }
+}
+```
+
+---
+
+## What It Does
+
+MemPalace is a local-first memory system for AI agents. It stores conversation history as **verbatim text** and retrieves it with semantic search. Official copy: it does not summarize, extract, or paraphrase. The index is a palace metaphor — people and projects are *wings*, topics are *rooms*, original content lives in *drawers* — so searches can be scoped instead of run against a flat corpus.
+
+The retrieval backend is pluggable (ChromaDB default; SQLite exact, Milvus, Qdrant, and pgvector are documented). Nothing leaves the machine unless the operator opts in. A temporal entity-relationship graph with validity windows sits on local SQLite. Each specialist agent can get its own wing and diary, discoverable at runtime via `mempalace_list_agents`.
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | GitHub description: **"The best-benchmarked open-source AI memory system. And it's free."** — [repo](https://github.com/MemPalace/mempalace). README: **"Local-first AI memory. Verbatim storage, pluggable backend"** and first-class Claude Code / Gemini CLI / MCP / local-model guides |
+| **Agent-specific primitive** | Verbatim drawers + wing/room scoping; `mine` / `search` / `wake-up`; per-agent wings and diaries; 44 MCP tools including agent coordination (logstream events + artifact handoffs) |
+| **Autonomy-compatible control plane** | After `mempalace init`, agents mine, search, and wake context without a human clicking through a dashboard. Auto-save hooks persist sessions before compaction |
+| **M2M integration surface** | `mempalace` CLI, Python API, stdio MCP, Docker image |
+| **Identity / delegation** | Specialist agents get their own wing and diary; `mempalace_list_agents` discovers them at runtime. Memory stays local unless the operator opts into a remote embedder |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **Wing / room / drawer** | Scoped palace layout: projects/people, topics, and verbatim source content |
+| **`mine`** | Ingest project files or conversation transcripts into the palace |
+| **`search` / `wake-up`** | Semantic retrieval and session-start context load |
+| **Pluggable backend** | Chroma default; SQLite exact, Milvus, Qdrant, pgvector via `--backend` / env / `config.json` |
+| **Knowledge graph** | Temporal entity-relationship graph with validity windows on local SQLite |
+| **Agent wing + diary** | Per-specialist-agent memory, listed at runtime |
+| **Auto-save hooks** | Claude Code, Codex, and Cursor hooks that persist before context compression |
+
+---
+
+## Autonomy Model
+
+```
+Operator installs CLI (`uv tool install mempalace`) and inits a palace
+    -> Agent or hook mines transcripts / project files into wings and drawers
+    -> Later sessions call search or wake-up (or MCP tools) without re-explaining history
+    -> Optional sweep stores one verbatim drawer per user/assistant message
+    -> Knowledge-graph add/query/invalidate stays in the same local control plane
+```
+
+No per-query human confirmation. The operator chooses the machine, backend, and whether embeddings stay local.
+
+---
+
+## Identity and Delegation Model
+
+- **Per-agent wings:** Each specialist agent gets its own wing and diary; `mempalace_list_agents` lists them without stuffing every agent into the system prompt.
+- **Local default:** Core path needs no API key. Remote OpenAI-compatible embedders are opt-in and require `mempalace repair rebuild-index`.
+- **Attribution:** Drawers are verbatim source text, not paraphrases, so retrieved memory points back at original content.
+- **No minted cloud identity:** Delegation is filesystem + MCP client access to the palace, not a hosted agent credential.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| CLI | `uv tool install mempalace` then `init`, `mine`, `search`, `wake-up` |
+| Python API | `pip install mempalace` inside a venv |
+| MCP stdio | Local CLI or `docker run -i ghcr.io/mempalace/mempalace` |
+| Docker | `ghcr.io/mempalace/mempalace:latest`; data under `/data` |
+| Docs | [Getting started](https://mempalaceofficial.com/guide/getting-started.html), [MCP tools](https://mempalaceofficial.com/reference/mcp-tools.html) |
+
+---
+
+## Human-in-the-Loop Support
+
+None required for mine/search/wake-up. Humans can read the markdown-adjacent palace on disk and review docs. Hooks exist so coding agents persist memory before compaction without asking the user each turn.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **Mem0 / Zep** | Those layers extract or graph *facts*. MemPalace's official contract is verbatim storage — it does not summarize, extract, or paraphrase |
+| **MemSearch** | MemSearch is a cross-platform *search-over-memory* index (Markdown + Milvus hybrid recall) for coding-agent sessions. MemPalace is a local palace (wings/rooms/drawers) with pluggable backends and a temporal graph |
+| **A raw vector database** | Stores embeddings only. It has no palace scoping, agent diaries, wake-up, or MCP coordination tools |
+
+---
+
+## Use Cases
+
+- **Claude Code / Codex retention** — mine JSONL transcripts and hook auto-save before compaction
+- **Project archaeology** — search why a stack decision was made without stuffing the whole repo into context
+- **Multi-agent coordination** — give each specialist its own wing and hand off artifacts through MCP tools
+- **Air-gapped memory** — keep verbatim history and embeddings on one machine

--- a/services/memory-and-state/memsearch.md
+++ b/services/memory-and-state/memsearch.md
@@ -1,0 +1,184 @@
+# MemSearch
+
+> **"Cross-platform semantic memory for AI coding agents."**
+
+| | |
+|---|---|
+| **Website** | https://zilliztech.github.io/memsearch/ |
+| **Docs** | https://zilliztech.github.io/memsearch/ |
+| **GitHub** | https://github.com/zilliztech/memsearch |
+| **Stars** | [![GitHub Stars](https://img.shields.io/github/stars/zilliztech/memsearch?style=social)](https://github.com/zilliztech/memsearch) |
+| **Classification** | `agent-native` |
+| **Category** | [Memory & State Services](README.md) |
+| **License** | MIT |
+| **Latest-month signal** | Last GitHub push 2026-08-23 ([repo metadata](https://api.github.com/repos/zilliztech/memsearch)); DeepSeek Harness plugin documented |
+| **Verified at** | 2026-08-25 |
+
+---
+
+## Official Website
+
+https://zilliztech.github.io/memsearch/
+
+---
+
+## Official Repo
+
+https://github.com/zilliztech/memsearch
+
+---
+
+## How to Use (Agent Onboarding)
+
+**Interaction pattern:** `CLI` + platform plugins
+
+```bash
+# CLI / library (ONNX embeddings, no API key)
+uv tool install "memsearch[onnx]"
+
+memsearch index ./memory/
+memsearch search "how to configure Redis?" --top-k 5
+```
+
+Python API from official docs:
+
+```python
+from memsearch import MemSearch
+
+mem = MemSearch(paths=["./memory"])
+await mem.index()
+results = await mem.search("Redis config", top_k=3)
+```
+
+Coding-agent plugins (official docs):
+
+```bash
+# Claude Code
+# /plugin marketplace add zilliztech/memsearch
+# /plugin install memsearch
+
+# DeepSeek Harness
+dsh plugin --profile web add @zilliz/memsearch-dsh
+```
+
+There is no URL-onboarding document.
+
+---
+
+## Agent Skills
+
+**Status:** ✅ Available as platform skills / `SKILL.md` recall (not `npx skills add`).
+
+| Skill | What It Teaches the Agent |
+|---|---|
+| Claude Code `memory-recall` | Fork-context subagent recall over indexed sessions (`SKILL.md` with `context: fork`) |
+| Codex memory-recall skill | Terminal skill for the same Markdown memory store |
+| DSH `memory-recall` | Native DeepSeek Harness skill + pre-step injection |
+
+Claude Code plugin install is the marketplace flow above. Codex uses `plugins/codex/scripts/install.sh`.
+
+---
+
+## MCP
+
+**Status:** ⚠️ Not the primary published interface.
+
+OpenClaw exposes `memory_search`, `memory_get`, and `memory_transcript` as plugin tools. The core product is Markdown files + Milvus hybrid search + per-platform plugins, not a standalone MCP server package.
+
+---
+
+## What It Does
+
+MemSearch is Zilliz's **search-over-memory** layer for coding agents. Official GitHub description: **"A persistent, unified memory layer for all your AI agents (e.g. Claude Code, Codex, DSH), backed by Markdown and Milvus."** Docs: install a plugin and the agent remembers prior work across sessions — conversations are captured, indexed with hybrid search, and recalled when needed.
+
+Markdown under `.memsearch/memory/` is the source of truth. Milvus is a derived, rebuildable index (dense + BM25 + RRF). Recall is progressive: search summaries, expand a section, then drill into the original transcript. The same collection-naming algorithm lets Claude Code, Codex, DeepSeek Harness, OpenClaw, and OpenCode share one project memory.
+
+Official positioning is **retrieval over agent memory**, not a general fact-extraction memory OS. That is the distinction versus Mem0, Zep, and Memoria.
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | Docs H1: **"Cross-platform semantic memory for AI coding agents."** — [docs](https://zilliztech.github.io/memsearch/). README: memories flow across Claude Code, Codex, DSH, OpenClaw, and OpenCode |
+| **Agent-specific primitive** | Auto-capture of agent turns; hybrid search over session memory; three-layer progressive disclosure (search → expand → transcript); shared project collections across harnesses |
+| **Autonomy-compatible control plane** | After plugin install, capture and recall run in hooks / turn events without the user running save commands |
+| **M2M integration surface** | CLI, Python API, Claude/Codex/DSH/OpenClaw/OpenCode plugins, optional OpenClaw memory tools |
+| **Identity / delegation** | Collection names derive from the project directory. OpenClaw documents per-workspace isolation. This is workspace/project memory, not a hosted per-agent KYA token |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **Markdown memory files** | Source of truth under `.memsearch/memory/` |
+| **Hybrid search** | Dense vector + BM25 sparse + RRF over Milvus |
+| **Progressive disclosure** | `search` → `expand <chunk_hash>` → original transcript |
+| **Smart dedup** | SHA-256 hashing skips re-embed of unchanged content |
+| **Live sync** | `memsearch watch` indexes on file change |
+| **Cross-platform plugins** | Same memory, different harness capture/recall paths |
+| **Skills from memory** | Documented distillation of repeated workflows into installable skills |
+
+---
+
+## Autonomy Model
+
+```
+Plugin captures a finished turn (hook / DSH event / SQLite daemon)
+    -> Writer updates Markdown memory
+    -> Indexer embeds into Milvus (local Lite, server, or Zilliz Cloud)
+    -> Next session: skill or tool searches; optional pre-step injection (DSH)
+    -> Agent expands a hit only when it needs the full section
+```
+
+Users do not run a manual save step on the documented plugin path.
+
+---
+
+## Identity and Delegation Model
+
+- **Project-scoped memory:** Collection names come from the project directory so two agents on the same repo share context.
+- **Workspace isolation (OpenClaw):** Point an agent's workspace at a project directory; tools stay inside that workspace.
+- **No cloud agent account required** for the ONNX + Milvus Lite path.
+- **Observation of history, not authorization:** Recall does not grant extra repo or production permissions.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| CLI | `memsearch index`, `search`, `expand`, `watch` |
+| Python API | `MemSearch(paths=...).index()` / `.search()` |
+| Claude Code plugin | Marketplace `zilliztech/memsearch` |
+| DSH plugin | `dsh plugin --profile web add @zilliz/memsearch-dsh` |
+| OpenClaw | `openclaw plugins install --force clawhub:memsearch` |
+| Storage | Markdown + Milvus Lite / Server / Zilliz Cloud |
+
+---
+
+## Human-in-the-Loop Support
+
+None required for capture/recall. Markdown files are human-readable and git-friendly. DSH's web profile adds a read-only memory browser. Compaction / "memory compact" is an optional LLM maintenance task.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **Mem0** | Extracts and updates *facts* for interactive agents. MemSearch indexes *session transcripts* for coding-agent recall |
+| **Zep** | Temporal knowledge graph / business memory. Not a Markdown+Milvus coding-agent memory bus |
+| **Memoria** | Git-versioned memory service. Different primitive (snapshots/branches) and not the documented cross-harness plugin matrix |
+| **MemPalace** | Verbatim palace (wings/rooms/drawers) plus a local graph. MemSearch is hybrid *search-over-memory* shared across Claude/Codex/DSH/OpenClaw/OpenCode |
+
+---
+
+## Use Cases
+
+- **Resume a debugging thread** — retrieve how a similar Redis/Docker/deploy issue was fixed
+- **Recover decision rationale** — why the repo chose a library or API shape
+- **Cross-harness continuity** — Claude Code today, DSH tomorrow, same `.memsearch/` store
+- **Agent-developer embedding** — call `MemSearch.search` from a custom harness

--- a/services/observability-and-tracing/README.md
+++ b/services/observability-and-tracing/README.md
@@ -34,6 +34,7 @@ Agent-native observability services capture **agent trajectory** — the semanti
 | [Galileo](galileo.md) | Agent reliability platform — observability, evals, and IDE MCP loop | Tracing + evals + Signals, MCP HTTP endpoint, Python/TS SDKs | ✅ |
 | [Laminar](laminar.md) [![⭐](https://img.shields.io/github/stars/lmnr-ai/lmnr?style=social)](https://github.com/lmnr-ai/lmnr) | Open-source observability for long-running agents — agent debugger, browser session replay, Signals | OTLP, Python/TS SDK, SQL API, Evals SDK, self-host | ⚠️ |
 | [OpenLIT](openlit.md) [![⭐](https://img.shields.io/github/stars/openlit/openlit?style=social)](https://github.com/openlit/openlit) | OpenTelemetry-native observability for LLMs and AI agents | Agent traces, tool-call spans, cost/token analytics | ✅ |
+| [AgentSight](agentsight.md) [![⭐](https://img.shields.io/github/stars/eunomia-bpf/agentsight?style=social)](https://github.com/eunomia-bpf/agentsight) | Lightweight system-level observability for AI Agents | CLI wrapper, eBPF record, session DBs, OTLP GenAI | ⚠️ |
 
 
 

--- a/services/observability-and-tracing/agentsight.md
+++ b/services/observability-and-tracing/agentsight.md
@@ -1,0 +1,165 @@
+# AgentSight
+
+> **"lightweight system-level observability for AI Agents"**
+
+| | |
+|---|---|
+| **Website** | https://eunomia.dev/agentsight/ |
+| **Docs** | https://eunomia.dev/agentsight/ |
+| **GitHub** | https://github.com/eunomia-bpf/agentsight |
+| **Stars** | [![GitHub Stars](https://img.shields.io/github/stars/eunomia-bpf/agentsight?style=social)](https://github.com/eunomia-bpf/agentsight) |
+| **Classification** | `agent-native` |
+| **Category** | [Observability & Tracing Services](README.md) |
+| **License** | MIT |
+| **Latest-month signal** | Last GitHub push 2026-08-25 ([repo metadata](https://api.github.com/repos/eunomia-bpf/agentsight)); docs updated 2026-08-24 |
+| **Verified at** | 2026-08-25 |
+
+---
+
+## Official Website
+
+https://eunomia.dev/agentsight/
+
+---
+
+## Official Repo
+
+https://github.com/eunomia-bpf/agentsight
+
+---
+
+## How to Use (Agent Onboarding)
+
+**Interaction pattern:** `CLI` wrapper (operator-surface track)
+
+```bash
+cargo install agentsight
+# or: brew tap eunomia-bpf/tap && brew install eunomia-bpf/tap/agentsight
+
+agentsight top
+sudo agentsight record -- claude
+```
+
+`agentsight top` ranks live sessions. `record -- <command>` wraps any command (official examples: `claude`, `gemini`, `kimi`, `grok`, or a raw binary). Replay local Claude/Codex/Gemini sessions with `agentsight vis`. There is no URL-onboarding document.
+
+This entry is admitted on the **operator-surface track**: wrap a command, observe, report. **Observation is not authorization.** AgentSight does not grant, deny, or enforce tool permissions.
+
+---
+
+## Agent Skills
+
+**Status:** ⚠️ No official Agent Skills package published.
+
+```bash
+npx clawhub@latest search agentsight
+```
+
+See: https://agentskills.io/specification to contribute one.
+
+---
+
+## MCP
+
+**Status:** ⚠️ Not an MCP server.
+
+AgentSight can observe MCP stdio traffic from the outside (see upstream `docs/agents.md`). It does not expose itself as MCP tools.
+
+---
+
+## What It Does
+
+AgentSight is a local-first `top`/`strace`-like observer for AI agents. Docs title: **"System-wide AI agent profiling and monitoring with eBPF"**. GitHub description: **"lightweight system-level observability for AI Agents"**. It correlates prompts, model calls, and tool decisions with **real host effects** — processes, files, network, TLS payloads at SSL call boundaries — without an SDK, proxy, or vendor hook inside the agent.
+
+`record` writes `agentsight-*.db` session files. `report` queries them (prompts JSON, token grouping, audit JSON). Optional OTLP/HTTP export emits OpenTelemetry **GenAI** (`gen_ai.*`) spans. `top` / `vis` / `report` can also read native Claude/Codex/Gemini session files without eBPF; `record` and live eBPF need Linux + privileges.
+
+**Complement, don't replace:** [Langfuse](langfuse.md) and [Laminar](laminar.md) are application/trace products (you instrument or proxy the app). [numbat](numbat.md) is endpoint/hook visibility with optional pre-action blocking. AgentSight is **system-level eBPF + session files + OTLP GenAI**, including closed-source CLIs that never called an SDK.
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | GitHub: **"lightweight system-level observability for AI Agents"** — [repo](https://github.com/eunomia-bpf/agentsight). Docs: **"System-wide AI agent profiling and monitoring with eBPF"** and **"local-first top/strace-like observability tool for AI agents"** — [eunomia.dev/agentsight](https://eunomia.dev/agentsight/) |
+| **Agent-specific primitive** | Session-ranked `top` (model, tokens, tool/file/network activity); wrap-any-command `record`; SQLite session files; GenAI OTLP export; agentpprof token flamegraphs from local Codex/Claude history |
+| **Autonomy-compatible control plane** | After install, `record -- claude` runs the agent without per-action human clicks. AgentSight is read-only relative to the agent's permissions |
+| **M2M integration surface** | CLI, `agentsight-capture` Rust crate, OTLP/HTTP, JSON/SQLite reports, optional web UI on `127.0.0.1:7395` |
+| **Identity / delegation** | State is attributed to a recorded command session / native agent session / SQLite `agentsight-*.db`. **Observation is not authorization or enforcement.** eBPF probes are privileged; the wrapped agent still runs as the normal user |
+
+This is the operator-surface track: purpose-built around live agent sessions (tokens, tools, files, model calls), not a generic process monitor. Autonomy, delegated credentials, and approval enforcement are **absent** and documented as such.
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **`agentsight top`** | Live ranked sessions (eBPF when sudo is already available; else snapshots + native session files) |
+| **`record -- <cmd>`** | Wrap any command; kernel + TLS boundary capture on Linux |
+| **Session DB** | `agentsight-*.db` in the working directory |
+| **`report`** | Summary, prompts, tokens, audit JSON, `serve` UI, export snapshot |
+| **`vis`** | Replay file effects from local coding-agent sessions |
+| **OTLP GenAI** | `debug trace --otel --otel-endpoint …` |
+| **agentpprof** | Offline token/system-effect profiles from local session history |
+
+---
+
+## Autonomy Model
+
+```
+Operator installs the CLI
+    -> agentsight top | sudo agentsight record -- <agent>
+    -> Collector writes a session DB and/or live UI
+    -> report / vis / OTLP consume the same session identity
+    -> Agent keeps executing; AgentSight does not approve or block tools
+```
+
+numbat can optionally block; AgentSight's documented product is observe/export.
+
+---
+
+## Identity and Delegation Model
+
+- **Session identity:** The recorded command, native CLI session files, or `--db` path.
+- **Attribution:** Process spawns, file opens, API calls, and LLM payloads hang off that session.
+- **Privilege split:** eBPF needs root/`CAP_BPF`; the agent process stays the invoking user.
+- **Not a policy engine:** Seeing a file write is not permission to have written it, and AgentSight does not stop the write.
+- **Sensitive logs:** Official FAQ: captured data can include prompts, paths, headers, and network targets — treat DBs as sensitive.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| CLI | `cargo install agentsight` / Homebrew tap `eunomia-bpf/tap` |
+| Rust library | `agentsight-capture` |
+| OTLP/HTTP | GenAI spans |
+| Local UI | `http://127.0.0.1:7395` during a session; `report serve` for a saved DB |
+| Session files | SQLite `agentsight-*.db`; `~/.agentsight/monitor` for the background service |
+
+---
+
+## Human-in-the-Loop Support
+
+`top`, `vis`, and the web UI are the operator surfaces. They are read-only with respect to agent authority. sudo is a human/ops prerequisite for eBPF `record`, not a per-tool approval product.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **Langfuse / Laminar** | App-level traces and evals. They miss subprocesses, local files, and closed-source CLIs unless you instrument or proxy |
+| **numbat** | Endpoint/hook visibility and optional pre-action blocking. Complements AgentSight; it is not eBPF system-effect profiling + session DBs |
+| **Generic `top` / `strace`** | Host process telemetry. They do not bind model/tool/token state to an agent session or export GenAI OTLP |
+| **A vendor LLM gateway** | Sees proxied HTTP only. AgentSight is explicitly zero-SDK / zero-proxy |
+
+---
+
+## Use Cases
+
+- **Debug a stuck coding agent** — correlate a prompt with the files and subprocesses it actually touched
+- **Token / resource forensics** — `report token` and agentpprof on local session history
+- **Security review** — `report audit --json` for spawns, file opens, and API calls (still not enforcement)
+- **Export to an existing APM** — OTLP GenAI spans without adding an SDK to Claude Code / Gemini CLI

--- a/services/tool-access-and-integration/README.md
+++ b/services/tool-access-and-integration/README.md
@@ -33,6 +33,8 @@ Agent-native tool access services solve all three problems with primitives that 
 | [OpenChatCut](openchatcut.md) [![⭐](https://img.shields.io/github/stars/0xsline/OpenChatCut?style=social)](https://github.com/0xsline/OpenChatCut) | Local-first agent-native video editor with real editable timelines | Agent Skill, Streamable HTTP MCP, isolated draft sessions, EditorCore tools | ✅ |
 | [Toolport](toolport.md) [![⭐](https://img.shields.io/github/stars/tsouth89/toolport?style=social)](https://github.com/tsouth89/toolport) | Every tool. One port. | stdio `toolport-gateway`, lazy meta-tools, per-client profiles, OS keychain | ✅ |
 | [SandBase CLI](sandbase-cli.md) [![⭐](https://img.shields.io/github/stars/sandbaseai/cli?style=social)](https://github.com/sandbaseai/cli) | Give your AI agent superpowers. One command. 2,000+ AI models. | local stdio MCP · `discover → inspect → run` · CLI connect/doctor/catalog · Agent Skill | ✅ |
+| [ContextForge](contextforge.md) [![⭐](https://img.shields.io/github/stars/IBM/mcp-context-forge?style=social)](https://github.com/IBM/mcp-context-forge) | Registry and proxy that federates MCP, A2A, and REST/gRPC | `mcpgateway` CLI, Docker, MCP/A2A/REST/gRPC, UAID routing | ✅ |
+| [MCP Gateway & Registry](mcp-gateway-registry.md) [![⭐](https://img.shields.io/github/stars/agentic-community/mcp-gateway-registry?style=social)](https://github.com/agentic-community/mcp-gateway-registry) | Unified Agent & MCP Server Registry – Gateway for AI Development Tools | nginx gateway, FastAPI registry, MCP, REST, Helm/Terraform | ✅ |
 
 
 

--- a/services/tool-access-and-integration/contextforge.md
+++ b/services/tool-access-and-integration/contextforge.md
@@ -1,0 +1,175 @@
+# ContextForge
+
+> **"An open source registry and proxy that federates MCP, A2A, and REST/gRPC APIs with centralized governance, discovery, and observability. Optimizes Agent & Tool calling, and supports plugins."**
+
+| | |
+|---|---|
+| **Website** | https://ibm.github.io/mcp-context-forge/ |
+| **Docs** | https://ibm.github.io/mcp-context-forge/ |
+| **GitHub** | https://github.com/IBM/mcp-context-forge |
+| **Stars** | [![GitHub Stars](https://img.shields.io/github/stars/IBM/mcp-context-forge?style=social)](https://github.com/IBM/mcp-context-forge) |
+| **Classification** | `agent-native` |
+| **Category** | [Tool Access & Integration Services](README.md) |
+| **License** | Apache-2.0 |
+| **Latest-month signal** | Last GitHub push 2026-08-25 ([repo metadata](https://api.github.com/repos/IBM/mcp-context-forge)); PyPI `mcp-contextforge-gateway`; image `ghcr.io/ibm/mcp-context-forge` |
+| **Verified at** | 2026-08-25 |
+
+---
+
+## Official Website
+
+https://ibm.github.io/mcp-context-forge/
+
+---
+
+## Official Repo
+
+https://github.com/IBM/mcp-context-forge
+
+---
+
+## How to Use (Agent Onboarding)
+
+**Interaction pattern:** `CLI` + MCP gateway
+
+```bash
+# Generate secrets, then start the gateway (official README TLDR)
+python3 -m mcpgateway.scripts.init_secrets
+export JWT_SECRET_KEY="$(grep '^JWT_SECRET_KEY=' .env.secrets | cut -d= -f2)"
+export AUTH_ENCRYPTION_SECRET="$(grep '^AUTH_ENCRYPTION_SECRET=' .env.secrets | cut -d= -f2)"
+JWT_SECRET_KEY="$JWT_SECRET_KEY" \
+AUTH_ENCRYPTION_SECRET="$AUTH_ENCRYPTION_SECRET" \
+MCPGATEWAY_UI_ENABLED=true \
+MCPGATEWAY_ADMIN_API_ENABLED=true \
+PLATFORM_ADMIN_EMAIL=admin@example.com \
+uvx --from mcp-contextforge-gateway mcpgateway --host 0.0.0.0 --port 4444
+```
+
+Container path from the official README:
+
+```bash
+docker pull ghcr.io/ibm/mcp-context-forge:latest
+```
+
+Direct installs (`uvx`, pip, `docker run`) listen on `http://localhost:4444`. This catalog lists ContextForge **once**, under tool access — it is an MCP/A2A registry and proxy, not a second LLM-gateway row.
+
+---
+
+## Agent Skills
+
+**Status:** ⚠️ No official `npx skills add` package published yet.
+
+```bash
+npx clawhub@latest search contextforge mcp-context-forge
+```
+
+See: https://agentskills.io/specification to contribute one.
+
+---
+
+## MCP
+
+**Status:** ✅ Available — the gateway **is** a compliant MCP server.
+
+| Detail | Value |
+|---|---|
+| **MCP Repo** | https://github.com/IBM/mcp-context-forge |
+| **Transport** | HTTP, JSON-RPC, WebSocket, SSE, stdio, streamable-HTTP |
+| **Compatible Clients** | Any MCP client that can reach the unified gateway endpoint |
+| **Also federates** | A2A servers and REST/gRPC APIs virtualized as MCP tools |
+
+---
+
+## What It Does
+
+ContextForge (IBM `mcp-context-forge`) sits in front of MCP servers, A2A agents, and REST/gRPC APIs and exposes **one governed endpoint**. Official docs split the product into a Tools Gateway (MCP, REST, gRPC-to-MCP, TOON compression), an Agent Gateway (A2A plus OpenAI-compatible and Anthropic agent routing), an API Gateway (rate limits, auth, retries), a plugin layer, and OpenTelemetry observability.
+
+It can wrap non-MCP services as virtual MCP servers, federate multiple backends, and route across gateways with **UAID** identifiers. Cross-gateway UAID routing is fail-closed: empty `UAID_ALLOWED_DOMAINS` blocks it; production needs a domain allowlist, shared JWT trust, `AUTH_REQUIRED=true`, and `UAID_FORWARD_AUTH=true`.
+
+Closest catalog peers are ToolHive, the hosted MCP Gateway (`mcpgateway.md`), and Obot. ContextForge is distinct because it federates **MCP + A2A + REST/gRPC** on one registry/proxy with UAID cross-gateway routing.
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | Official tagline: **"An open source registry and proxy that federates MCP, A2A, and REST/gRPC APIs with centralized governance, discovery, and observability. Optimizes Agent & Tool calling, and supports plugins."** — [docs](https://ibm.github.io/mcp-context-forge/), [README](https://github.com/IBM/mcp-context-forge) |
+| **Agent-specific primitive** | Unified MCP endpoint over federated tools/agents/APIs; gRPC-to-MCP translation; A2A agent routing; UAID cross-gateway routing with forwarded bearer tokens |
+| **Autonomy-compatible control plane** | After the gateway is up, agents discover and call federated tools through one URL with retries, rate limits, and auth — no per-call human click |
+| **M2M integration surface** | `uvx --from mcp-contextforge-gateway mcpgateway`, Docker image, REST/JSON-RPC/WebSocket/SSE/stdio/streamable-HTTP, Admin API |
+| **Identity / delegation** | JWT / Basic / custom auth; user-scoped OAuth tokens; UAID routing forwards `Authorization` and records source gateway + user in headers. Empty UAID allowlist fail-closes cross-gateway calls |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **Federated MCP endpoint** | One server in front of many MCP, A2A, and REST/gRPC backends |
+| **Virtual MCP server** | Wrap a legacy REST/gRPC API as MCP tools, prompts, and resources |
+| **gRPC-to-MCP translation** | Reflection-based service discovery and method introspection |
+| **A2A / agent routing** | External agents (OpenAI, Anthropic, custom) behind the Agent Gateway |
+| **UAID routing** | Cross-gateway tool/agent addressing with domain allowlist and forwarded auth |
+| **Plugin layer** | Documented plugin extensibility for extra transports and integrations |
+| **OTLP observability** | OpenTelemetry traces to Phoenix, Jaeger, Zipkin, and other backends |
+
+---
+
+## Autonomy Model
+
+```
+Operator starts mcpgateway (uvx or Docker) with JWT and encryption secrets
+    -> Register or federate MCP servers, A2A agents, and REST/gRPC APIs
+    -> Agent connects to the single gateway URL as an MCP (or A2A) client
+    -> Gateway authenticates, rate-limits, retries, and routes by registry / UAID
+    -> Optional Admin UI watches logs; it is not required for each tool call
+```
+
+---
+
+## Identity and Delegation Model
+
+- **Caller identity:** JWT or configured auth scheme on the gateway; user-scoped OAuth tokens for upstreams; `X-Upstream-Authorization` is documented as always supported.
+- **UAID hops:** Cross-gateway calls forward the bearer token. Remote gateways re-validate and keep RBAC context. Source gateway and user are tracked in headers.
+- **Fail-closed federation:** `UAID_ALLOWED_DOMAINS` empty means no cross-gateway routing.
+- **No end-user wallet:** This is a tool/agent registry, not a payment identity.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| CLI | `uvx --from mcp-contextforge-gateway mcpgateway --host 0.0.0.0 --port 4444` |
+| Docker | `docker pull ghcr.io/ibm/mcp-context-forge:latest` |
+| MCP | HTTP, JSON-RPC, WebSocket, SSE, stdio, streamable-HTTP |
+| A2A | Agent Gateway routing |
+| REST / gRPC | Native REST plus gRPC-to-MCP virtualization |
+| Admin API / UI | Optional; `MCPGATEWAY_ADMIN_API_ENABLED` / `MCPGATEWAY_UI_ENABLED` |
+
+---
+
+## Human-in-the-Loop Support
+
+Admin UI and log viewer are optional operator surfaces. Tool and agent calls on the data plane do not require a human click. Auth, retries, and rate limits are the control plane.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **Hosted MCP Gateway (`mcpgateway.md`)** | Commercial one-URL tools/skills/sandboxes platform. ContextForge is IBM's open-source MCP+A2A+REST/gRPC federation proxy with UAID routing |
+| **ToolHive** | Secure *runtime* for launching MCP servers in containers. It does not federate A2A and REST/gRPC behind UAID |
+| **Obot** | MCP hosting/registry/gateway product with a chat client. ContextForge's distinct claim is protocol federation (MCP + A2A + REST/gRPC) and cross-gateway UAID |
+| **A generic API gateway** | Routes HTTP. It has no MCP tool registry, A2A agent routing, or gRPC-to-MCP virtualization |
+
+---
+
+## Use Cases
+
+- **One MCP URL for many backends** — federate internal MCP servers and virtualized REST/gRPC APIs
+- **A2A + tools on one hop** — route agent-to-agent traffic and tool calls through the same governance layer
+- **Multi-cluster federation** — UAID routing across allowlisted gateways with forwarded auth
+- **Observable agent tool calls** — export OTLP traces without replacing the agent runtime

--- a/services/tool-access-and-integration/mcp-gateway-registry.md
+++ b/services/tool-access-and-integration/mcp-gateway-registry.md
@@ -1,0 +1,165 @@
+# MCP Gateway & Registry
+
+> **"Unified Agent & MCP Server Registry – Gateway for AI Development Tools"**
+
+| | |
+|---|---|
+| **Website** | https://agentic-community.github.io/mcp-gateway-registry/ |
+| **Docs** | https://agentic-community.github.io/mcp-gateway-registry/ |
+| **GitHub** | https://github.com/agentic-community/mcp-gateway-registry |
+| **Stars** | [![GitHub Stars](https://img.shields.io/github/stars/agentic-community/mcp-gateway-registry?style=social)](https://github.com/agentic-community/mcp-gateway-registry) |
+| **Classification** | `agent-native` |
+| **Category** | [Tool Access & Integration Services](README.md) |
+| **License** | Apache-2.0 |
+| **Latest-month signal** | Last GitHub push 2026-08-25 ([repo metadata](https://api.github.com/repos/agentic-community/mcp-gateway-registry)) |
+| **Verified at** | 2026-08-25 |
+
+---
+
+## Official Website
+
+https://agentic-community.github.io/mcp-gateway-registry/
+
+---
+
+## Official Repo
+
+https://github.com/agentic-community/mcp-gateway-registry
+
+---
+
+## How to Use (Agent Onboarding)
+
+**Interaction pattern:** `CLI` + MCP gateway
+
+Name this row **MCP Gateway & Registry** so it does not collide with hosted [MCP Gateway](mcpgateway.md).
+
+```bash
+git clone https://github.com/agentic-community/mcp-gateway-registry.git
+cd mcp-gateway-registry
+cp .env.example .env
+# Set required secrets (KEYCLOAK_ADMIN_PASSWORD, SECRET_KEY, …) — see docs/configuration.md
+./build_and_run.sh --prebuilt
+```
+
+The registry UI is served by nginx on port 80 (`http://localhost`). Full walkthrough: [Complete Installation Guide](https://github.com/agentic-community/mcp-gateway-registry/blob/main/docs/installation.md). EKS Helm, ECS Terraform, and a macOS setup skill are documented for other targets.
+
+---
+
+## Agent Skills
+
+**Status:** ✅ Available as in-repo skills (not `npx skills add`).
+
+| Skill | What It Teaches the Agent |
+|---|---|
+| macOS setup | End-to-end local install on a MacBook (`.claude/skills/macos-setup/SKILL.md`) |
+| Terraform setup | ECS/Terraform deploy assistance (`.claude/skills/terraform-setup/SKILL.md`) |
+
+---
+
+## MCP
+
+**Status:** ✅ Available — agents and coding assistants connect through the gateway as MCP clients.
+
+| Detail | Value |
+|---|---|
+| **MCP Repo** | https://github.com/agentic-community/mcp-gateway-registry |
+| **Transport** | HTTPS through nginx; MCP / OAuth to the gateway |
+| **Compatible Clients** | Coding assistants and autonomous agents that speak MCP |
+| **Also registers** | A2A agents, `SKILL.md` skills, admin-defined custom entities |
+
+---
+
+## What It Does
+
+The **MCP Gateway & Registry** (agentic-community) is an open-source control plane for organizational AI assets: MCP servers, A2A agents, skills, and custom entity types. Official docs: it began as one secure entry to many MCP servers and grew into a general AI asset registry on the same access-control and audit model.
+
+The **gateway** is the data plane (nginx: TLS, auth validation, routing). The **registry** is the control plane (FastAPI: inventory, access model, audit, embeddings). An auth server talks to Keycloak, Entra ID, Okta, Auth0, Cognito, or PingFederate. By default, A2A discovery and ACL happen in the registry and agents then talk peer-to-peer; reverse-proxy mode can force A2A through the gateway.
+
+**Distinctness:** hosted [MCP Gateway](mcpgateway.md) is a commercial one-URL tools/skills/sandboxes platform (`mcpgateway-sdk`). [ToolHive](toolhive.md) runs MCP servers in secure containers. [ContextForge](contextforge.md) federates MCP+A2A+REST/gRPC with UAID routing. This project is the agentic-community **enterprise registry** (IdP, virtual MCP servers, 3LO egress auth, admission scanning, external-registry federation).
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | Docs: **"Unified Agent & MCP Server Registry – Gateway for AI Development Tools"** and **"one governed entry point for every AI asset"** — [docs](https://agentic-community.github.io/mcp-gateway-registry/), [README](https://github.com/agentic-community/mcp-gateway-registry) |
+| **Agent-specific primitive** | Natural-language tool discovery; virtual MCP servers; A2A agent registry; `SKILL.md` skill registry with scan-on-register; per-user egress OAuth (3LO/OBO/PAT) |
+| **Autonomy-compatible control plane** | After registration and token mint, agents call tools through one authenticated gateway. Rate limits and quarantine are admin APIs, not per-call humans |
+| **M2M integration surface** | MCP, REST/OpenAPI, Python `registry_client.py`, `registry_management.py` CLI, Helm/Terraform/Compose |
+| **Identity / delegation** | OAuth2/OIDC against the org IdP; fine-grained scopes; M2M service accounts; vaulted per-user egress tokens; attributable audit log with credential masking |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **Asset registry** | MCP servers, A2A agents, skills, custom entity types |
+| **Authenticated gateway** | Single ingress; nginx + auth-server `/validate` |
+| **Semantic + lexical search** | Runtime tool/agent discovery by natural language |
+| **Virtual MCP server** | Aggregate tools from many backends with per-tool ACL |
+| **Egress auth** | 3LO / OBO / PAT so SaaS tokens are not stored in agent dotfiles |
+| **Admission gate** | Scan-on-register; fail-closed hold for unsafe assets |
+| **Federation** | Pull Anthropic MCP Registry, AWS Agent Registry, peer registries |
+| **Quarantine / rate limits** | Identity- and target-aware caps; admin kill switch |
+
+---
+
+## Autonomy Model
+
+```
+Operator deploys Compose/Helm/Terraform and connects an IdP
+    -> Register servers, agents, and skills (scan + scopes)
+    -> Agent or coding assistant obtains an MCP token (TTL configurable)
+    -> Calls go through the gateway; A2A may be peer-to-peer or proxied
+    -> Audit log records access; quarantine can drop a caller or target
+```
+
+---
+
+## Identity and Delegation Model
+
+- **Human users and M2M agents** both exist as first-class callers with groups and scopes.
+- **Egress:** gateway runs OAuth for Slack/Atlassian/GitHub-style MCP servers and injects vaulted tokens — the agent never holds the long-lived SaaS secret on disk.
+- **Audit:** access and admin events are attributable, with credential masking.
+- **Quarantine:** admin-only; cannot quarantine admin-group users (server-side, fail-closed).
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| MCP / HTTPS | nginx data plane |
+| REST / OpenAPI | Registry API (`api/openapi.json`) |
+| CLI | `registry_management.py`; `./build_and_run.sh --prebuilt` |
+| Deploy | Docker Compose, Helm (EKS), Terraform (ECS) |
+| A2A | Discovery + optional reverse-proxy mode |
+
+---
+
+## Human-in-the-Loop Support
+
+Admin UI for inventory, scopes, rate limits, and quarantine. Data-plane tool calls do not require a human click. First-time 3LO for a SaaS MCP server needs a user to complete OAuth once.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **MCP Gateway (mcpgateway.com)** | Different product (hosted SDK + one URL). Do not merge the rows |
+| **ToolHive** | Secure MCP *runtime*. Not an org-wide IdP registry with 3LO egress and A2A assets |
+| **ContextForge** | Protocol federation + UAID. Not this Keycloak/Entra registry with virtual MCP + skill scanning |
+| **A generic API gateway** | No MCP tool search, skill admission, or agent-to-agent registry |
+
+---
+
+## Use Cases
+
+- **Enterprise MCP on-ramp** — one OAuth gateway instead of credentials in every agent config
+- **Runtime tool discovery** — agents search the registry instead of hard-coding server lists
+- **Governed A2A** — register agents, then peer-to-peer or proxied invoke
+- **Skill catalog with scanning** — versioned `SKILL.md` assets on the same ACL as servers

--- a/skill.md
+++ b/skill.md
@@ -72,7 +72,7 @@ These services can be joined with a single instruction, right now, with no human
 
 ---
 
-## Full Catalog — 16 Categories, 190 Services
+## Full Catalog — 16 Categories, 201 Services
 
 ### 1. Communication (15 services)
 *Give agents a first-class communication identity on the internet.*
@@ -97,7 +97,7 @@ These services can be joined with a single instruction, right now, with no human
 
 ---
 
-### 2. Browser & Web Execution (24 services)
+### 2. Browser & Web Execution (25 services)
 *Remote browser and web data extraction for agents.*
 
 | Service | Tagline | Onboarding |
@@ -126,10 +126,11 @@ These services can be joined with a single instruction, right now, with no human
 | [CamoFox Browser](https://github.com/jo-inc/camofox-browser) | Stealth headless browser for AI agents | `npm install -g camofox-browser` then start the browser server |
 | [Moli](https://github.com/lexmount/moli) | Structured-first browser engine for AI agents | Build the Rust workspace, then run `moli fetch`, `moli serve`, or `moli mcp` |
 | [Kernel](https://www.kernel.sh) | you build agents. we give them the internet. | `brew install kernel/tap/kernel` or `npm install -g @onkernel/cli`, then `kernel browsers create -o json` |
+| [Stealth Browser MCP](https://github.com/vibheksoni/stealth-browser-mcp) | Stealth browser automation for MCP-compatible AI agents | Clone repo → `pip install -r requirements.txt` → `claude mcp add-json stealth-browser-mcp` |
 
 ---
 
-### 3. Tool Access & Integration (17 services)
+### 3. Tool Access & Integration (19 services)
 *Runtime tool discovery, auth, and execution without human pre-configuration.*
 
 | Service | Tagline | Onboarding |
@@ -151,6 +152,8 @@ These services can be joined with a single instruction, right now, with no human
 | [OpenChatCut](https://github.com/0xsline/OpenChatCut) | Local-first agent-native video editor | `npx skills add 0xsline/OpenChatCut`, then ask the agent to set it up |
 | [Toolport](https://toolport.app) | Every tool. One port. | Install from GitHub Releases, add servers, connect each AI client to `toolport-gateway` |
 | [SandBase CLI](https://github.com/sandbaseai/cli) | Give your AI agent superpowers. One command. 2,000+ AI models. | GitHub `v0.1.17` tarball `connect`, then `npx skills add sandbaseai/cli --skill sandbase` |
+| [ContextForge](https://ibm.github.io/mcp-context-forge/) | Registry and proxy that federates MCP, A2A, and REST/gRPC | `uvx --from mcp-contextforge-gateway mcpgateway --host 0.0.0.0 --port 4444` |
+| [MCP Gateway & Registry](https://agentic-community.github.io/mcp-gateway-registry/) | Unified Agent & MCP Server Registry | `git clone https://github.com/agentic-community/mcp-gateway-registry && ./build_and_run.sh --prebuilt` |
 
 ---
 
@@ -167,7 +170,7 @@ These services can be joined with a single instruction, right now, with no human
 
 ---
 
-### 5. Commerce & Payments (9 services)
+### 5. Commerce & Payments (11 services)
 *Verified financial identity and real-economy transactions for agents.*
 
 | Service | Tagline | Onboarding |
@@ -181,10 +184,12 @@ These services can be joined with a single instruction, right now, with no human
 | [Nevermined](https://nevermined.io) | The payment layer AI agents actually need | `pip install payments-py` → x402 inline payments |
 | [Coinbase CDP (x402)](https://docs.cdp.coinbase.com/x402/welcome) | HTTP-native payments for autonomous API clients | [docs.cdp.coinbase.com/x402](https://docs.cdp.coinbase.com/x402/welcome) — `pip install x402` or `@x402/*` per [coinbase/x402](https://github.com/coinbase/x402) |
 | [SecondSign Core](https://github.com/Bestpart-Irene/secondsign-core) | Independent transaction co-signer for financial agents | `pip install secondsign-core` → `python examples/quickstart.py` (pre-1.0 evaluation) |
+| [UCP](https://ucp.dev) | The common language for platforms, agents, and businesses | Read [ucp.dev](https://ucp.dev) then `cargo install ucp-schema` |
+| [AP2](https://ap2-protocol.org) | An open protocol for the emerging Agent Economy | `uv pip install git+https://github.com/google-agentic-commerce/AP2.git@main` |
 
 ---
 
-### 6. Agent Runtime & Infrastructure (27 services)
+### 6. Agent Runtime & Infrastructure (28 services)
 *Secure execution, session isolation, secrets, identity, and gateway for production agents.*
 
 | Service | Tagline | Onboarding |
@@ -216,10 +221,11 @@ These services can be joined with a single instruction, right now, with no human
 | [Polos](https://github.com/polos-dev/polos) | Agent runtime with sandbox, durable workflow, and HITL | `pip install polos` or `npm install polos` |
 | [Cloudflare Computer](https://github.com/cloudflare/computer) | Give your agent a computer | `npm install @cloudflare/computer` then attach `withWorkspace` to a Durable Object (preview only) |
 | [Agent Executor (AX)](https://github.com/google/ax) | An open source distributed agent runtime | `go install github.com/google/ax/cmd/ax@latest` then `ax --input "…"` |
+| [Agent Substrate](https://github.com/agent-substrate/substrate) | High-density Kubernetes runtime for large-scale agent deployments | `hack/install-ate-kind.sh --deploy-ate-system` then `kubectl ate create actor` |
 
 ---
 
-### 7. Agent Harnesses & Operator Surfaces (9 services)
+### 7. Agent Harnesses & Operator Surfaces (10 services)
 *Durable agent-loop control, multi-agent orchestration, and live operator surfaces tied to concrete sessions.*
 
 | Service | Tagline | Onboarding |
@@ -233,10 +239,11 @@ These services can be joined with a single instruction, right now, with no human
 | [Codex HUD (anhannin)](https://github.com/anhannin/codex-hud) | Patched Codex status line for usage and session state | Review the patch/install script, then run `Codex-HUD/install.sh` and start a new session |
 | [Claude HUD](https://github.com/jarrodwatts/claude-hud) | A Claude Code plugin that shows what's happening | `/plugin marketplace add jarrodwatts/claude-hud` then `/plugin install claude-hud` and `/claude-hud:setup` |
 | [LoopX](https://huangruiteng.github.io/loopx/) | Stateful control plane for long-horizon agents | `python3 -m pip install --upgrade loopx` then `loopx workflow-skills --install` and `loopx connect` |
+| [DeepSeek Harness (dsh)](https://deepseek.com/harness) | Everything is a Plugin. | `npx @deepseek-ai/dsh web` |
 
 ---
 
-### 8. Memory & State (17 services)
+### 8. Memory & State (19 services)
 *Persistent, queryable memory across sessions — memory as infrastructure, not application logic.*
 
 | Service | Tagline | Onboarding |
@@ -258,6 +265,8 @@ These services can be joined with a single instruction, right now, with no human
 | [Hindsight](https://github.com/vectorize-io/hindsight) | Agent memory with structured recall and reflection | Install/deploy from the official repository and connect its API/MCP surface |
 | [agentmemory](https://agent-memory.dev) ⭐ | Your coding agent remembers everything | `Read https://raw.githubusercontent.com/rohitg00/agentmemory/main/INSTALL_FOR_AGENTS.md and follow the instructions` |
 | [TencentDB Agent Memory](https://github.com/TencentCloud/TencentDB-Agent-Memory) | Agents remember,Humans innovate. | `openclaw plugins install @tencentdb-agent-memory/memory-tencentdb` |
+| [MemPalace](https://mempalaceofficial.com) | The best-benchmarked open-source AI memory system. And it's free. | `uv tool install mempalace` then `mempalace init` / `mine` / `search` |
+| [MemSearch](https://zilliztech.github.io/memsearch/) | Cross-platform semantic memory for AI coding agents | `uv tool install "memsearch[onnx]"` or Claude Code `/plugin marketplace add zilliztech/memsearch` |
 
 ---
 
@@ -278,7 +287,7 @@ These services can be joined with a single instruction, right now, with no human
 
 ---
 
-### 10. Code Execution (10 services)
+### 10. Code Execution (11 services)
 *Secure isolated runtimes for AI-generated code with LLM-formatted output.*
 
 | Service | Tagline | Onboarding |
@@ -293,10 +302,11 @@ These services can be joined with a single instruction, right now, with no human
 | [AIO Sandbox](https://github.com/agent-infra/sandbox) | Browser + shell + VS Code + Jupyter + MCP in one Docker sandbox | `docker run -p 8080:8080 ghcr.io/agent-infra/sandbox:latest` — MCP `http://localhost:8080/mcp` |
 | [Riza](https://riza.io) | AI writes code. Riza runs it. | `uv add rizaio` → `riza.command.exec(...)` — [docs.riza.io](https://docs.riza.io) |
 | [Agent Sandbox](https://agentsandbox.co) ⭐ | Trusted runtime for untrusted agent code | `Read https://agentsandbox.co/skill.md and follow the instructions` or `pip install agentsandbox-sdk` |
+| [Agent Sandbox (Kubernetes SIG)](https://agent-sandbox.sigs.k8s.io) | Secure isolated execution layer for autonomous agents on Kubernetes | `pip install k8s-agent-sandbox` then `SandboxClient().create_sandbox(...)` |
 
 ---
 
-### 11. Observability & Tracing (11 services)
+### 11. Observability & Tracing (12 services)
 *Full trajectory tracing, evaluation datasets, and cost attribution for agent runs.*
 
 | Service | Tagline | Onboarding |
@@ -312,6 +322,7 @@ These services can be joined with a single instruction, right now, with no human
 | [Galileo](https://galileo.ai) | Agent reliability platform with observability and evals | Add MCP URL `https://api.galileo.ai/mcp/http/mcp` with a Galileo API key |
 | [Laminar](https://github.com/lmnr-ai/lmnr) | Open-source observability for long-running agents | `pip install lmnr` → `Laminar.initialize()` |
 | [OpenLIT](https://github.com/openlit/openlit) | OpenTelemetry-native observability for LLMs and agents | `pip install openlit` then configure OpenTelemetry export |
+| [AgentSight](https://eunomia.dev/agentsight/) | Lightweight system-level observability for AI Agents | `cargo install agentsight` then `agentsight top` or `sudo agentsight record -- claude` |
 
 ---
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- 11 OSS agent-native catalog adds from a 2026-08-26 web/GitHub sweep (no issue-first step; maintainer-authorized batch).
- Added services (category · license · GitHub):
  - **DeepSeek Harness (dsh)** — Agent Harnesses & Operator Surfaces · MIT · https://github.com/deepseek-ai/deepseek-harness
  - **MemPalace** — Memory & State · MIT · https://github.com/MemPalace/mempalace
  - **ContextForge** — Tool Access & Integration · Apache-2.0 · https://github.com/IBM/mcp-context-forge
  - **Agent Sandbox (Kubernetes SIG)** — Code Execution · Apache-2.0 · https://github.com/kubernetes-sigs/agent-sandbox
  - **UCP** — Commerce & Payments · Apache-2.0 · https://github.com/Universal-Commerce-Protocol/ucp
  - **AP2** — Commerce & Payments · Apache-2.0 · https://github.com/google-agentic-commerce/AP2
  - **MemSearch** — Memory & State · MIT · https://github.com/zilliztech/memsearch
  - **Agent Substrate** — Agent Runtime & Infrastructure · Apache-2.0 · https://github.com/agent-substrate/substrate
  - **Stealth Browser MCP** — Browser & Web Execution · MIT · https://github.com/vibheksoni/stealth-browser-mcp
  - **MCP Gateway & Registry** — Tool Access & Integration · Apache-2.0 · https://github.com/agentic-community/mcp-gateway-registry
  - **AgentSight** — Observability & Tracing · MIT · https://github.com/eunomia-bpf/agentsight
- Explicit skips from the same sweep (not added): joinly (stale), Agent Browser Protocol, Lelu (thin), Dograh / Opik / Hatchet / Conductor (C1 fails). Also not added per brief: Opik, Hatchet, Conductor, Agentspan, Future AGI, Envoy AI Gateway, AgentLot, Microsandbox, Observra, polyrouter, DuraGraph, OpenComputer.
- **Kubernetes SIG Agent Sandbox ≠ hosted Agent Sandbox.** The existing `services/code-execution/agent-sandbox.md` (agentsandbox.co) is unchanged. The SIG project is a different CRD/controller; OpenSandbox only integrates that CRD.
- ContextForge is listed once under tool-access-and-integration (MCP/A2A registry+proxy), not under llm-gateway-and-routing.
- Agent Substrate is not google/ax (AX = harness runtime; Substrate = K8s compute control plane). Dossier discloses early-dev / not a supported Google product.
- AgentSight is operator-surface / read-only observation (eBPF + session files + OTLP GenAI), not authorization; complements Langfuse/Laminar/numbat.
- Catalog counts: 190 → 201. Category table counts bumped for the eight affected collections.
- Live homepage notes: mempalaceofficial.com is the official docs host per the repo README (Cloudflare bot-check on fetch); Stealth Browser MCP and Agent Substrate are GitHub-canonical (no separate marketing site). AP2 last code push 2026-06-17; Stealth Browser MCP last push 2026-07-24.

## Test plan
- [x] build-github-pages.sh + build-machine-catalog.py clean
- [x] build-machine-catalog.py --check
- [x] check-repository-health.py --local --freshness-max-days 45
- [x] CI validate + build green

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f2be2a9c-7530-4ac5-a552-c05970a7a813?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f2be2a9c-7530-4ac5-a552-c05970a7a813&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

