### PR TITLE
[New Service] August 28 OSS catalog additions

### DIFF
--- a/.skills/add-to-awesome-list/SKILL.md
+++ b/.skills/add-to-awesome-list/SKILL.md
@@ -9,7 +9,7 @@ license: CC0-1.0
 compatibility: Works with agents that can read repository files and browse official sources.
 metadata:
   repo: https://github.com/haoruilee/awesome-agent-native-services
-  catalog-version: "2026-08-25"
+  catalog-version: "2026-08-27"
 allowed-tools: WebSearch Read Bash
 ---
 

--- a/.skills/evaluate-agent-native/SKILL.md
+++ b/.skills/evaluate-agent-native/SKILL.md
@@ -8,7 +8,7 @@ license: CC0-1.0
 compatibility: Works with agents that can inspect official websites, repositories, and protocol documentation.
 metadata:
   repo: https://github.com/haoruilee/awesome-agent-native-services
-  catalog-version: "2026-08-25"
+  catalog-version: "2026-08-27"
 allowed-tools: WebSearch Read
 ---
 

--- a/.skills/find-agent-service/SKILL.md
+++ b/.skills/find-agent-service/SKILL.md
@@ -9,7 +9,7 @@ license: CC0-1.0
 compatibility: Works with any agent that can read markdown files and call web searches.
 metadata:
   repo: https://github.com/haoruilee/awesome-agent-native-services
-  catalog-version: "2026-08-25"
+  catalog-version: "2026-08-27"
 allowed-tools: WebSearch Read
 ---
 

--- a/.skills/install-agent-service/SKILL.md
+++ b/.skills/install-agent-service/SKILL.md
@@ -9,7 +9,7 @@ license: CC0-1.0
 compatibility: Works with Claude Code plugin skills and agents that can read SKILL.md.
 metadata:
   repo: https://github.com/haoruilee/awesome-agent-native-services
-  catalog-version: "2026-08-25"
+  catalog-version: "2026-08-27"
 allowed-tools: WebSearch Read Bash
 ---
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Recommended flow for agents: start with `skill.md` for quick discovery, switch t
 
 ## Categories
 
-**201 services across 16 categories.**
+**206 services across 16 categories.**
 
 | # | Category | Services | Description |
 |---|---|---|---|
@@ -91,12 +91,12 @@ Recommended flow for agents: start with `skill.md` for quick discovery, switch t
 | 2 | [Browser & Web Execution](#2-browser--web-execution-services) | 25 | Remote browser and web data extraction for agents |
 | 3 | [Tool Access & Integration](#3-tool-access--integration-services) | 19 | Runtime tool discovery, auth, and execution |
 | 4 | [Oversight & Approval](#4-oversight--approval-services) | 5 | Human-in-the-loop approval and escalation |
-| 5 | [Commerce & Payments](#5-commerce--payment-services) | 11 | Agent-native wallets, identity, and transactions |
+| 5 | [Commerce & Payments](#5-commerce--payment-services) | 12 | Agent-native wallets, identity, and transactions |
 | 6 | [Agent Runtime & Infrastructure](#6-agent-runtime--infrastructure-services) | 28 | Execution, session isolation, secrets, and gateway |
 | 7 | [Agent Harnesses & Operator Surfaces](#7-agent-harnesses--operator-surfaces) | 10 | Durable agent-loop control and live operator visibility |
-| 8 | [Memory & State](#8-memory--state-services) | 19 | Persistent agent memory across sessions |
+| 8 | [Memory & State](#8-memory--state-services) | 21 | Persistent agent memory across sessions |
 | 9 | [Search & Web Intelligence](#9-search--web-intelligence-services) | 9 | LLM-optimized web search and content retrieval |
-| 10 | [Code Execution](#10-code-execution-services) | 11 | Secure sandboxes for AI-generated code |
+| 10 | [Code Execution](#10-code-execution-services) | 13 | Secure sandboxes for AI-generated code |
 | 11 | [Observability & Tracing](#11-observability--tracing-services) | 12 | Agent trajectory tracing and evaluation |
 | 12 | [Durable Execution & Scheduling](#12-durable-execution--scheduling-services) | 7 | Fault-tolerant long-running agent workflows |
 | 13 | [Meeting & Conversation](#13-meeting--conversation-services) | 7 | Agent presence in voice and video meetings |
@@ -237,6 +237,7 @@ Recommended flow for agents: start with `skill.md` for quick discovery, switch t
 | [SecondSign Core](services/commerce-and-payments/secondsign-core.md) [![⭐](https://img.shields.io/github/stars/Bestpart-Irene/secondsign-core?style=social)](https://github.com/Bestpart-Irene/secondsign-core) | Independent transaction co-signer for financial AI agents | Policy engine · mTLS gateway/approver · execute-once rail · hash-chained receipts | ⚠️ | `pip install secondsign-core` then `python examples/quickstart.py` (pre-1.0 evaluation) |
 | [UCP](services/commerce-and-payments/ucp.md) [![⭐](https://img.shields.io/github/stars/Universal-Commerce-Protocol/ucp?style=social)](https://github.com/Universal-Commerce-Protocol/ucp) | The common language for platforms, agents, and businesses | Capability profiles · checkout sessions · OAuth linking · AP2 payments | ⚠️ | Read [ucp.dev](https://ucp.dev) then `cargo install ucp-schema` — samples/SDKs under [Universal-Commerce-Protocol](https://github.com/orgs/Universal-Commerce-Protocol/repositories) |
 | [AP2](services/commerce-and-payments/ap2.md) [![⭐](https://img.shields.io/github/stars/google-agentic-commerce/AP2?style=social)](https://github.com/google-agentic-commerce/AP2) | An open protocol for the emerging Agent Economy | Checkout/payment mandates · VDC chain · A2A/UCP extension | ⚠️ | `uv pip install git+https://github.com/google-agentic-commerce/AP2.git@main` — last code push 2026-06-17 |
+| [MPP](services/commerce-and-payments/mpp.md) [![⭐](https://img.shields.io/github/stars/wevm/mppx?style=social)](https://github.com/wevm/mppx) | MPP lets agents pay for services on the web, extensible to any payment method | HTTP 402 Challenge/Credential/Receipt · Tempo sessions · MCP transport · `mppx` | ⚠️ | `npm i mppx` then `Mppx.create({ methods: [tempo({ account })] })` — [quickstart](https://mpp.dev/quickstart/client.md) |
 
 ---
 
@@ -329,6 +330,8 @@ Recommended flow for agents: start with `skill.md` for quick discovery, switch t
 | [TencentDB Agent Memory](services/memory-and-state/tencentdb-agent-memory.md) [![⭐](https://img.shields.io/github/stars/TencentCloud/TencentDB-Agent-Memory?style=social)](https://github.com/TencentCloud/TencentDB-Agent-Memory) | Agents remember,Humans innovate. | Symbolic Mermaid canvas · L0–L3 layering · OpenClaw/Hermes plugins | ⚠️ | `openclaw plugins install @tencentdb-agent-memory/memory-tencentdb` then enable `memory-tencentdb` |
 | [MemPalace](services/memory-and-state/mempalace.md) [![⭐](https://img.shields.io/github/stars/MemPalace/mempalace?style=social)](https://github.com/MemPalace/mempalace) | The best-benchmarked open-source AI memory system. And it's free. | Verbatim drawers · wings/rooms · pluggable backends · 44 MCP tools | ✅ | `uv tool install mempalace` then `mempalace init` / `mine` / `search` |
 | [MemSearch](services/memory-and-state/memsearch.md) [![⭐](https://img.shields.io/github/stars/zilliztech/memsearch?style=social)](https://github.com/zilliztech/memsearch) | Cross-platform semantic memory for AI coding agents | Markdown + Milvus hybrid search · progressive recall · harness plugins | ⚠️ | `uv tool install "memsearch[onnx]"` or `/plugin marketplace add zilliztech/memsearch` |
+| [Claude-Mem](services/memory-and-state/claude-mem.md) [![⭐](https://img.shields.io/github/stars/thedotmack/claude-mem?style=social)](https://github.com/thedotmack/claude-mem) | Persistent memory compression system for Claude Code | Auto-firehose observations · compression worker · session priming · MCP search | ✅ | `npx claude-mem install` or `/plugin marketplace add thedotmack/claude-mem` then `/plugin install claude-mem` |
+| [Engram](services/memory-and-state/engram.md) [![⭐](https://img.shields.io/github/stars/Gentleman-Programming/engram?style=social)](https://github.com/Gentleman-Programming/engram) | Persistent memory for AI coding agents | Agent-curated `mem_save`/`mem_search` · SQLite FTS5 · single Go binary | ✅ | `brew install gentleman-programming/tap/engram` then `claude plugin install engram` or `engram setup <agent>` |
 
 ---
 
@@ -371,6 +374,8 @@ Recommended flow for agents: start with `skill.md` for quick discovery, switch t
 | [Agent Sandbox](services/code-execution/agent-sandbox.md) | The trusted runtime for untrusted code | Hosted code sessions · Dependency install · Files/artifacts API · URL onboarding | ⚠️ | Read https://agentsandbox.co/skill.md and follow the instructions |
 | [Riza](services/code-execution/riza.md) | AI writes code. Riza runs it. | Command Exec API · Tools API · Secrets · MCP · Self-hosting | ✅ | `uv add rizaio` then `riza.command.exec(...)` — [docs.riza.io](https://docs.riza.io/) |
 | [Agent Sandbox (Kubernetes SIG)](services/code-execution/kubernetes-agent-sandbox.md) [![⭐](https://img.shields.io/github/stars/kubernetes-sigs/agent-sandbox?style=social)](https://github.com/kubernetes-sigs/agent-sandbox) | Secure isolated execution layer for autonomous agents on Kubernetes | Sandbox CRD · WarmPool/Claim · RuntimeClass · Python/Go SDKs | ⚠️ | `pip install k8s-agent-sandbox` then `SandboxClient().create_sandbox(...)` — not hosted agentsandbox.co |
+| [Clawk](services/code-execution/clawk.md) [![⭐](https://img.shields.io/github/stars/clawkwork/clawk?style=social)](https://github.com/clawkwork/clawk) | Give a coding agent its own disposable Linux machine, not yours | Local hypervisor VM · DNS-aware egress allow-list · `status --json` · snapshot/destroy | ⚠️ | `brew install clawkwork/tap/clawk` then `cd <repo> && clawk` (pre-1.0; macOS Apple silicon) |
+| [Dormice](services/code-execution/dormice.md) [![⭐](https://img.shields.io/github/stars/BitMiracle-AI/Dormice?style=social)](https://github.com/BitMiracle-AI/Dormice) | The SQLite of agent sandboxes — self-hosted, idle costs nothing | Idempotent `acquireSandbox` · freeze/stop/archive · HTTP RPC · E2B SDK compat | ⚠️ | `curl -fsSL https://raw.githubusercontent.com/BitMiracle-AI/Dormice/main/deploy/install.sh \| bash` then `npx skills add BitMiracle-AI/Dormice` (early-dev) |
 
 ---
 

--- a/catalog.json
+++ b/catalog.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://lihaorui.com/awesome-agent-native-services/catalog.schema.json",
   "schema_version": "1.0.0",
-  "catalog_version": "2026-08-25",
-  "generated_at": "2026-08-25",
+  "catalog_version": "2026-08-27",
+  "generated_at": "2026-08-27",
   "license": "CC0-1.0",
   "source": {
     "repository": "https://github.com/haoruilee/awesome-agent-native-services",
@@ -11,7 +11,7 @@
     "service_directory": "services",
     "content_digest": {
       "algorithm": "sha256",
-      "value": "ecad0f3e36c634b61c8ed0f201333a037022db385a0aa71c0c23675fc85ae646",
+      "value": "4eec68af300c6d7878f69e362b13667e2232503304e012a4e0508f60a6752c68",
       "input_paths": [
         "README.md",
         "skill.md",
@@ -89,6 +89,7 @@
         "services/commerce-and-payments/circle-agent-stack.md",
         "services/commerce-and-payments/coinbase-x402.md",
         "services/commerce-and-payments/cymetica-ai.md",
+        "services/commerce-and-payments/mpp.md",
         "services/commerce-and-payments/nevermined.md",
         "services/commerce-and-payments/openlibx402.md",
         "services/commerce-and-payments/payman-ai.md",
@@ -137,7 +138,9 @@
         "services/agent-harnesses-and-control-planes/ruflo.md",
         "services/memory-and-state/README.md",
         "services/memory-and-state/agentmemory.md",
+        "services/memory-and-state/claude-mem.md",
         "services/memory-and-state/cognee.md",
+        "services/memory-and-state/engram.md",
         "services/memory-and-state/ensue.md",
         "services/memory-and-state/hindsight.md",
         "services/memory-and-state/llm-wiki.md",
@@ -169,8 +172,10 @@
         "services/code-execution/agent-infra-sandbox.md",
         "services/code-execution/agent-sandbox.md",
         "services/code-execution/axern.md",
+        "services/code-execution/clawk.md",
         "services/code-execution/coderunner.md",
         "services/code-execution/daytona.md",
+        "services/code-execution/dormice.md",
         "services/code-execution/e2b.md",
         "services/code-execution/kubernetes-agent-sandbox.md",
         "services/code-execution/opensandbox.md",
@@ -237,7 +242,7 @@
   },
   "counts": {
     "categories": 16,
-    "services": 201
+    "services": 206
   },
   "categories": [
     {
@@ -273,7 +278,7 @@
       "name": "Commerce & Payments",
       "description": "Services that give AI agents a verified financial identity and the ability to transact in the real economy — paying for services, moving money, and being recognized as a legitimate, accountable economic actor.",
       "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/commerce-and-payments/README.md",
-      "service_count": 11
+      "service_count": 12
     },
     {
       "id": "agent-runtime-and-infrastructure",
@@ -294,7 +299,7 @@
       "name": "Memory & State",
       "description": "Services that give AI agents persistent, queryable memory across sessions — treating memory as infrastructure rather than application logic, and managing the full lifecycle of what agents remember, forget, and retrieve.",
       "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/README.md",
-      "service_count": 19
+      "service_count": 21
     },
     {
       "id": "search-and-web-intelligence",
@@ -308,7 +313,7 @@
       "name": "Code Execution",
       "description": "Services that give AI agents a secure, isolated runtime for executing generated code — without human-side sandbox setup, without risking the host environment, and with output formatted for direct LLM consumption.",
       "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/README.md",
-      "service_count": 11
+      "service_count": 13
     },
     {
       "id": "observability-and-tracing",
@@ -2542,6 +2547,40 @@
       "verification_sources": []
     },
     {
+      "id": "commerce-and-payments/mpp",
+      "slug": "mpp",
+      "name": "MPP",
+      "tagline": "MPP lets agents pay for services on the web, extensible to any payment method.",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "commerce-and-payments",
+      "website": "https://mpp.dev",
+      "repository": "https://github.com/wevm/mppx",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/commerce-and-payments/mpp.md",
+      "source_path": "services/commerce-and-payments/mpp.md",
+      "onboarding": {
+        "type": "sdk",
+        "pattern": "SDK + HTTP 402",
+        "instruction": "npm i mppx",
+        "url": "https://mpp.dev/quickstart/client.md"
+      },
+      "protocols": [
+        "mcp",
+        "cli",
+        "sdk",
+        "http",
+        "api"
+      ],
+      "mcp_status": "available",
+      "agent_skill_status": "unavailable",
+      "latest_month_signal": "Last wevm/mppx push 2026-08-27 (repo metadata); thinner star count than neighboring commerce OSS — still the documented TypeScript SDK",
+      "verified_at": "2026-08-27",
+      "verification_sources": [
+        "https://api.github.com/repos/wevm/mppx"
+      ]
+    },
+    {
       "id": "commerce-and-payments/nevermined",
       "slug": "nevermined",
       "name": "Nevermined",
@@ -3939,6 +3978,40 @@
       ]
     },
     {
+      "id": "memory-and-state/claude-mem",
+      "slug": "claude-mem",
+      "name": "Claude-Mem",
+      "tagline": "Persistent memory compression system for Claude Code",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "memory-and-state",
+      "website": "https://claude-mem.ai",
+      "repository": "https://github.com/thedotmack/claude-mem",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/claude-mem.md",
+      "source_path": "services/memory-and-state/claude-mem.md",
+      "onboarding": {
+        "type": "cli",
+        "pattern": "CLI + coding-agent plugin",
+        "instruction": "npx claude-mem install",
+        "url": "https://docs.claude-mem.ai/installation"
+      },
+      "protocols": [
+        "agent-skill",
+        "mcp",
+        "cli",
+        "http",
+        "api"
+      ],
+      "mcp_status": "available",
+      "agent_skill_status": "available",
+      "latest_month_signal": "Last GitHub push 2026-08-26 (repo metadata); npm/plugin installers for Claude Code, Cursor, Windsurf, OpenCode, Codex CLI, Antigravity CLI, OpenClaw",
+      "verified_at": "2026-08-27",
+      "verification_sources": [
+        "https://api.github.com/repos/thedotmack/claude-mem"
+      ]
+    },
+    {
       "id": "memory-and-state/cognee",
       "slug": "cognee",
       "name": "Cognee",
@@ -3967,6 +4040,40 @@
       "latest_month_signal": null,
       "verified_at": null,
       "verification_sources": []
+    },
+    {
+      "id": "memory-and-state/engram",
+      "slug": "engram",
+      "name": "Engram",
+      "tagline": "Persistent memory for AI coding agents",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "memory-and-state",
+      "website": "https://gentleman-programming-engram.mintlify.app/introduction",
+      "repository": "https://github.com/Gentleman-Programming/engram",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/engram.md",
+      "source_path": "services/memory-and-state/engram.md",
+      "onboarding": {
+        "type": "mcp",
+        "pattern": "CLI + MCP / plugin",
+        "instruction": "brew install gentleman-programming/tap/engram",
+        "url": "https://github.com/Gentleman-Programming/engram/blob/main/docs/INSTALLATION.md"
+      },
+      "protocols": [
+        "agent-skill",
+        "mcp",
+        "cli",
+        "stdio",
+        "http"
+      ],
+      "mcp_status": "available",
+      "agent_skill_status": "available",
+      "latest_month_signal": "Last GitHub push 2026-08-27 (repo metadata); Homebrew tap + engram setup <agent> matrix",
+      "verified_at": "2026-08-27",
+      "verification_sources": [
+        "https://api.github.com/repos/Gentleman-Programming/engram"
+      ]
     },
     {
       "id": "memory-and-state/ensue",
@@ -4897,6 +5004,37 @@
       ]
     },
     {
+      "id": "code-execution/clawk",
+      "slug": "clawk",
+      "name": "Clawk",
+      "tagline": "Give a coding agent its own disposable Linux machine, not yours.",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "code-execution",
+      "website": "https://github.com/clawkwork/clawk",
+      "repository": "https://github.com/clawkwork/clawk",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/clawk.md",
+      "source_path": "services/code-execution/clawk.md",
+      "onboarding": {
+        "type": "cli",
+        "pattern": "CLI (local hypervisor VM)",
+        "instruction": "brew install clawkwork/tap/clawk\ncd <repo>\nclawk                      # boot a sandbox for this dir + attach Claude Code",
+        "url": "https://github.com/clawkwork/clawk#install"
+      },
+      "protocols": [
+        "cli",
+        "http"
+      ],
+      "mcp_status": "unknown",
+      "agent_skill_status": "unavailable",
+      "latest_month_signal": "Last GitHub push 2026-08-13 (repo metadata); Homebrew tap clawkwork/tap/clawk",
+      "verified_at": "2026-08-27",
+      "verification_sources": [
+        "https://api.github.com/repos/clawkwork/clawk"
+      ]
+    },
+    {
       "id": "code-execution/coderunner",
       "slug": "coderunner",
       "name": "CodeRunner",
@@ -4958,6 +5096,40 @@
       "latest_month_signal": null,
       "verified_at": null,
       "verification_sources": []
+    },
+    {
+      "id": "code-execution/dormice",
+      "slug": "dormice",
+      "name": "Dormice",
+      "tagline": "The SQLite of agent sandboxes — a self-hosted sandbox platform for AI agents. One machine, sandboxes that live forever, idle costs nothing.",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "code-execution",
+      "website": "https://github.com/BitMiracle-AI/Dormice",
+      "repository": "https://github.com/BitMiracle-AI/Dormice",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/dormice.md",
+      "source_path": "services/code-execution/dormice.md",
+      "onboarding": {
+        "type": "agent-skill",
+        "pattern": "self-hosted daemon + SDK / CLI / Agent Skill",
+        "instruction": "curl -fsSL https://raw.githubusercontent.com/BitMiracle-AI/Dormice/main/deploy/install.sh | bash",
+        "url": "https://raw.githubusercontent.com/BitMiracle-AI/Dormice/main/deploy/install.sh"
+      },
+      "protocols": [
+        "agent-skill",
+        "cli",
+        "sdk",
+        "http",
+        "api"
+      ],
+      "mcp_status": "unavailable",
+      "agent_skill_status": "available",
+      "latest_month_signal": "Last GitHub push 2026-08-14 (repo metadata); npx skills add BitMiracle-AI/Dormice",
+      "verified_at": "2026-08-27",
+      "verification_sources": [
+        "https://api.github.com/repos/BitMiracle-AI/Dormice"
+      ]
     },
     {
       "id": "code-execution/e2b",

--- a/docs/catalog.json
+++ b/docs/catalog.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://lihaorui.com/awesome-agent-native-services/catalog.schema.json",
   "schema_version": "1.0.0",
-  "catalog_version": "2026-08-25",
-  "generated_at": "2026-08-25",
+  "catalog_version": "2026-08-27",
+  "generated_at": "2026-08-27",
   "license": "CC0-1.0",
   "source": {
     "repository": "https://github.com/haoruilee/awesome-agent-native-services",
@@ -11,7 +11,7 @@
     "service_directory": "services",
     "content_digest": {
       "algorithm": "sha256",
-      "value": "ecad0f3e36c634b61c8ed0f201333a037022db385a0aa71c0c23675fc85ae646",
+      "value": "4eec68af300c6d7878f69e362b13667e2232503304e012a4e0508f60a6752c68",
       "input_paths": [
         "README.md",
         "skill.md",
@@ -89,6 +89,7 @@
         "services/commerce-and-payments/circle-agent-stack.md",
         "services/commerce-and-payments/coinbase-x402.md",
         "services/commerce-and-payments/cymetica-ai.md",
+        "services/commerce-and-payments/mpp.md",
         "services/commerce-and-payments/nevermined.md",
         "services/commerce-and-payments/openlibx402.md",
         "services/commerce-and-payments/payman-ai.md",
@@ -137,7 +138,9 @@
         "services/agent-harnesses-and-control-planes/ruflo.md",
         "services/memory-and-state/README.md",
         "services/memory-and-state/agentmemory.md",
+        "services/memory-and-state/claude-mem.md",
         "services/memory-and-state/cognee.md",
+        "services/memory-and-state/engram.md",
         "services/memory-and-state/ensue.md",
         "services/memory-and-state/hindsight.md",
         "services/memory-and-state/llm-wiki.md",
@@ -169,8 +172,10 @@
         "services/code-execution/agent-infra-sandbox.md",
         "services/code-execution/agent-sandbox.md",
         "services/code-execution/axern.md",
+        "services/code-execution/clawk.md",
         "services/code-execution/coderunner.md",
         "services/code-execution/daytona.md",
+        "services/code-execution/dormice.md",
         "services/code-execution/e2b.md",
         "services/code-execution/kubernetes-agent-sandbox.md",
         "services/code-execution/opensandbox.md",
@@ -237,7 +242,7 @@
   },
   "counts": {
     "categories": 16,
-    "services": 201
+    "services": 206
   },
   "categories": [
     {
@@ -273,7 +278,7 @@
       "name": "Commerce & Payments",
       "description": "Services that give AI agents a verified financial identity and the ability to transact in the real economy — paying for services, moving money, and being recognized as a legitimate, accountable economic actor.",
       "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/commerce-and-payments/README.md",
-      "service_count": 11
+      "service_count": 12
     },
     {
       "id": "agent-runtime-and-infrastructure",
@@ -294,7 +299,7 @@
       "name": "Memory & State",
       "description": "Services that give AI agents persistent, queryable memory across sessions — treating memory as infrastructure rather than application logic, and managing the full lifecycle of what agents remember, forget, and retrieve.",
       "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/README.md",
-      "service_count": 19
+      "service_count": 21
     },
     {
       "id": "search-and-web-intelligence",
@@ -308,7 +313,7 @@
       "name": "Code Execution",
       "description": "Services that give AI agents a secure, isolated runtime for executing generated code — without human-side sandbox setup, without risking the host environment, and with output formatted for direct LLM consumption.",
       "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/README.md",
-      "service_count": 11
+      "service_count": 13
     },
     {
       "id": "observability-and-tracing",
@@ -2542,6 +2547,40 @@
       "verification_sources": []
     },
     {
+      "id": "commerce-and-payments/mpp",
+      "slug": "mpp",
+      "name": "MPP",
+      "tagline": "MPP lets agents pay for services on the web, extensible to any payment method.",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "commerce-and-payments",
+      "website": "https://mpp.dev",
+      "repository": "https://github.com/wevm/mppx",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/commerce-and-payments/mpp.md",
+      "source_path": "services/commerce-and-payments/mpp.md",
+      "onboarding": {
+        "type": "sdk",
+        "pattern": "SDK + HTTP 402",
+        "instruction": "npm i mppx",
+        "url": "https://mpp.dev/quickstart/client.md"
+      },
+      "protocols": [
+        "mcp",
+        "cli",
+        "sdk",
+        "http",
+        "api"
+      ],
+      "mcp_status": "available",
+      "agent_skill_status": "unavailable",
+      "latest_month_signal": "Last wevm/mppx push 2026-08-27 (repo metadata); thinner star count than neighboring commerce OSS — still the documented TypeScript SDK",
+      "verified_at": "2026-08-27",
+      "verification_sources": [
+        "https://api.github.com/repos/wevm/mppx"
+      ]
+    },
+    {
       "id": "commerce-and-payments/nevermined",
       "slug": "nevermined",
       "name": "Nevermined",
@@ -3939,6 +3978,40 @@
       ]
     },
     {
+      "id": "memory-and-state/claude-mem",
+      "slug": "claude-mem",
+      "name": "Claude-Mem",
+      "tagline": "Persistent memory compression system for Claude Code",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "memory-and-state",
+      "website": "https://claude-mem.ai",
+      "repository": "https://github.com/thedotmack/claude-mem",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/claude-mem.md",
+      "source_path": "services/memory-and-state/claude-mem.md",
+      "onboarding": {
+        "type": "cli",
+        "pattern": "CLI + coding-agent plugin",
+        "instruction": "npx claude-mem install",
+        "url": "https://docs.claude-mem.ai/installation"
+      },
+      "protocols": [
+        "agent-skill",
+        "mcp",
+        "cli",
+        "http",
+        "api"
+      ],
+      "mcp_status": "available",
+      "agent_skill_status": "available",
+      "latest_month_signal": "Last GitHub push 2026-08-26 (repo metadata); npm/plugin installers for Claude Code, Cursor, Windsurf, OpenCode, Codex CLI, Antigravity CLI, OpenClaw",
+      "verified_at": "2026-08-27",
+      "verification_sources": [
+        "https://api.github.com/repos/thedotmack/claude-mem"
+      ]
+    },
+    {
       "id": "memory-and-state/cognee",
       "slug": "cognee",
       "name": "Cognee",
@@ -3967,6 +4040,40 @@
       "latest_month_signal": null,
       "verified_at": null,
       "verification_sources": []
+    },
+    {
+      "id": "memory-and-state/engram",
+      "slug": "engram",
+      "name": "Engram",
+      "tagline": "Persistent memory for AI coding agents",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "memory-and-state",
+      "website": "https://gentleman-programming-engram.mintlify.app/introduction",
+      "repository": "https://github.com/Gentleman-Programming/engram",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/engram.md",
+      "source_path": "services/memory-and-state/engram.md",
+      "onboarding": {
+        "type": "mcp",
+        "pattern": "CLI + MCP / plugin",
+        "instruction": "brew install gentleman-programming/tap/engram",
+        "url": "https://github.com/Gentleman-Programming/engram/blob/main/docs/INSTALLATION.md"
+      },
+      "protocols": [
+        "agent-skill",
+        "mcp",
+        "cli",
+        "stdio",
+        "http"
+      ],
+      "mcp_status": "available",
+      "agent_skill_status": "available",
+      "latest_month_signal": "Last GitHub push 2026-08-27 (repo metadata); Homebrew tap + engram setup <agent> matrix",
+      "verified_at": "2026-08-27",
+      "verification_sources": [
+        "https://api.github.com/repos/Gentleman-Programming/engram"
+      ]
     },
     {
       "id": "memory-and-state/ensue",
@@ -4897,6 +5004,37 @@
       ]
     },
     {
+      "id": "code-execution/clawk",
+      "slug": "clawk",
+      "name": "Clawk",
+      "tagline": "Give a coding agent its own disposable Linux machine, not yours.",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "code-execution",
+      "website": "https://github.com/clawkwork/clawk",
+      "repository": "https://github.com/clawkwork/clawk",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/clawk.md",
+      "source_path": "services/code-execution/clawk.md",
+      "onboarding": {
+        "type": "cli",
+        "pattern": "CLI (local hypervisor VM)",
+        "instruction": "brew install clawkwork/tap/clawk\ncd <repo>\nclawk                      # boot a sandbox for this dir + attach Claude Code",
+        "url": "https://github.com/clawkwork/clawk#install"
+      },
+      "protocols": [
+        "cli",
+        "http"
+      ],
+      "mcp_status": "unknown",
+      "agent_skill_status": "unavailable",
+      "latest_month_signal": "Last GitHub push 2026-08-13 (repo metadata); Homebrew tap clawkwork/tap/clawk",
+      "verified_at": "2026-08-27",
+      "verification_sources": [
+        "https://api.github.com/repos/clawkwork/clawk"
+      ]
+    },
+    {
       "id": "code-execution/coderunner",
       "slug": "coderunner",
       "name": "CodeRunner",
@@ -4958,6 +5096,40 @@
       "latest_month_signal": null,
       "verified_at": null,
       "verification_sources": []
+    },
+    {
+      "id": "code-execution/dormice",
+      "slug": "dormice",
+      "name": "Dormice",
+      "tagline": "The SQLite of agent sandboxes — a self-hosted sandbox platform for AI agents. One machine, sandboxes that live forever, idle costs nothing.",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "code-execution",
+      "website": "https://github.com/BitMiracle-AI/Dormice",
+      "repository": "https://github.com/BitMiracle-AI/Dormice",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/dormice.md",
+      "source_path": "services/code-execution/dormice.md",
+      "onboarding": {
+        "type": "agent-skill",
+        "pattern": "self-hosted daemon + SDK / CLI / Agent Skill",
+        "instruction": "curl -fsSL https://raw.githubusercontent.com/BitMiracle-AI/Dormice/main/deploy/install.sh | bash",
+        "url": "https://raw.githubusercontent.com/BitMiracle-AI/Dormice/main/deploy/install.sh"
+      },
+      "protocols": [
+        "agent-skill",
+        "cli",
+        "sdk",
+        "http",
+        "api"
+      ],
+      "mcp_status": "unavailable",
+      "agent_skill_status": "available",
+      "latest_month_signal": "Last GitHub push 2026-08-14 (repo metadata); npx skills add BitMiracle-AI/Dormice",
+      "verified_at": "2026-08-27",
+      "verification_sources": [
+        "https://api.github.com/repos/BitMiracle-AI/Dormice"
+      ]
     },
     {
       "id": "code-execution/e2b",

--- a/docs/categories/code-execution.md
+++ b/docs/categories/code-execution.md
@@ -6,7 +6,7 @@ hero_image: "/assets/images/editorial-runtime.webp"
 permalink: /categories/code-execution/
 page_kind: collection
 collection_number: "10"
-service_count: 11
+service_count: 13
 ---
 
 <p class="collection-source"><a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/README.md">Collection notes ↗</a></p>
@@ -55,7 +55,18 @@ service_count: 11
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--05">
+  <article class="service-card service-card--new atlas-sheet--arrival atlas-visual--05">
+    <span class="service-card__image" aria-hidden="true"></span>
+    <div class="service-card__copy">
+    <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
+    <h2 class="service-card__title">Clawk</h2>
+    <div class="service-card__actions">
+      <a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/clawk.md">Open dossier ↗</a>
+      <a href="https://github.com/clawkwork/clawk">Official repo ↗</a>
+    </div>
+    </div>
+  </article>
+  <article class="service-card atlas-sheet--arrival atlas-visual--06">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -66,7 +77,7 @@ service_count: 11
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--06">
+  <article class="service-card atlas-sheet--arrival atlas-visual--07">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -77,7 +88,18 @@ service_count: 11
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--07">
+  <article class="service-card service-card--new atlas-sheet--arrival atlas-visual--08">
+    <span class="service-card__image" aria-hidden="true"></span>
+    <div class="service-card__copy">
+    <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
+    <h2 class="service-card__title">Dormice</h2>
+    <div class="service-card__actions">
+      <a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/dormice.md">Open dossier ↗</a>
+      <a href="https://github.com/BitMiracle-AI/Dormice">Official repo ↗</a>
+    </div>
+    </div>
+  </article>
+  <article class="service-card atlas-sheet--arrival atlas-visual--09">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -88,7 +110,7 @@ service_count: 11
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--08">
+  <article class="service-card atlas-sheet--arrival atlas-visual--10">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -99,7 +121,7 @@ service_count: 11
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--09">
+  <article class="service-card atlas-sheet--arrival atlas-visual--11">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -110,7 +132,7 @@ service_count: 11
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--10">
+  <article class="service-card atlas-sheet--arrival atlas-visual--12">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -121,7 +143,7 @@ service_count: 11
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--11">
+  <article class="service-card atlas-sheet--arrival atlas-visual--13">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>

--- a/docs/categories/commerce-and-payments.md
+++ b/docs/categories/commerce-and-payments.md
@@ -6,7 +6,7 @@ hero_image: "/assets/images/editorial-authority.webp"
 permalink: /categories/commerce-and-payments/
 page_kind: collection
 collection_number: "05"
-service_count: 11
+service_count: 12
 ---
 
 <p class="collection-source"><a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/commerce-and-payments/README.md">Collection notes ↗</a></p>
@@ -65,7 +65,18 @@ service_count: 11
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--06">
+  <article class="service-card service-card--new atlas-sheet--service atlas-visual--06">
+    <span class="service-card__image" aria-hidden="true"></span>
+    <div class="service-card__copy">
+    <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
+    <h2 class="service-card__title">MPP</h2>
+    <div class="service-card__actions">
+      <a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/commerce-and-payments/mpp.md">Open dossier ↗</a>
+      <a href="https://github.com/wevm/mppx">Official repo ↗</a>
+    </div>
+    </div>
+  </article>
+  <article class="service-card atlas-sheet--service atlas-visual--07">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -76,7 +87,7 @@ service_count: 11
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--07">
+  <article class="service-card atlas-sheet--service atlas-visual--08">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -87,7 +98,7 @@ service_count: 11
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--08">
+  <article class="service-card atlas-sheet--service atlas-visual--09">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -97,7 +108,7 @@ service_count: 11
     </div>
     </div>
   </article>
-  <article class="service-card service-card--new atlas-sheet--service atlas-visual--09">
+  <article class="service-card service-card--new atlas-sheet--service atlas-visual--10">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
@@ -108,7 +119,7 @@ service_count: 11
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--10">
+  <article class="service-card atlas-sheet--service atlas-visual--11">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -118,7 +129,7 @@ service_count: 11
     </div>
     </div>
   </article>
-  <article class="service-card service-card--new atlas-sheet--service atlas-visual--11">
+  <article class="service-card service-card--new atlas-sheet--service atlas-visual--12">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>

--- a/docs/categories/index.md
+++ b/docs/categories/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Agent-Native Collections"
-description: "Browse 201 agent-native services across 16 curated infrastructure collections."
+description: "Browse 206 agent-native services across 16 curated infrastructure collections."
 permalink: /categories/
 page_kind: document
 ---
@@ -43,7 +43,7 @@ page_kind: document
     <span class="collection-card__copy">
     <span class="collection-card__number">05</span>
     <span class="collection-card__title">Commerce &amp; Payments</span>
-    <span class="collection-card__count">11</span>
+    <span class="collection-card__count">12</span>
     </span>
   </a>
   <a class="collection-card atlas-visual--06" href="{{ '/categories/agent-runtime-and-infrastructure/' | relative_url }}">
@@ -67,7 +67,7 @@ page_kind: document
     <span class="collection-card__copy">
     <span class="collection-card__number">08</span>
     <span class="collection-card__title">Memory &amp; State</span>
-    <span class="collection-card__count">19</span>
+    <span class="collection-card__count">21</span>
     </span>
   </a>
   <a class="collection-card atlas-visual--09" href="{{ '/categories/search-and-web-intelligence/' | relative_url }}">
@@ -83,7 +83,7 @@ page_kind: document
     <span class="collection-card__copy">
     <span class="collection-card__number">10</span>
     <span class="collection-card__title">Code Execution</span>
-    <span class="collection-card__count">11</span>
+    <span class="collection-card__count">13</span>
     </span>
   </a>
   <a class="collection-card atlas-visual--11" href="{{ '/categories/observability-and-tracing/' | relative_url }}">

--- a/docs/categories/memory-and-state.md
+++ b/docs/categories/memory-and-state.md
@@ -6,7 +6,7 @@ hero_image: "/assets/images/editorial-memory.webp"
 permalink: /categories/memory-and-state/
 page_kind: collection
 collection_number: "08"
-service_count: 19
+service_count: 21
 ---
 
 <p class="collection-source"><a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/README.md">Collection notes ↗</a></p>
@@ -23,7 +23,18 @@ service_count: 19
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--02">
+  <article class="service-card service-card--new atlas-sheet--arrival atlas-visual--02">
+    <span class="service-card__image" aria-hidden="true"></span>
+    <div class="service-card__copy">
+    <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
+    <h2 class="service-card__title">Claude-Mem</h2>
+    <div class="service-card__actions">
+      <a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/claude-mem.md">Open dossier ↗</a>
+      <a href="https://github.com/thedotmack/claude-mem">Official repo ↗</a>
+    </div>
+    </div>
+  </article>
+  <article class="service-card atlas-sheet--arrival atlas-visual--03">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -34,7 +45,18 @@ service_count: 19
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--03">
+  <article class="service-card service-card--new atlas-sheet--arrival atlas-visual--04">
+    <span class="service-card__image" aria-hidden="true"></span>
+    <div class="service-card__copy">
+    <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
+    <h2 class="service-card__title">Engram</h2>
+    <div class="service-card__actions">
+      <a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/engram.md">Open dossier ↗</a>
+      <a href="https://github.com/Gentleman-Programming/engram">Official repo ↗</a>
+    </div>
+    </div>
+  </article>
+  <article class="service-card atlas-sheet--arrival atlas-visual--05">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -45,7 +67,7 @@ service_count: 19
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--04">
+  <article class="service-card atlas-sheet--arrival atlas-visual--06">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -56,7 +78,7 @@ service_count: 19
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--05">
+  <article class="service-card atlas-sheet--arrival atlas-visual--07">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -67,7 +89,7 @@ service_count: 19
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--06">
+  <article class="service-card atlas-sheet--arrival atlas-visual--08">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -78,7 +100,7 @@ service_count: 19
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--07">
+  <article class="service-card atlas-sheet--arrival atlas-visual--09">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -89,7 +111,7 @@ service_count: 19
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--08">
+  <article class="service-card atlas-sheet--arrival atlas-visual--10">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -100,7 +122,7 @@ service_count: 19
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--09">
+  <article class="service-card atlas-sheet--arrival atlas-visual--11">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -111,7 +133,7 @@ service_count: 19
     </div>
     </div>
   </article>
-  <article class="service-card service-card--new atlas-sheet--arrival atlas-visual--10">
+  <article class="service-card service-card--new atlas-sheet--arrival atlas-visual--12">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
@@ -122,7 +144,7 @@ service_count: 19
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--11">
+  <article class="service-card atlas-sheet--arrival atlas-visual--13">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -133,7 +155,7 @@ service_count: 19
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--12">
+  <article class="service-card atlas-sheet--arrival atlas-visual--14">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -144,7 +166,7 @@ service_count: 19
     </div>
     </div>
   </article>
-  <article class="service-card service-card--new atlas-sheet--arrival atlas-visual--13">
+  <article class="service-card service-card--new atlas-sheet--arrival atlas-visual--15">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
@@ -155,7 +177,7 @@ service_count: 19
     </div>
     </div>
   </article>
-  <article class="service-card service-card--new atlas-sheet--arrival atlas-visual--14">
+  <article class="service-card service-card--new atlas-sheet--arrival atlas-visual--16">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
@@ -166,7 +188,7 @@ service_count: 19
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--15">
+  <article class="service-card atlas-sheet--service atlas-visual--01">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -177,7 +199,7 @@ service_count: 19
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--16">
+  <article class="service-card atlas-sheet--service atlas-visual--02">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -188,7 +210,7 @@ service_count: 19
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--01">
+  <article class="service-card atlas-sheet--service atlas-visual--03">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -199,7 +221,7 @@ service_count: 19
     </div>
     </div>
   </article>
-  <article class="service-card service-card--new atlas-sheet--service atlas-visual--02">
+  <article class="service-card service-card--new atlas-sheet--service atlas-visual--04">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
@@ -210,7 +232,7 @@ service_count: 19
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--03">
+  <article class="service-card atlas-sheet--service atlas-visual--05">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,9 +3,9 @@ title: "The Agent-Native Index"
 description: "A curated 2026 collection of agent-native infrastructure: MCP tools, harnesses, identity, memory, sandboxes, browsers, payments, and runtimes."
 image: /assets/images/social-preview.png
 page_kind: home
-service_count: 201
+service_count: 206
 collection_count: 16
-new_arrivals_count: 48
+new_arrivals_count: 53
 ---
 
 <section id="new-arrivals" aria-labelledby="new-arrivals-title">
@@ -103,7 +103,31 @@ new_arrivals_count: 48
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--12" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/commerce-and-payments/ucp.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--12" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/commerce-and-payments/mpp.md">
+      <span class="arrival-card__image" aria-hidden="true"></span>
+      <span class="arrival-card__copy">
+        <span class="arrival-card__category">Commerce &amp; Payments</span>
+        <strong class="arrival-card__name">MPP</strong>
+        <span class="arrival-card__arrow" aria-hidden="true">↗</span>
+      </span>
+    </a>
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--13" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/engram.md">
+      <span class="arrival-card__image" aria-hidden="true"></span>
+      <span class="arrival-card__copy">
+        <span class="arrival-card__category">Memory &amp; State</span>
+        <strong class="arrival-card__name">Engram</strong>
+        <span class="arrival-card__arrow" aria-hidden="true">↗</span>
+      </span>
+    </a>
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--14" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/claude-mem.md">
+      <span class="arrival-card__image" aria-hidden="true"></span>
+      <span class="arrival-card__copy">
+        <span class="arrival-card__category">Memory &amp; State</span>
+        <strong class="arrival-card__name">Claude-Mem</strong>
+        <span class="arrival-card__arrow" aria-hidden="true">↗</span>
+      </span>
+    </a>
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--15" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/commerce-and-payments/ucp.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Commerce &amp; Payments</span>
@@ -111,7 +135,7 @@ new_arrivals_count: 48
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--13" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/agent-substrate.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--16" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/agent-substrate.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Agent Runtime &amp; Infrastructure</span>
@@ -119,7 +143,7 @@ new_arrivals_count: 48
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--14" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/observability-and-tracing/agentsight.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--01" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/observability-and-tracing/agentsight.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Observability &amp; Tracing</span>
@@ -127,7 +151,7 @@ new_arrivals_count: 48
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--15" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/mempalace.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--02" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/mempalace.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Memory &amp; State</span>
@@ -135,7 +159,7 @@ new_arrivals_count: 48
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--16" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/kubernetes-agent-sandbox.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--03" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/kubernetes-agent-sandbox.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Code Execution</span>
@@ -143,7 +167,7 @@ new_arrivals_count: 48
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--01" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/contextforge.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--04" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/contextforge.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Tool Access &amp; Integration</span>
@@ -151,7 +175,7 @@ new_arrivals_count: 48
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--02" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/mcp-gateway-registry.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--05" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/mcp-gateway-registry.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Tool Access &amp; Integration</span>
@@ -159,7 +183,7 @@ new_arrivals_count: 48
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--03" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/sandbase-cli.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--06" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/sandbase-cli.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Tool Access &amp; Integration</span>
@@ -167,7 +191,7 @@ new_arrivals_count: 48
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--04" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/memsearch.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--07" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/memsearch.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Memory &amp; State</span>
@@ -175,7 +199,7 @@ new_arrivals_count: 48
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--05" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/deepseek-harness.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--08" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/deepseek-harness.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Agent Harnesses &amp; Operator Surfaces</span>
@@ -183,7 +207,7 @@ new_arrivals_count: 48
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--06" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-social-network/agentgram.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--09" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-social-network/agentgram.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Agent Social &amp; Community</span>
@@ -191,7 +215,7 @@ new_arrivals_count: 48
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--07" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/toolport.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--10" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/toolport.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Tool Access &amp; Integration</span>
@@ -199,7 +223,7 @@ new_arrivals_count: 48
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--08" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/loopx.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--11" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/loopx.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Agent Harnesses &amp; Operator Surfaces</span>
@@ -207,7 +231,7 @@ new_arrivals_count: 48
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--09" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/cloudflare-computer.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--12" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/cloudflare-computer.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Agent Runtime &amp; Infrastructure</span>
@@ -215,7 +239,7 @@ new_arrivals_count: 48
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--10" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/oversight-and-approval/preloop.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--13" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/oversight-and-approval/preloop.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Oversight &amp; Approval</span>
@@ -223,7 +247,7 @@ new_arrivals_count: 48
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--11" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/claude-hud.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--14" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/claude-hud.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Agent Harnesses &amp; Operator Surfaces</span>
@@ -231,7 +255,7 @@ new_arrivals_count: 48
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--12" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/search-and-web-intelligence/agent-search-mcp.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--15" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/search-and-web-intelligence/agent-search-mcp.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Search &amp; Web Intelligence</span>
@@ -239,7 +263,7 @@ new_arrivals_count: 48
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--13" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/agentmemory.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--16" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/agentmemory.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Memory &amp; State</span>
@@ -247,7 +271,15 @@ new_arrivals_count: 48
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--14" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/google-ax.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--01" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/dormice.md">
+      <span class="arrival-card__image" aria-hidden="true"></span>
+      <span class="arrival-card__copy">
+        <span class="arrival-card__category">Code Execution</span>
+        <strong class="arrival-card__name">Dormice</strong>
+        <span class="arrival-card__arrow" aria-hidden="true">↗</span>
+      </span>
+    </a>
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--02" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/google-ax.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Agent Runtime &amp; Infrastructure</span>
@@ -255,7 +287,7 @@ new_arrivals_count: 48
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--15" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/voice-and-phone/patter.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--03" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/voice-and-phone/patter.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Voice &amp; Phone</span>
@@ -263,7 +295,15 @@ new_arrivals_count: 48
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--16" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/communication/atomic-mail.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--04" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/clawk.md">
+      <span class="arrival-card__image" aria-hidden="true"></span>
+      <span class="arrival-card__copy">
+        <span class="arrival-card__category">Code Execution</span>
+        <strong class="arrival-card__name">Clawk</strong>
+        <span class="arrival-card__arrow" aria-hidden="true">↗</span>
+      </span>
+    </a>
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--05" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/communication/atomic-mail.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Communication</span>
@@ -271,7 +311,7 @@ new_arrivals_count: 48
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--01" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/meeting-and-conversation/agentcall.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--06" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/meeting-and-conversation/agentcall.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Meeting &amp; Conversation</span>
@@ -279,7 +319,7 @@ new_arrivals_count: 48
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--02" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/communication/agentteam-email.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--07" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/communication/agentteam-email.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Communication</span>
@@ -287,7 +327,7 @@ new_arrivals_count: 48
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--03" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/browser-and-web-execution/stealth-browser-mcp.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--08" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/browser-and-web-execution/stealth-browser-mcp.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Browser &amp; Web Execution</span>
@@ -295,7 +335,7 @@ new_arrivals_count: 48
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--04" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/commerce-and-payments/ap2.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--09" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/commerce-and-payments/ap2.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Commerce &amp; Payments</span>
@@ -303,7 +343,7 @@ new_arrivals_count: 48
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--05" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/tencentdb-agent-memory.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--10" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/tencentdb-agent-memory.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Memory &amp; State</span>
@@ -311,7 +351,7 @@ new_arrivals_count: 48
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--06" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/longhorizon-harness.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--11" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/longhorizon-harness.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Agent Harnesses &amp; Operator Surfaces</span>
@@ -319,7 +359,7 @@ new_arrivals_count: 48
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--07" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/search-and-web-intelligence/contextx.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--12" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/search-and-web-intelligence/contextx.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Search &amp; Web Intelligence</span>
@@ -327,7 +367,7 @@ new_arrivals_count: 48
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--08" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/qm.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--13" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/qm.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Agent Harnesses &amp; Operator Surfaces</span>
@@ -335,7 +375,7 @@ new_arrivals_count: 48
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--09" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/axern.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--14" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/axern.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Code Execution</span>
@@ -343,7 +383,7 @@ new_arrivals_count: 48
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--10" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-social-network/agent-chamber.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--15" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-social-network/agent-chamber.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Agent Social &amp; Community</span>
@@ -351,7 +391,7 @@ new_arrivals_count: 48
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--11" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/voice-and-phone/qwen-audio-agent.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--16" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/voice-and-phone/qwen-audio-agent.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Voice &amp; Phone</span>
@@ -359,7 +399,7 @@ new_arrivals_count: 48
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--12" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/llm-gateway-and-routing/sageroute.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--01" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/llm-gateway-and-routing/sageroute.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">LLM Gateway &amp; Routing</span>
@@ -367,7 +407,7 @@ new_arrivals_count: 48
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--13" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/observability-and-tracing/numbat.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--02" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/observability-and-tracing/numbat.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Observability &amp; Tracing</span>
@@ -375,7 +415,7 @@ new_arrivals_count: 48
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--14" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/memmy-agent.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--03" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/memmy-agent.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Memory &amp; State</span>
@@ -383,7 +423,7 @@ new_arrivals_count: 48
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--15" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/meeting-and-conversation/looped-meet.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--04" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/meeting-and-conversation/looped-meet.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Meeting &amp; Conversation</span>
@@ -391,7 +431,7 @@ new_arrivals_count: 48
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--16" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/durable-execution-and-scheduling/pi-dispatch.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--05" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/durable-execution-and-scheduling/pi-dispatch.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Durable Execution &amp; Scheduling</span>
@@ -415,7 +455,7 @@ new_arrivals_count: 48
   <div class="section-intro">
     <span class="section-number">02</span>
     <h2 class="section-title" id="collections-title">The collections</h2>
-    <p class="section-note">16 fields · 201 dossiers</p>
+    <p class="section-note">16 fields · 206 dossiers</p>
   </div>
   <div class="collection-grid">
     <a class="collection-card atlas-visual--01" href="{{ '/categories/communication/' | relative_url }}">
@@ -455,7 +495,7 @@ new_arrivals_count: 48
       <span class="collection-card__copy">
       <span class="collection-card__number">05</span>
       <span class="collection-card__title">Commerce &amp; Payments</span>
-      <span class="collection-card__count">11</span>
+      <span class="collection-card__count">12</span>
       </span>
     </a>
     <a class="collection-card atlas-visual--06" href="{{ '/categories/agent-runtime-and-infrastructure/' | relative_url }}">
@@ -479,7 +519,7 @@ new_arrivals_count: 48
       <span class="collection-card__copy">
       <span class="collection-card__number">08</span>
       <span class="collection-card__title">Memory &amp; State</span>
-      <span class="collection-card__count">19</span>
+      <span class="collection-card__count">21</span>
       </span>
     </a>
     <a class="collection-card atlas-visual--09" href="{{ '/categories/search-and-web-intelligence/' | relative_url }}">
@@ -495,7 +535,7 @@ new_arrivals_count: 48
       <span class="collection-card__copy">
       <span class="collection-card__number">10</span>
       <span class="collection-card__title">Code Execution</span>
-      <span class="collection-card__count">11</span>
+      <span class="collection-card__count">13</span>
       </span>
     </a>
     <a class="collection-card atlas-visual--11" href="{{ '/categories/observability-and-tracing/' | relative_url }}">
@@ -566,6 +606,6 @@ new_arrivals_count: 48
   <div>
   <span class="section-number">03</span>
   <h2 class="section-title">Full source.</h2>
-  <a class="source-gateway__link" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/README.md">Open 201 dossiers ↗</a>
+  <a class="source-gateway__link" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/README.md">Open 206 dossiers ↗</a>
   </div>
 </section>

--- a/docs/skill.md
+++ b/docs/skill.md
@@ -59,7 +59,7 @@ These services can be joined with a single instruction, right now, with no human
 
 ---
 
-## Full Catalog — 16 Categories, 201 Services
+## Full Catalog — 16 Categories, 206 Services
 
 ### 1. Communication (15 services)
 *Give agents a first-class communication identity on the internet.*
@@ -157,7 +157,7 @@ These services can be joined with a single instruction, right now, with no human
 
 ---
 
-### 5. Commerce & Payments (11 services)
+### 5. Commerce & Payments (12 services)
 *Verified financial identity and real-economy transactions for agents.*
 
 | Service | Tagline | Onboarding |
@@ -173,6 +173,7 @@ These services can be joined with a single instruction, right now, with no human
 | [SecondSign Core](https://github.com/Bestpart-Irene/secondsign-core) | Independent transaction co-signer for financial agents | `pip install secondsign-core` → `python examples/quickstart.py` (pre-1.0 evaluation) |
 | [UCP](https://ucp.dev) | The common language for platforms, agents, and businesses | Read [ucp.dev](https://ucp.dev) then `cargo install ucp-schema` |
 | [AP2](https://ap2-protocol.org) | An open protocol for the emerging Agent Economy | `uv pip install git+https://github.com/google-agentic-commerce/AP2.git@main` |
+| [MPP](https://mpp.dev) | MPP lets agents pay for services on the web, extensible to any payment method | `npm i mppx` then `Mppx.create({ methods: [tempo({ account })] })` |
 
 ---
 
@@ -230,7 +231,7 @@ These services can be joined with a single instruction, right now, with no human
 
 ---
 
-### 8. Memory & State (19 services)
+### 8. Memory & State (21 services)
 *Persistent, queryable memory across sessions — memory as infrastructure, not application logic.*
 
 | Service | Tagline | Onboarding |
@@ -254,6 +255,8 @@ These services can be joined with a single instruction, right now, with no human
 | [TencentDB Agent Memory](https://github.com/TencentCloud/TencentDB-Agent-Memory) | Agents remember,Humans innovate. | `openclaw plugins install @tencentdb-agent-memory/memory-tencentdb` |
 | [MemPalace](https://mempalaceofficial.com) | The best-benchmarked open-source AI memory system. And it's free. | `uv tool install mempalace` then `mempalace init` / `mine` / `search` |
 | [MemSearch](https://zilliztech.github.io/memsearch/) | Cross-platform semantic memory for AI coding agents | `uv tool install "memsearch[onnx]"` or Claude Code `/plugin marketplace add zilliztech/memsearch` |
+| [Claude-Mem](https://claude-mem.ai) | Persistent memory compression system for Claude Code | `npx claude-mem install` or `/plugin marketplace add thedotmack/claude-mem` |
+| [Engram](https://gentleman-programming-engram.mintlify.app/introduction) | Persistent memory for AI coding agents | `brew install gentleman-programming/tap/engram` then `engram setup <agent>` |
 
 ---
 
@@ -274,7 +277,7 @@ These services can be joined with a single instruction, right now, with no human
 
 ---
 
-### 10. Code Execution (11 services)
+### 10. Code Execution (13 services)
 *Secure isolated runtimes for AI-generated code with LLM-formatted output.*
 
 | Service | Tagline | Onboarding |
@@ -290,6 +293,8 @@ These services can be joined with a single instruction, right now, with no human
 | [Riza](https://riza.io) | AI writes code. Riza runs it. | `uv add rizaio` → `riza.command.exec(...)` — [docs.riza.io](https://docs.riza.io) |
 | [Agent Sandbox](https://agentsandbox.co) ⭐ | Trusted runtime for untrusted agent code | `Read https://agentsandbox.co/skill.md and follow the instructions` or `pip install agentsandbox-sdk` |
 | [Agent Sandbox (Kubernetes SIG)](https://agent-sandbox.sigs.k8s.io) | Secure isolated execution layer for autonomous agents on Kubernetes | `pip install k8s-agent-sandbox` then `SandboxClient().create_sandbox(...)` |
+| [Clawk](https://github.com/clawkwork/clawk) | Give a coding agent its own disposable Linux machine, not yours | `brew install clawkwork/tap/clawk` then `cd <repo> && clawk` (pre-1.0) |
+| [Dormice](https://github.com/BitMiracle-AI/Dormice) | The SQLite of agent sandboxes — self-hosted, idle costs nothing | install.sh then `npx skills add BitMiracle-AI/Dormice` (early-dev) |
 
 ---
 

--- a/services/code-execution/README.md
+++ b/services/code-execution/README.md
@@ -31,6 +31,8 @@ Agent-native code execution services solve this with:
 | [Agent Sandbox](agent-sandbox.md) | The trusted runtime for untrusted code | REST API, Python SDK, URL onboarding (`skill.md`) | ⚠️ |
 | [Riza](riza.md) | AI writes code. Riza runs it. | REST API, Python/TypeScript/Go SDKs, MCP server, self-hosting | ✅ |
 | [Agent Sandbox (Kubernetes SIG)](kubernetes-agent-sandbox.md) [![⭐](https://img.shields.io/github/stars/kubernetes-sigs/agent-sandbox?style=social)](https://github.com/kubernetes-sigs/agent-sandbox) | Secure isolated execution layer for autonomous agents on Kubernetes | Sandbox CRD, WarmPool/Claim, Python/Go SDKs, RuntimeClass | ⚠️ |
+| [Clawk](clawk.md) [![⭐](https://img.shields.io/github/stars/clawkwork/clawk?style=social)](https://github.com/clawkwork/clawk) | Give a coding agent its own disposable Linux machine, not yours | Local hypervisor VM, DNS-aware egress allow-list, JSON CLI | ⚠️ |
+| [Dormice](dormice.md) [![⭐](https://img.shields.io/github/stars/BitMiracle-AI/Dormice?style=social)](https://github.com/BitMiracle-AI/Dormice) | The SQLite of agent sandboxes — self-hosted, idle costs nothing | acquireSandbox, HTTP RPC, E2B SDK compat, dor CLI | ⚠️ |
 
 
 ---

--- a/services/code-execution/clawk.md
+++ b/services/code-execution/clawk.md
@@ -1,0 +1,188 @@
+# Clawk
+
+> **"Give a coding agent its own disposable Linux machine, not yours."**
+
+| | |
+|---|---|
+| **Website** | https://github.com/clawkwork/clawk |
+| **Docs** | https://github.com/clawkwork/clawk/tree/main/docs |
+| **GitHub** | https://github.com/clawkwork/clawk |
+| **Stars** | [![GitHub Stars](https://img.shields.io/github/stars/clawkwork/clawk?style=social)](https://github.com/clawkwork/clawk) |
+| **Classification** | `agent-native` |
+| **Category** | [Code Execution Services](README.md) |
+| **License** | Apache-2.0 |
+| **Maturity** | ⚠️ Pre-1.0 — official README: expect breaking changes ([Status](https://github.com/clawkwork/clawk/blob/main/README.md#status)) |
+| **Latest-month signal** | Last GitHub push 2026-08-13 ([repo metadata](https://api.github.com/repos/clawkwork/clawk)); Homebrew tap `clawkwork/tap/clawk` |
+| **Verified at** | 2026-08-27 |
+
+---
+
+## Official Website
+
+GitHub-only. The repository does not publish a separate product homepage (`homepage` is empty in [repo metadata](https://api.github.com/repos/clawkwork/clawk)).
+
+https://github.com/clawkwork/clawk
+
+---
+
+## Official Repo
+
+https://github.com/clawkwork/clawk
+
+GitHub description: **"Give coding agents a disposable Linux VM, not your laptop."** README lead: *Give a coding agent its own disposable Linux machine, not yours.*
+
+---
+
+## How to Use (Agent Onboarding)
+
+**Interaction pattern:** `CLI` (local hypervisor VM)
+
+Requires **macOS 14+ on Apple silicon**. Linux via Firecracker is official but **experimental** ([linux-quickstart](https://github.com/clawkwork/clawk/blob/main/docs/linux-quickstart.md)). No Windows.
+
+```bash
+brew install clawkwork/tap/clawk
+cd <repo>
+clawk                      # boot a sandbox for this dir + attach Claude Code
+```
+
+From-source alternative: `git clone https://github.com/clawkwork/clawk && make install` (Go 1.26+). No Docker daemon, qemu, or sudo — the hypervisor is Virtualization.framework (macOS) or Firecracker (Linux).
+
+Structured control plane after first boot:
+
+```bash
+clawk run shell
+clawk run codex
+clawk status --json
+clawk up / down
+clawk snapshot
+clawk destroy
+```
+
+There is no URL-onboarding document.
+
+---
+
+## Agent Skills
+
+**Status:** ⚠️ No official `npx skills add` / `SKILL.md` package published.
+
+`clawk.mod` can seed skills and MCP servers **inside** the guest. That is guest configuration, not a published Agent Skills package.
+
+```bash
+npx clawhub@latest search clawk
+```
+
+See: https://agentskills.io/specification to contribute one.
+
+---
+
+## MCP
+
+**Status:** ⚠️ Not a hosted MCP server. Clawk can *provision* MCP servers in the guest via `clawk.mod`.
+
+| Detail | Value |
+|---|---|
+| **Primary interface** | `clawk` CLI (`status --json`, up/down/snapshot/destroy, `run <agent>`) |
+| **Guest MCP** | Documented in [docs/mcp.md](https://github.com/clawkwork/clawk/blob/main/docs/mcp.md) — credentials stay off the guest disk |
+| **Compatible clients** | Claude Code, Codex, pi, OpenCode, or a shell attached inside the VM |
+
+---
+
+## What It Does
+
+Clawk gives a coding agent a **disposable Linux VM** on the operator's desk instead of the host laptop. `cd` into a repo and run `clawk`: the project is live-mounted, the agent runs as root in the guest with permission-bypass flags, and host files, keychain, and unlisted network destinations stay out of reach.
+
+Isolation is a **hypervisor** (Apple Virtualization.framework / Firecracker), not a process sandbox. Egress is deny-by-default and **DNS-aware** — the userspace stack in the per-sandbox daemon filters TCP/UDP/ICMP; the guest cannot reconfigure it. Idle VMs balloon memory and can suspend; `clawk destroy` drops the VM disk while repo and agent conversation state stay on the host.
+
+**Pre-1.0:** README IMPORTANT callout and Status section both say the project is pre-1.0, moving fast, and will break between releases.
+
+**Distinct from** hosted [Agent Sandbox](agent-sandbox.md) (`agentsandbox.co`), [Kubernetes SIG Agent Sandbox](kubernetes-agent-sandbox.md), E2B / Daytona / Runloop / Vercel Sandbox (cloud microVMs), and [CodeRunner](coderunner.md) (Apple Containers). Clawk is local-first hypervisor VMs with a DNS-aware egress allow-list.
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | README: **"Give a coding agent its own disposable Linux machine, not yours."** and **"The agent gets its own machine instead of yours."** — [repo](https://github.com/clawkwork/clawk) |
+| **Agent-specific primitive** | Per-project disposable Linux VM; runners start in externally-sandboxed modes (`--dangerously-skip-permissions` / Codex bypass / OpenCode `--auto`); DNS-aware egress allow-list; ticket worktrees |
+| **Autonomy-compatible control plane** | After `clawk`, the agent works without per-command host approvals. `--safe` is the opt-out that restores prompts. Honest C4: the **daily path is a human launching `clawk`** — same pattern as catalog [CodeRunner](coderunner.md). The structured CLI (`status --json`, `up`/`down`/`snapshot`/`destroy`) is the machine control plane |
+| **M2M integration surface** | `clawk` CLI with JSON status; `clawk.mod` templates; no hosted REST API |
+| **Identity / delegation** | Each sandbox is a separate VM + allow-list. Host ssh-agent is forwarded (signing stays on the host). Claude token via `clawk auth set-token`. Audit of blocked destinations: `clawk network denials` |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **Disposable Linux VM** | Virtualization.framework (macOS) or Firecracker (Linux, experimental) |
+| **`clawk` / `clawk run`** | Attach Claude, Codex, pi, OpenCode, or a shell |
+| **DNS-aware egress allow-list** | Default deny; hostname-based; denials logged |
+| **`clawk status --json`** | Scriptable state, forwards, blocked hosts |
+| **Snapshot / pause / destroy** | Hibernate RAM to disk, or drop the VM; host-side agent state persists |
+| **`clawk.mod`** | Optional go.mod-style template: image, network, forwards, env, MCP, hooks |
+| **Ticket mode** | `clawk work TICKET` — worktree per repo; `clawk pr` opens linked PRs |
+| **Port forwards** | Guest → localhost and reverse host → guest |
+
+---
+
+## Autonomy Model
+
+```
+Operator installs Clawk and runs `clawk` in a repo (human daily path)
+    -> Per-sandbox daemon boots the VM and attaches the agent
+    -> Agent runs with host permission prompts bypassed; VM + allow-list contain it
+    -> CLI (`status --json`, up/down/snapshot/destroy) manages lifecycle without a dashboard
+    -> `clawk destroy && clawk` recreates a wrecked VM; conversations stay on the host
+```
+
+`--safe` restores the agent's own confirmation prompts for that attach.
+
+---
+
+## Identity and Delegation Model
+
+- **Sandbox identity:** One VM per project or ticket name; agent home dirs are host-mounted under `~/.clawk/namespaces/…/state/`.
+- **Credentials:** ssh-agent proxy keeps private keys off the guest; `clawk auth set-token` injects a Claude token so sandboxes do not share `/login`.
+- **Network policy:** Allow-list is the delegation of which hosts the agent may reach. `clawk network denials` is the audit log of blocked destinations.
+- **Limits (official):** Whatever you mount or allow is exposed; forwarded secrets are readable; hypervisor escapes are out of scope ([SECURITY.md](https://github.com/clawkwork/clawk/blob/main/SECURITY.md)).
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| CLI | `brew install clawkwork/tap/clawk` then `clawk`, `run`, `status --json`, `up`/`down`/`snapshot`/`destroy` |
+| Config | Optional `clawk.mod` |
+| Docs | https://github.com/clawkwork/clawk/tree/main/docs |
+| MCP | Guest-side servers via `clawk.mod`; not a Clawk-hosted MCP package |
+
+---
+
+## Human-in-the-Loop Support
+
+The everyday entry is a human typing `clawk`. After attach, the default is full autonomy inside the VM. `--safe` brings back runner confirmation prompts. Operators review egress denials, add allow-list entries, and treat sandbox output like an untrusted PR (official security model).
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **Hosted Agent Sandbox (agentsandbox.co)** | Different product: hosted sessions + `skill.md`. Not a local hypervisor |
+| **Kubernetes SIG Agent Sandbox** | In-cluster CRDs. Not a laptop VM workflow |
+| **E2B / Daytona / Runloop / Vercel Sandbox** | Billed cloud microVMs. Clawk is local-first; code stays on the desk |
+| **CodeRunner** | Apple Containers on the host kernel. Clawk is a separate Linux VM + DNS-aware egress filter |
+| **Lima / generic VMs** | A Linux VM without per-project agent attach, default-deny egress, or ticket worktrees |
+| **OS-level agent sandboxes** | Process policy on the real machine. One mistake exposes the keychain |
+
+---
+
+## Use Cases
+
+- **Local autonomous coding** — let Claude/Codex install packages and run servers without `--dangerously-skip-permissions` on the host
+- **Untrusted builds** — break the VM, `clawk destroy && clawk`, keep the repo
+- **Multi-repo tickets** — `clawk work INFRA-123` then `clawk pr`
+- **Egress-constrained agents** — default-deny network with a denial log

--- a/services/code-execution/clawk.md
+++ b/services/code-execution/clawk.md
@@ -19,9 +19,9 @@
 
 ## Official Website
 
-GitHub-only. The repository does not publish a separate product homepage (`homepage` is empty in [repo metadata](https://api.github.com/repos/clawkwork/clawk)).
-
 https://github.com/clawkwork/clawk
+
+GitHub-only. The repository does not publish a separate product homepage (`homepage` is empty in GitHub repo metadata).
 
 ---
 
@@ -37,7 +37,7 @@ GitHub description: **"Give coding agents a disposable Linux VM, not your laptop
 
 **Interaction pattern:** `CLI` (local hypervisor VM)
 
-Requires **macOS 14+ on Apple silicon**. Linux via Firecracker is official but **experimental** ([linux-quickstart](https://github.com/clawkwork/clawk/blob/main/docs/linux-quickstart.md)). No Windows.
+Requires **macOS 14+ on Apple silicon** ([README](https://github.com/clawkwork/clawk#install)). No Windows.
 
 ```bash
 brew install clawkwork/tap/clawk
@@ -45,7 +45,7 @@ cd <repo>
 clawk                      # boot a sandbox for this dir + attach Claude Code
 ```
 
-From-source alternative: `git clone https://github.com/clawkwork/clawk && make install` (Go 1.26+). No Docker daemon, qemu, or sudo — the hypervisor is Virtualization.framework (macOS) or Firecracker (Linux).
+From-source alternative: `git clone https://github.com/clawkwork/clawk && make install` (Go 1.26+). No Docker daemon, qemu, or sudo — the hypervisor is Virtualization.framework (macOS) or Firecracker (Linux). Linux via Firecracker is official but **experimental** ([linux-quickstart](https://github.com/clawkwork/clawk/blob/main/docs/linux-quickstart.md)).
 
 Structured control plane after first boot:
 

--- a/services/code-execution/dormice.md
+++ b/services/code-execution/dormice.md
@@ -1,0 +1,205 @@
+# Dormice
+
+> **"The SQLite of agent sandboxes — a self-hosted sandbox platform for AI agents. One machine, sandboxes that live forever, idle costs nothing."**
+
+| | |
+|---|---|
+| **Website** | https://github.com/BitMiracle-AI/Dormice |
+| **Docs** | https://github.com/BitMiracle-AI/Dormice/blob/main/README.md |
+| **GitHub** | https://github.com/BitMiracle-AI/Dormice |
+| **Stars** | [![GitHub Stars](https://img.shields.io/github/stars/BitMiracle-AI/Dormice?style=social)](https://github.com/BitMiracle-AI/Dormice) |
+| **Classification** | `agent-native` |
+| **Category** | [Code Execution Services](README.md) |
+| **License** | Apache-2.0 |
+| **Maturity** | ⚠️ Early development — official README: **"Nothing here is ready for production yet."** Same honesty bar as [Axern](axern.md) |
+| **Latest-month signal** | Last GitHub push 2026-08-14 ([repo metadata](https://api.github.com/repos/BitMiracle-AI/Dormice)); `npx skills add BitMiracle-AI/Dormice` |
+| **Verified at** | 2026-08-27 |
+
+---
+
+## Official Website
+
+GitHub-only. Repo `homepage` is empty. The daemon serves a small web console at `http://127.0.0.1:3676/console` after install (token → httpOnly session cookie).
+
+https://github.com/BitMiracle-AI/Dormice
+
+---
+
+## Official Repo
+
+https://github.com/BitMiracle-AI/Dormice
+
+---
+
+## How to Use (Agent Onboarding)
+
+**Interaction pattern:** self-hosted daemon + SDK / CLI / Agent Skill
+
+One command on a bare Ubuntu/Debian x86_64 host (as root), from the [README](https://github.com/BitMiracle-AI/Dormice/blob/main/README.md):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/BitMiracle-AI/Dormice/main/deploy/install.sh | bash
+```
+
+Then install the official skill:
+
+```bash
+npx skills add BitMiracle-AI/Dormice
+```
+
+Native TypeScript client (`@dormice/sdk` — README: **not on npm yet**; `pnpm build` inside the repo produces it):
+
+```ts
+import { Dormice } from '@dormice/sdk';
+
+const client = new Dormice({
+  endpoint: 'http://127.0.0.1:3676',
+  token: process.env.DORMICE_API_TOKEN!,
+});
+
+await client.acquireSandbox('my-agent', { policy: { stopAfterSeconds: null } });
+const result = await client.execCommand('my-agent', 'python3 -c "print(6 * 7)"');
+```
+
+E2B SDK compatibility — official `e2b` package, two URL changes:
+
+```ts
+import { Sandbox } from 'e2b';
+
+const sbx = await Sandbox.create({
+  apiKey: `e2b_${process.env.DORMICE_API_TOKEN}`,
+  apiUrl: 'http://127.0.0.1:3676/e2b/api',
+  sandboxUrl: 'http://127.0.0.1:3676/e2b/envd',
+});
+```
+
+There is no URL-onboarding document.
+
+---
+
+## Agent Skills
+
+**Status:** ✅ Available
+
+```bash
+npx skills add BitMiracle-AI/Dormice
+```
+
+| Skill | What It Teaches the Agent |
+|---|---|
+| `dormice` | Connect, pick E2B SDK / native HTTP / `dor` CLI, run commands, move files, set lifecycle policy — [skills/dormice/SKILL.md](https://github.com/BitMiracle-AI/Dormice/blob/main/skills/dormice/SKILL.md) |
+
+---
+
+## MCP
+
+**Status:** ⚠️ Not published as a dedicated MCP server.
+
+| Detail | Value |
+|---|---|
+| **Primary interface** | HTTP RPC (`POST /acquireSandbox`, `POST /execCommand`, …), `@dormice/sdk`, `dor` CLI, official `e2b` SDK |
+| **Compatible clients** | Any agent that can call HTTP RPC or the E2B SDK against the daemon |
+| **Docs for agents** | Skill above; README says the docs build emits `/llms.txt` twins |
+
+---
+
+## What It Does
+
+Dormice is a **self-hosted sandbox platform** that inverts billed-ephemeral cloud sandboxes. Official idea: you run one daemon on a machine you already pay for; sandboxes are **permanent** and get cheaper the longer they sit idle (`active → frozen → stopped → archived`). `acquireSandbox(userKey)` is idempotent — same key always returns the same sandbox.
+
+Idle freeze is the headline: README claims freezing an idle 1 GiB sandbox down to ~5 MiB RSS and ~50 ms wake (measured on their hardware). Deploy shape: one daemon, one SQLite ledger, one port. Isolation is Docker + gVisor, not Firecracker.
+
+**Early-dev warning (do not skip):** README status block: the daemon, lifecycle engine, SDK, CLI, console, Docker+gVisor executor, S3 archiver, and E2B-compatible API work end to end — **"Nothing here is ready for production yet."** Treat it as evaluation software, same honesty bar as [Axern](axern.md).
+
+**Distinct from [E2B](e2b.md)** (billed ephemeral cloud): self-hosted, single-binary-shaped, permanent cheap-idle sandboxes, E2B SDK by changing two URLs. **Not** [Kubernetes SIG Agent Sandbox](kubernetes-agent-sandbox.md) and **not** hosted [Agent Sandbox](agent-sandbox.md) (`agentsandbox.co`).
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | README: **"The SQLite of agent sandboxes — a self-hosted sandbox platform for AI agents."** Skill frontmatter: **"Dormice's users are agents"** — [repo](https://github.com/BitMiracle-AI/Dormice) |
+| **Agent-specific primitive** | Idempotent `acquireSandbox(userKey)`; idle freeze/stop/archive; HTTP RPC verbs; resident-agent policy (`stopAfterSeconds: null`) |
+| **Autonomy-compatible control plane** | After the daemon and token exist, an agent acquires, execs, and writes files without a console click. Console is secondary |
+| **M2M integration surface** | HTTP RPC, `@dormice/sdk`, `dor` CLI, unmodified `e2b` SDK, Agent Skill |
+| **Identity / delegation** | One API token (installer) plus revocable `dor apikey` keys. Sandbox **name** is the stable address. Console uses an httpOnly session cookie so the page never stores the token |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **`acquireSandbox(userKey)`** | Idempotent: create / wake / start / restore the same sandbox |
+| **Idle cooldown** | `active → frozen → stopped → archived`; acquire reverses it |
+| **HTTP RPC** | `POST /acquireSandbox`, `/execCommand`, `/writeFiles`, … |
+| **`@dormice/sdk`** | Native TypeScript client (first npm release queued per README) |
+| **`dor` CLI** | `dor sandbox ls / exec / push / pull / rebuild / destroy`, `dor doctor` |
+| **E2B compat** | `/e2b/api` + `/e2b/envd`; `metadata.name` maps to idempotent acquire |
+| **S3 cold archive** | Optional last idle step; next acquire reports `{ status: 'restoring', progress }` |
+| **`/console`** | Operator UI on `:3676/console` |
+
+---
+
+## Autonomy Model
+
+```
+Operator runs install.sh; dor doctor verifies Docker + gVisor
+    -> Agent receives endpoint + DORMICE_API_TOKEN (or a minted API key)
+    -> acquireSandbox('my-agent') creates or wakes the named sandbox
+    -> execCommand / writeFiles without per-step human approval
+    -> Idle policy freezes/stops/archives; next acquire restores
+    -> destroySandbox is the only verb that loses disk data
+```
+
+---
+
+## Identity and Delegation Model
+
+- **Sandbox name = address:** Same key, same disk, whatever lifecycle state.
+- **Token vs API keys:** Installer token can mint/revoke keys; keys cannot manage keys.
+- **Loopback bind:** Daemon listens on `127.0.0.1` only. Exposure is an explicit SSH tunnel or reverse proxy.
+- **No hosted tenant account:** Delegation is "this token on this machine," not a cloud KYA passport.
+- **Threat-model honesty (upstream):** gVisor, not hardware virtualization; block cloud metadata; `"icc": false`. Wrong tool if you need Firecracker-class isolation or a multi-machine fleet.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| Installer | `curl -fsSL https://raw.githubusercontent.com/BitMiracle-AI/Dormice/main/deploy/install.sh \| bash` |
+| HTTP RPC | `http://127.0.0.1:3676/<verb>` + `Authorization: Bearer` |
+| Native SDK | `@dormice/sdk` (build from repo until npm publish) |
+| E2B SDK | Official `e2b` package against `/e2b/api` and `/e2b/envd` |
+| CLI | `dor` |
+| Agent Skill | `npx skills add BitMiracle-AI/Dormice` |
+| Console | `http://127.0.0.1:3676/console` |
+
+---
+
+## Human-in-the-Loop Support
+
+Install, `dor doctor`, network hardening, and optional reverse proxy are operator work. Runtime acquire/exec is API-driven. The console is a convenience UI, not required per command. Production use is **not** recommended by upstream yet.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **E2B (hosted)** | Billed-ephemeral cloud sandboxes. Dormice is self-hosted permanence + cheap idle |
+| **Hosted Agent Sandbox (agentsandbox.co)** | Different hosted product + URL onboarding. Not this daemon |
+| **Kubernetes SIG Agent Sandbox** | Cluster CRDs / warm pools. Dormice is one machine, one SQLite ledger |
+| **Axern** | Different control plane (Principals, Axrun, gRPC). Not E2B-protocol compatible by two URLs |
+| **Raw Docker socket** | No idempotent acquire, idle freeze ladder, or E2B wire compat |
+
+---
+
+## Use Cases
+
+- **Resident coding agents** — one named sandbox that freezes instead of dying
+- **E2B app migration** — point the official SDK at two local URLs
+- **Cheap-idle eval harnesses** — keep many stopped sandboxes on one host
+- **Self-hosted only** — no hosted SLA; that is E2B's product (official "wrong tool" list)

--- a/services/code-execution/dormice.md
+++ b/services/code-execution/dormice.md
@@ -19,9 +19,9 @@
 
 ## Official Website
 
-GitHub-only. Repo `homepage` is empty. The daemon serves a small web console at `http://127.0.0.1:3676/console` after install (token → httpOnly session cookie).
-
 https://github.com/BitMiracle-AI/Dormice
+
+GitHub-only. Repo `homepage` is empty. After install the daemon serves a small web console on loopback port 3676 at `/console` (token → httpOnly session cookie).
 
 ---
 

--- a/services/commerce-and-payments/README.md
+++ b/services/commerce-and-payments/README.md
@@ -29,6 +29,7 @@ No legacy payment processor was designed with these requirements. The services i
 | [SecondSign Core](secondsign-core.md) [![⭐](https://img.shields.io/github/stars/Bestpart-Irene/secondsign-core?style=social)](https://github.com/Bestpart-Irene/secondsign-core) | Independent transaction co-signer for financial AI agents | Python API, mTLS gateway/approver channels, execute-once rail, hash-chained receipts | ⚠️ |
 | [UCP](ucp.md) [![⭐](https://img.shields.io/github/stars/Universal-Commerce-Protocol/ucp?style=social)](https://github.com/Universal-Commerce-Protocol/ucp) | The common language for platforms, agents, and businesses | REST/JSON-RPC, MCP, A2A, `ucp-schema`, checkout capabilities | ⚠️ |
 | [AP2](ap2.md) [![⭐](https://img.shields.io/github/stars/google-agentic-commerce/AP2?style=social)](https://github.com/google-agentic-commerce/AP2) | An open protocol for the emerging Agent Economy | VDC mandates, Python/Go/Android samples, A2A/UCP extension | ⚠️ |
+| [MPP](mpp.md) [![⭐](https://img.shields.io/github/stars/wevm/mppx?style=social)](https://github.com/wevm/mppx) | MPP lets agents pay for services on the web, extensible to any payment method | HTTP 402 Challenge/Credential/Receipt, mppx SDK/CLI, MCP transport | ⚠️ |
 
 
 ---

--- a/services/commerce-and-payments/mpp.md
+++ b/services/commerce-and-payments/mpp.md
@@ -1,0 +1,200 @@
+# MPP
+
+> **"MPP lets agents pay for services on the web, extensible to any payment method."**
+
+| | |
+|---|---|
+| **Website** | https://mpp.dev |
+| **Docs** | https://mpp.dev |
+| **GitHub** | https://github.com/wevm/mppx (canonical TypeScript SDK) |
+| **Stars** | [![GitHub Stars](https://img.shields.io/github/stars/wevm/mppx?style=social)](https://github.com/wevm/mppx) |
+| **Classification** | `agent-native` |
+| **Category** | [Commerce & Payment Services](README.md) |
+| **License** | MIT (`wevm/mppx`); protocol/site repos are separate (see Official Repo) |
+| **Latest-month signal** | Last `wevm/mppx` push 2026-08-27 ([repo metadata](https://api.github.com/repos/wevm/mppx)); thinner star count than neighboring commerce OSS — still the documented TypeScript SDK |
+| **Verified at** | 2026-08-27 |
+
+---
+
+## Official Website
+
+https://mpp.dev
+
+Homepage H1: **"MPP lets agents pay for services on the web, extensible to any payment method."** Designed by **Tempo × Stripe**. Homepage Integrations strip (fetched 2026-08-27): Amazon, Alchemy, Browserbase, Cloudflare, Dune, Parallel, Visa. Do not infer additional partners beyond that list.
+
+Supporting copy: **"Let agents pay for services autonomously"** — [Agentic payments](https://mpp.dev/use-cases/agentic-payments).
+
+---
+
+## Official Repo
+
+There is **no single official monorepo**. Live GitHub surfaces:
+
+| Repo | Role | License (GitHub API) |
+|---|---|---|
+| [wevm/mppx](https://github.com/wevm/mppx) | Canonical TypeScript SDK / CLI (`npm i mppx`) — use this for the star badge | MIT |
+| [tempoxyz/mpp-specs](https://github.com/tempoxyz/mpp-specs) | Protocol specs — "Payment" HTTP authentication scheme; homepage https://paymentauth.org | see repo |
+| [tempoxyz/mpp](https://github.com/tempoxyz/mpp) | Website source for https://mpp.dev | Apache-2.0 |
+
+---
+
+## How to Use (Agent Onboarding)
+
+**Interaction pattern:** `SDK` + HTTP 402
+
+```bash
+npm i mppx
+```
+
+Client (official [quickstart](https://mpp.dev/quickstart/client.md)):
+
+```ts
+import { privateKeyToAccount } from 'viem/accounts'
+import { Mppx, tempo } from 'mppx/client'
+
+Mppx.create({
+  methods: [tempo({ account: privateKeyToAccount('0x...') })],
+})
+
+const res = await fetch('https://mpp.dev/api/ping/paid')
+```
+
+Prompt-mode onboarding (paste into a coding agent) is published at https://mpp.dev/quickstart/client.md.
+
+MCP client payments: [Official MCP SDK](https://mpp.dev/partner-integrations/mcp-sdk) — `Mppx.create` wraps the TypeScript MCP SDK's Streamable HTTP transport so paid tool calls retry with a Credential.
+
+There is no URL-onboarding document.
+
+---
+
+## Agent Skills
+
+**Status:** ⚠️ No official `npx skills add` package. Docs ship copy-paste **prompt mode** for agents.
+
+| Skill | What It Teaches the Agent |
+|---|---|
+| Client prompt | https://mpp.dev/quickstart/client.md — add `mppx`, polyfill `fetch` for 402, ping `https://mpp.dev/api/ping/paid` |
+| Paid MCP server prompt | https://mpp.dev/guides/monetize-mcp-server.md |
+| Docs MCP | `search_docs` on `https://mpp.dev/api/mcp` (documentation search, not the payment protocol itself) |
+
+```bash
+npx clawhub@latest search mpp mppx
+```
+
+See: https://agentskills.io/specification to contribute one.
+
+---
+
+## MCP
+
+**Status:** ✅ First-class **transport and SDK**, not a single hosted "MPP MCP server."
+
+| Detail | Value |
+|---|---|
+| **MCP client payments** | [mpp.dev/partner-integrations/mcp-sdk](https://mpp.dev/partner-integrations/mcp-sdk) — payment-aware fetch for Streamable HTTP MCP |
+| **MCP server charges** | [Monetize your MCP server](https://mpp.dev/guides/monetize-mcp-server) — JSON-RPC error `-32042`, Credential/Receipt in `_meta` |
+| **Transport spec** | https://mpp.dev/protocol/transports/mcp |
+| **Compatible Clients** | Official TypeScript MCP SDK plus any client that implements the MPP MCP encoding |
+
+`mppx` can also speak **x402 exact** on HTTP (`PAYMENT-REQUIRED` / `PAYMENT-SIGNATURE`) alongside native MPP Challenges ([mcp-sdk](https://mpp.dev/partner-integrations/mcp-sdk)).
+
+---
+
+## What It Does
+
+MPP (Machine Payments Protocol) is an open **pay-in-the-request** standard. Official `llms.txt`: it standardizes HTTP 402 for machine-to-machine payments. Flow: **Challenge → Credential → Receipt**. A server answers `402 Payment Required` with accepted methods and price; the client pays (Tempo stablecoins, cards/Stripe, Lightning, EVM, and other documented rails) and retries; the server returns a `Payment-Receipt`.
+
+It is designed so agents do not need pre-provisioned API keys or a checkout form ([agentic payments](https://mpp.dev/use-cases/agentic-payments)). Sessions support metered pay-as-you-go (including per-token). `mppx` is the TypeScript interface: client polyfill, server `charge`, CLI, and a payments `Proxy`.
+
+**Distinct from catalog x402 / [OpenLibx402](openlibx402.md):** those are the IETF-adjacent HTTP 402 / `PAYMENT-REQUIRED` crypto rail. MPP adds cards, bank-style Stripe paths, Lightning, Tempo sessions, and can *also* speak x402 exact from one SDK. **Distinct from [AP2](ap2.md) / [UCP](ucp.md):** those are checkout mandates and a commerce language, not inline HTTP 402. **Distinct from [Skyfire](skyfire.md) / [AgentsPay](agentspay.md) / [Circle Agent Stack](circle-agent-stack.md) / [Payman AI](payman-ai.md):** hosted KYA/wallets, not an open pay-in-the-request protocol.
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | Homepage: **"MPP lets agents pay for services on the web, extensible to any payment method."** — [mpp.dev](https://mpp.dev). Use-case page: **"Let agents pay for services autonomously"** — [agentic payments](https://mpp.dev/use-cases/agentic-payments) |
+| **Agent-specific primitive** | HTTP 402 Challenge / Credential / `Payment-Receipt`; Tempo sessions; MCP `-32042` paid tools |
+| **Autonomy-compatible control plane** | After `Mppx.create`, `fetch` handles 402 without a human checkout. Official: "The agent doesn't need pre-provisioned API keys, an account, or a human in the loop" |
+| **M2M integration surface** | `mppx` client/server/proxy/CLI; MCP transport; protocol specs in `mpp-specs` |
+| **Identity / delegation** | `Payment-Receipt` on success. Optional **Web Bot Auth** and **Trusted Agent Protocol (TAP)** request attestation on the initial request and paid retries — [Expanding identity support in mppx](https://mpp.dev/blog/mppx-identity-support). Spend limits via documented scoped access keys ([Managing agent spend](https://mpp.dev/guides/managing-agent-spend)) |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **Challenge** | `402` + accepted methods, amount, and how to pay |
+| **Credential** | Client payment proof bound to the challenge |
+| **Payment-Receipt** | Success header / MCP `_meta` receipt |
+| **Charge / Session / Subscription** | One-time, metered, and recurring intents |
+| **Tempo sessions** | Pay-as-you-go channels reused across requests |
+| **Multi-rail methods** | Tempo, Stripe/cards, Lightning, EVM (incl. x402 exact), plus other homepage-documented rails |
+| **`Mppx.create`** | Client polyfill or server `charge` / session |
+| **Attestation** | Optional Web Bot Auth and TAP signers/verifiers |
+
+---
+
+## Autonomy Model
+
+```
+Operator funds an account / access key and calls Mppx.create({ methods: [tempo({ account })] })
+    -> Agent fetch() hits a paid resource
+    -> Server returns 402 Challenge
+    -> mppx builds a Credential and retries (including MCP tool retries)
+    -> Server verifies, fulfills, returns Payment-Receipt
+```
+
+No per-request checkout UI on the documented autonomous path. Manual `preparePayment` / `createCredential` exists when a human UI is desired.
+
+---
+
+## Identity and Delegation Model
+
+- **Payment identity:** The signing account (viem, Privy, Accounts SDK, or scoped access key) is the payer. Receipts carry a reference and timestamp.
+- **Agent attestation (optional):** Web Bot Auth (`Signature-Agent` + trusted HTTPS directory) and TAP (`browse` / `payment` intent) sign the first request and each 402 retry ([blog](https://mpp.dev/blog/mppx-identity-support)). MPP leaves the identity protocol to the application.
+- **Spend delegation:** Documented access keys with spending limits, call scopes, recipient restrictions, and revocation.
+- **Not a hosted wallet product:** Operators bring the rail (Tempo, Stripe, Lightning, …). MPP is the open challenge/credential protocol.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| Spec / site | https://mpp.dev — site source [tempoxyz/mpp](https://github.com/tempoxyz/mpp) |
+| Protocol drafts | [tempoxyz/mpp-specs](https://github.com/tempoxyz/mpp-specs) — Payment HTTP auth scheme |
+| TypeScript SDK | `npm i mppx` — [wevm/mppx](https://github.com/wevm/mppx) |
+| CLI | `npx mppx account create` then `mppx example.com` |
+| MCP | Client wrap + server `Transport.mcpSdk()` |
+| Docs MCP | `https://mpp.dev/api/mcp` |
+| x402 interop | Same `mppx` fetch can satisfy x402 exact |
+
+---
+
+## Human-in-the-Loop Support
+
+Not required for the autonomous 402 retry path. Optional: present payment UI via `preparePayment` before creating a Credential; Accounts SDK / Wagmi connectors for a human-held wallet; `--safe`-style spend keys for long-running agents. Checkout mandates are **AP2's** job, not MPP's.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **Coinbase x402 / OpenLibx402** | HTTP 402 crypto `PAYMENT-REQUIRED` scheme. MPP is a multi-rail Challenge/Credential protocol that can *also* speak x402 exact |
+| **AP2** | Verifiable checkout/payment **mandates** (VDCs). Not inline HTTP 402 settlement |
+| **UCP** | Checkout/commerce language. It may use AP2 for payment; it is not pay-in-the-request 402 |
+| **Skyfire / AgentsPay / Circle / Payman** | Hosted KYA, wallets, or banking agents. Not an open pay-in-the-request protocol any merchant can speak |
+| **A generic Stripe Checkout page** | Human-first hosted pay form. No machine 402 Challenge/Credential loop |
+
+---
+
+## Use Cases
+
+- **Agent pays for an API mid-loop** — LLM, search, image, or data call without a pre-issued API key
+- **Paid MCP tools** — charge `-32042` per tool; client SDK retries with a Credential
+- **Metered sessions** — per-token or per-request channels
+- **One SDK, two dialects** — native MPP and x402 exact from `mppx`

--- a/services/memory-and-state/README.md
+++ b/services/memory-and-state/README.md
@@ -43,6 +43,8 @@ Agent-native memory services solve this by providing:
 | [TencentDB Agent Memory](tencentdb-agent-memory.md) [![⭐](https://img.shields.io/github/stars/TencentCloud/TencentDB-Agent-Memory?style=social)](https://github.com/TencentCloud/TencentDB-Agent-Memory) | Agents remember,Humans innovate. | OpenClaw plugin, Hermes Gateway, layered + symbolic memory | ⚠️ |
 | [MemPalace](mempalace.md) [![⭐](https://img.shields.io/github/stars/MemPalace/mempalace?style=social)](https://github.com/MemPalace/mempalace) | The best-benchmarked open-source AI memory system. And it's free. | CLI, stdio MCP, Python API, verbatim palace + graph | ✅ |
 | [MemSearch](memsearch.md) [![⭐](https://img.shields.io/github/stars/zilliztech/memsearch?style=social)](https://github.com/zilliztech/memsearch) | Cross-platform semantic memory for AI coding agents | CLI, Python API, Claude/Codex/DSH/OpenClaw/OpenCode plugins | ⚠️ |
+| [Claude-Mem](claude-mem.md) [![⭐](https://img.shields.io/github/stars/thedotmack/claude-mem?style=social)](https://github.com/thedotmack/claude-mem) | Persistent memory compression system for Claude Code | Installer, lifecycle hooks, local worker, MCP search | ✅ |
+| [Engram](engram.md) [![⭐](https://img.shields.io/github/stars/Gentleman-Programming/engram?style=social)](https://github.com/Gentleman-Programming/engram) | Persistent memory for AI coding agents | CLI, stdio MCP, HTTP API, TUI, `engram setup` | ✅ |
 
 
 

--- a/services/memory-and-state/claude-mem.md
+++ b/services/memory-and-state/claude-mem.md
@@ -1,0 +1,192 @@
+# Claude-Mem
+
+> **"Persistent memory compression system for Claude Code"**
+
+| | |
+|---|---|
+| **Website** | https://claude-mem.ai |
+| **Docs** | https://docs.claude-mem.ai/introduction |
+| **GitHub** | https://github.com/thedotmack/claude-mem |
+| **Stars** | [![GitHub Stars](https://img.shields.io/github/stars/thedotmack/claude-mem?style=social)](https://github.com/thedotmack/claude-mem) |
+| **Classification** | `agent-native` |
+| **Category** | [Memory & State Services](README.md) |
+| **License** | Apache-2.0 (relicensed from AGPL-3.0 in [v13.0.0, 2026-05-08](https://github.com/thedotmack/claude-mem/blob/main/CHANGELOG.md)) |
+| **Latest-month signal** | Last GitHub push 2026-08-26 ([repo metadata](https://api.github.com/repos/thedotmack/claude-mem)); npm/plugin installers for Claude Code, Cursor, Windsurf, OpenCode, Codex CLI, Antigravity CLI, OpenClaw |
+| **Verified at** | 2026-08-27 |
+
+---
+
+## Official Website
+
+https://claude-mem.ai
+
+Homepage positions **claude-mem** as the open-source engine and **CMEM Cloud** as the optional hosted mirror / private MCP link. Official install copy on the homepage: `$ npx claude-mem install`.
+
+---
+
+## Official Repo
+
+https://github.com/thedotmack/claude-mem
+
+GitHub description: **"Persistent Context Across Sessions for Every Agent – Captures everything your agent does during sessions, compresses it with AI, and injects relevant context back into future sessions."**
+
+---
+
+## How to Use (Agent Onboarding)
+
+**Interaction pattern:** `CLI` + coding-agent plugin
+
+Recommended installer ([docs](https://docs.claude-mem.ai/installation)):
+
+```bash
+npx claude-mem install
+```
+
+The installer detects installed IDEs (Claude Code, Cursor, Windsurf, OpenCode, Codex CLI, Antigravity CLI) and wires hooks plus the local worker. Official note: `npm install -g claude-mem` installs the **SDK/library only** and does **not** register hooks or start the worker.
+
+Claude Code marketplace:
+
+```text
+/plugin marketplace add thedotmack/claude-mem
+/plugin install claude-mem
+```
+
+Other official installers from the [README](https://github.com/thedotmack/claude-mem/blob/main/README.md):
+
+```bash
+npx claude-mem install --ide opencode
+npx claude-mem install --ide antigravity
+curl -fsSL https://install.cmem.ai/openclaw.sh | bash
+```
+
+There is no URL-onboarding document.
+
+---
+
+## Agent Skills
+
+**Status:** ✅ Bundled with the plugin (not `npx skills add`).
+
+| Skill | What It Teaches the Agent |
+|---|---|
+| `mem-search` | Natural-language query over compressed observations with progressive disclosure ([README](https://github.com/thedotmack/claude-mem/blob/main/README.md)) |
+| Claude Desktop skill | Search memory from Claude Desktop conversations |
+| Troubleshoot skill | Diagnose worker / install issues from a problem description |
+
+Docs also list **Knowledge Agents** ("queryable brains" from observation history). [docs/license.md](https://github.com/thedotmack/claude-mem/blob/main/docs/license.md) reserves hosted cloud, team sync, enterprise features, and **premium knowledge agents** outside the Apache-2.0 public core.
+
+---
+
+## MCP
+
+**Status:** ✅ Available — four search tools on the local worker.
+
+| Detail | Value |
+|---|---|
+| **MCP Repo** | https://github.com/thedotmack/claude-mem |
+| **Transport** | Local worker HTTP API + MCP tools (stdio/plugin wiring via installer) |
+| **Compatible Clients** | Claude Code, Cursor, Windsurf, OpenCode, Codex CLI, Antigravity CLI, OpenClaw, other MCP clients |
+| **Tools (upstream)** | `search`, `timeline`, `get_observations` (3-layer workflow); README also lists a fourth MCP search surface |
+
+---
+
+## What It Does
+
+Claude-Mem is a **persistent memory compression system** for coding agents. Official docs: it automatically captures tool-usage observations, generates semantic summaries, and injects relevant context into later sessions so the agent keeps project continuity after a session ends.
+
+The capture path is a **firehose**: lifecycle hooks record prompts and tool executions (Read, Write, and the rest), a local Bun worker compresses them via the Claude Agent SDK, and the next SessionStart primes context from recent sessions. Storage is SQLite + FTS5 with an optional Chroma vector index.
+
+**Distinct from [MemPalace](mempalace.md)** (verbatim palace rooms/drawers, no official paraphrase) and **[MemSearch](memsearch.md)** (Markdown + Milvus hybrid search plugins): Claude-Mem auto-captures a tool-call firehose, compresses it, and primes the next session.
+
+**OSS vs hosted:** Apache-2.0 covers the local engine, CLI, MCP tools, and docs. [docs/license.md](https://github.com/thedotmack/claude-mem/blob/main/docs/license.md) states Claude-Mem Server v0.1 does **not** ship hosted cloud, team sync, enterprise features, premium knowledge agents, private evals, or customer deployment tooling — those sit outside the public implementation. CMEM Cloud (homepage: paid cloud mirror + private MCP link) is that hosted layer.
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | Docs H1: **"Persistent memory compression system for Claude Code"** — [docs](https://docs.claude-mem.ai/introduction). Repo: **"Persistent Context Across Sessions for Every Agent"** — [thedotmack/claude-mem](https://github.com/thedotmack/claude-mem) |
+| **Agent-specific primitive** | Auto-firehose of tool observations + AI compression + SessionStart priming; 3-layer MCP search (`search` → `timeline` → `get_observations`) |
+| **Autonomy-compatible control plane** | Official: **"Automatic Operation — No manual intervention required."** After install, hooks capture and the worker compresses without a save click ([introduction](https://docs.claude-mem.ai/introduction)) |
+| **M2M integration surface** | `npx claude-mem install`, Claude Code / OpenCode / Codex / Antigravity / OpenClaw installers, local worker HTTP API, MCP search tools |
+| **Identity / delegation** | Memory is scoped to the local user data dir (`~/.claude-mem/`) and the wired agent/IDE. `<private>` tags exclude content from storage. Hosted team scopes and premium knowledge-agent corpora are reserved commercial surfaces, not the OSS core |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **Lifecycle hooks** | SessionStart, UserPromptSubmit, PostToolUse, Stop/Summary, SessionEnd capture the firehose |
+| **Observation** | Structured record of a tool use / learning, cited by ID |
+| **Compression worker** | Local Bun/Express service (default port `37700 + (uid % 100)`) that extracts summaries via the Claude Agent SDK |
+| **Session priming** | Inject context from recent sessions at SessionStart |
+| **FTS5 + optional Chroma** | Keyword and hybrid semantic search over observations |
+| **3-layer recall** | Compact `search` index → `timeline` → full `get_observations` |
+| **Folder `CLAUDE.md`** | Auto-generated folder context files with activity timelines (docs) |
+| **`<private>` tags** | Exclude sensitive spans from storage |
+
+---
+
+## Autonomy Model
+
+```
+Operator runs `npx claude-mem install` (or the marketplace / OpenClaw installer)
+    -> Worker starts; hooks register on the chosen agent/IDE
+    -> SessionStart injects compressed context from prior sessions
+    -> Tool executions are captured automatically
+    -> Worker compresses observations without a human save step
+    -> Later sessions search or receive primed context
+```
+
+No per-turn confirmation for capture or recall.
+
+---
+
+## Identity and Delegation Model
+
+- **Local-first engine:** Observations live under `~/.claude-mem/` (override with `CLAUDE_MEM_DATA_DIR`). The agent's session is the capture subject.
+- **Privacy tags:** `<private>` content is excluded from storage.
+- **No minted KYA token** in the OSS path. Delegation is "this machine's worker + this agent's hooks."
+- **Hosted boundary:** CMEM Cloud / team sync / premium knowledge agents are reserved outside Apache-2.0 ([license.md](https://github.com/thedotmack/claude-mem/blob/main/docs/license.md)). Do not treat the cloud MCP link as part of the open core.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| Installer | `npx claude-mem install` (multi-IDE) |
+| Claude Code plugin | `/plugin marketplace add thedotmack/claude-mem` then `/plugin install claude-mem` |
+| OpenCode / Antigravity | `npx claude-mem install --ide opencode` / `--ide antigravity` |
+| OpenClaw | `curl -fsSL https://install.cmem.ai/openclaw.sh \| bash` |
+| MCP search | `search`, `timeline`, `get_observations` |
+| Worker HTTP | Local API + web viewer (port printed on startup) |
+| Docs | https://docs.claude-mem.ai/introduction |
+
+---
+
+## Human-in-the-Loop Support
+
+None required for capture, compression, or session priming. Humans can browse the local web viewer, tune `~/.claude-mem/settings.json`, and wrap secrets in `<private>` tags. Cloud sync and team governance are optional paid surfaces.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **MemPalace** | Verbatim palace (wings/rooms/drawers) that officially does **not** summarize. Claude-Mem's contract is firehose capture + compression |
+| **MemSearch** | Markdown + Milvus hybrid *search-over-memory* with harness plugins. Not an auto-compressing observation worker |
+| **Engram** | Agent-curated `mem_save` / FTS5. Engram's own [COMPARISON.md](https://github.com/Gentleman-Programming/engram/blob/main/docs/COMPARISON.md) contrasts that with Claude-Mem's raw-tool-call firehose (COMPARISON.md's AGPL row is stale — Claude-Mem is Apache-2.0 as of v13.0.0) |
+| **A raw SQLite file** | No hook firehose, no compression worker, no SessionStart priming |
+
+---
+
+## Use Cases
+
+- **Resume a Claude Code / Codex / OpenCode project** — next session starts with compressed history instead of a blank context
+- **Search past bugfixes by citation ID** — `search` then `get_observations`
+- **OpenClaw gateway memory** — official `install.cmem.ai/openclaw.sh` plugin path
+- **Local-only memory** — keep the Apache-2.0 engine on disk; skip CMEM Cloud

--- a/services/memory-and-state/engram.md
+++ b/services/memory-and-state/engram.md
@@ -1,0 +1,183 @@
+# Engram
+
+> **"Persistent memory for AI coding agents"**
+
+| | |
+|---|---|
+| **Website** | https://gentleman-programming-engram.mintlify.app/introduction |
+| **Docs** | https://gentleman-programming-engram.mintlify.app/introduction |
+| **GitHub** | https://github.com/Gentleman-Programming/engram |
+| **Stars** | [![GitHub Stars](https://img.shields.io/github/stars/Gentleman-Programming/engram?style=social)](https://github.com/Gentleman-Programming/engram) |
+| **Classification** | `agent-native` |
+| **Category** | [Memory & State Services](README.md) |
+| **License** | MIT |
+| **Latest-month signal** | Last GitHub push 2026-08-27 ([repo metadata](https://api.github.com/repos/Gentleman-Programming/engram)); Homebrew tap + `engram setup <agent>` matrix |
+| **Verified at** | 2026-08-27 |
+
+---
+
+## Official Website
+
+https://gentleman-programming-engram.mintlify.app/introduction
+
+Mintlify docs H1: **"Persistent memory system for AI coding agents."** The GitHub README tagline is **"Persistent memory for AI coding agents"** with the supporting line **"One brain. Local or cloud. Agent-agnostic, single binary, zero dependencies."**
+
+---
+
+## Official Repo
+
+https://github.com/Gentleman-Programming/engram
+
+---
+
+## How to Use (Agent Onboarding)
+
+**Interaction pattern:** `CLI` + MCP / plugin
+
+```bash
+brew install gentleman-programming/tap/engram
+```
+
+Wire an agent (official README table):
+
+```bash
+# Claude Code
+claude plugin marketplace add Gentleman-Programming/engram && claude plugin install engram
+
+# Codex, OpenCode, Cursor, and others
+engram setup codex
+engram setup opencode
+engram setup cursor
+```
+
+`engram setup <agent>` writes MCP config and plugin files. Most agents launch `engram mcp` as a short-lived stdio subprocess — no manual `engram serve` except OpenCode / Pi HTTP session tracking (default port 7437). Other install methods: [docs/INSTALLATION.md](https://github.com/Gentleman-Programming/engram/blob/main/docs/INSTALLATION.md).
+
+There is no URL-onboarding document.
+
+---
+
+## Agent Skills
+
+**Status:** ✅ Published as a Claude Code marketplace plugin with a Memory Protocol skill (not `npx skills add`).
+
+| Skill | What It Teaches the Agent |
+|---|---|
+| Memory Protocol (Claude Code plugin) | When to `mem_save` / `mem_search` and the session-close summary ([docs](https://gentleman-programming-engram.mintlify.app/agents/claude-code)) |
+| Pi package `gentle-engram` | Persistent project memory + compaction recovery via `engram setup pi` |
+
+```bash
+npx clawhub@latest search engram
+```
+
+---
+
+## MCP
+
+**Status:** ✅ Available — stdio MCP is the primary agent surface.
+
+| Detail | Value |
+|---|---|
+| **MCP Repo** | https://github.com/Gentleman-Programming/engram |
+| **Transport** | stdio (`engram mcp`). Official README: **no HTTP/network MCP endpoint** |
+| **Compatible Clients** | Claude Code, OpenCode, Gemini CLI, Codex, VS Code (Copilot), Antigravity, Cursor, Windsurf, Pi, and any other MCP client |
+| **Tool count (upstream)** | README lists **20** MCP tools (`mem_save`, `mem_search`, session lifecycle, conflict surfacing, …). Mintlify intro still says "14 MCP Tools" on an older page |
+
+---
+
+## What It Does
+
+Engram is a **single Go binary** that gives coding agents a persistent SQLite + FTS5 memory. Official positioning: the **agent** decides what is worth remembering via `mem_save`; Engram stores and searches it. Docs: "Engram trusts the agent to decide what's worth remembering — not a firehose of raw tool calls."
+
+Next session, the agent calls `mem_search` / `mem_context` (and plugins can inject prior session context). Progressive disclosure is `mem_search` → `mem_timeline` → `mem_get_observation`. Optional git-chunk sync and opt-in cloud replication leave local SQLite authoritative.
+
+**Distinct from [Claude-Mem](claude-mem.md):** Claude-Mem auto-captures a tool-call firehose and compresses it in a worker. Engram is agent-curated FTS5 — one binary, zero Node/Bun/Python/Chroma. Their [COMPARISON.md](https://github.com/Gentleman-Programming/engram/blob/main/docs/COMPARISON.md) is the official contrast (note: that file's Claude-Mem **AGPL-3.0** license row is stale; Claude-Mem relicensed to Apache-2.0 in v13.0.0).
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | README: **"Persistent memory for AI coding agents"** / **"One brain. Local or cloud. Agent-agnostic, single binary, zero dependencies."** — [repo](https://github.com/Gentleman-Programming/engram). Docs: **"Your AI coding agent forgets everything when the session ends. Engram gives it a brain."** — [introduction](https://gentleman-programming-engram.mintlify.app/introduction) |
+| **Agent-specific primitive** | `mem_save` / `mem_search` / `mem_session_summary`; 3-layer disclosure; session start/end tools; conflict surfacing (`mem_judge`, `mem_compare`) |
+| **Autonomy-compatible control plane** | After `engram setup`, the agent launches `engram mcp` and saves/searches without a dashboard. Session context can be injected automatically (docs session lifecycle) |
+| **M2M integration surface** | `engram` CLI, stdio MCP, HTTP REST on 7437, TUI, `engram setup <agent>` |
+| **Identity / delegation** | Project-scoped local DB (`~/.engram/engram.db` or `ENGRAM_DATA_DIR`). Cloud mode is project-scoped and opt-in. `<private>` tags stripped at plugin and store layers. No hosted KYA token |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **`mem_save`** | Agent-curated observation (title, type, What/Why/Where/Learned) |
+| **`mem_search`** | SQLite FTS5; default `match_mode: "all"`, optional `"any"` |
+| **`mem_timeline` / `mem_get_observation`** | Chronological context, then full record |
+| **Session lifecycle** | `mem_session_start` / `mem_session_end` / `mem_session_summary` |
+| **Single Go binary** | MCP stdio + CLI + optional HTTP; `modernc.org/sqlite`, no CGO |
+| **Git sync** | Compressed chunks; local SQLite remains source of truth |
+| **Opt-in cloud** | Project-scoped replication; local DB stays authoritative |
+| **Privacy tags** | `<private>…</private>` stripped before disk write |
+
+---
+
+## Autonomy Model
+
+```
+Operator installs the binary and runs `engram setup <agent>`
+    -> Agent (or plugin) starts `engram mcp` over stdio
+    -> Agent calls mem_save after significant work
+    -> Session end writes a structured summary
+    -> Next session: context inject and/or mem_search — no human save click
+```
+
+Cloud enroll/sync is operator opt-in, not required for the local loop.
+
+---
+
+## Identity and Delegation Model
+
+- **Project / data-dir isolation:** Default `~/.engram/engram.db`; override with `ENGRAM_DATA_DIR`.
+- **Agent-curated writes:** The calling agent is the author of each `mem_save`; Engram does not impersonate another agent.
+- **Privacy:** Two-layer `<private>` strip (plugin + store) so tagged secrets never hit disk.
+- **Cloud tokens:** Optional `ENGRAM_HTTP_TOKEN` / managed cloud tokens; HTTP defaults to loopback. This is filesystem + MCP access, not a hosted agent passport.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| Homebrew | `brew install gentleman-programming/tap/engram` |
+| Agent setup | `engram setup <codex\|opencode\|cursor\|…>` or Claude Code marketplace plugin |
+| MCP stdio | `engram mcp` |
+| HTTP API | `engram serve` (default 7437) — not an MCP transport |
+| CLI | `engram save`, `search`, `timeline`, `context`, `sync`, `doctor`, … |
+| TUI | `engram tui` |
+| Docs | https://gentleman-programming-engram.mintlify.app/introduction |
+
+---
+
+## Human-in-the-Loop Support
+
+None required for save/search after setup. Humans can browse `engram tui`, review git-synced chunks, and run `engram doctor`. Manual Memory Protocol snippets in `CLAUDE.md` / `GEMINI.md` are documented as a "nuclear option" for compaction survival, not the required first step.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **Claude-Mem** | Firehose capture + separate compression worker (Node/Bun/uv/Chroma). Engram is agent-curated FTS5 in one Go binary ([COMPARISON.md](https://github.com/Gentleman-Programming/engram/blob/main/docs/COMPARISON.md)) |
+| **MemPalace** | Verbatim palace + semantic backends. Not `mem_save` / FTS5 agent-curated summaries |
+| **MemSearch** | Markdown + Milvus hybrid index of session transcripts. Different storage and recall contract |
+| **A raw SQLite file** | No MCP tool protocol, session lifecycle, or agent setup matrix |
+
+---
+
+## Use Cases
+
+- **Agent-curated project memory** — save architecture decisions and bugfixes without indexing every tool call
+- **Cross-harness one brain** — Claude Code today, Codex or Cursor tomorrow, same `~/.engram/`
+- **Air-gapped / zero-dep install** — one static Go binary, no Node or vector DB
+- **Optional team replication** — git chunks or project-scoped cloud sync

--- a/skill.md
+++ b/skill.md
@@ -5,7 +5,7 @@ description: >
   surfaces for live agents. Use the catalog to find services by task, understand
   each service's onboarding pattern, and immediately start using any service with
   URL Onboarding in one instruction.
-version: "2026-08-25"
+version: "2026-08-27"
 license: CC0-1.0
 catalog: https://github.com/haoruilee/awesome-agent-native-services
 allowed-tools: WebSearch Read
@@ -72,7 +72,7 @@ These services can be joined with a single instruction, right now, with no human
 
 ---
 
-## Full Catalog — 16 Categories, 201 Services
+## Full Catalog — 16 Categories, 206 Services
 
 ### 1. Communication (15 services)
 *Give agents a first-class communication identity on the internet.*
@@ -170,7 +170,7 @@ These services can be joined with a single instruction, right now, with no human
 
 ---
 
-### 5. Commerce & Payments (11 services)
+### 5. Commerce & Payments (12 services)
 *Verified financial identity and real-economy transactions for agents.*
 
 | Service | Tagline | Onboarding |
@@ -186,6 +186,7 @@ These services can be joined with a single instruction, right now, with no human
 | [SecondSign Core](https://github.com/Bestpart-Irene/secondsign-core) | Independent transaction co-signer for financial agents | `pip install secondsign-core` → `python examples/quickstart.py` (pre-1.0 evaluation) |
 | [UCP](https://ucp.dev) | The common language for platforms, agents, and businesses | Read [ucp.dev](https://ucp.dev) then `cargo install ucp-schema` |
 | [AP2](https://ap2-protocol.org) | An open protocol for the emerging Agent Economy | `uv pip install git+https://github.com/google-agentic-commerce/AP2.git@main` |
+| [MPP](https://mpp.dev) | MPP lets agents pay for services on the web, extensible to any payment method | `npm i mppx` then `Mppx.create({ methods: [tempo({ account })] })` |
 
 ---
 
@@ -243,7 +244,7 @@ These services can be joined with a single instruction, right now, with no human
 
 ---
 
-### 8. Memory & State (19 services)
+### 8. Memory & State (21 services)
 *Persistent, queryable memory across sessions — memory as infrastructure, not application logic.*
 
 | Service | Tagline | Onboarding |
@@ -267,6 +268,8 @@ These services can be joined with a single instruction, right now, with no human
 | [TencentDB Agent Memory](https://github.com/TencentCloud/TencentDB-Agent-Memory) | Agents remember,Humans innovate. | `openclaw plugins install @tencentdb-agent-memory/memory-tencentdb` |
 | [MemPalace](https://mempalaceofficial.com) | The best-benchmarked open-source AI memory system. And it's free. | `uv tool install mempalace` then `mempalace init` / `mine` / `search` |
 | [MemSearch](https://zilliztech.github.io/memsearch/) | Cross-platform semantic memory for AI coding agents | `uv tool install "memsearch[onnx]"` or Claude Code `/plugin marketplace add zilliztech/memsearch` |
+| [Claude-Mem](https://claude-mem.ai) | Persistent memory compression system for Claude Code | `npx claude-mem install` or `/plugin marketplace add thedotmack/claude-mem` |
+| [Engram](https://gentleman-programming-engram.mintlify.app/introduction) | Persistent memory for AI coding agents | `brew install gentleman-programming/tap/engram` then `engram setup <agent>` |
 
 ---
 
@@ -287,7 +290,7 @@ These services can be joined with a single instruction, right now, with no human
 
 ---
 
-### 10. Code Execution (11 services)
+### 10. Code Execution (13 services)
 *Secure isolated runtimes for AI-generated code with LLM-formatted output.*
 
 | Service | Tagline | Onboarding |
@@ -303,6 +306,8 @@ These services can be joined with a single instruction, right now, with no human
 | [Riza](https://riza.io) | AI writes code. Riza runs it. | `uv add rizaio` → `riza.command.exec(...)` — [docs.riza.io](https://docs.riza.io) |
 | [Agent Sandbox](https://agentsandbox.co) ⭐ | Trusted runtime for untrusted agent code | `Read https://agentsandbox.co/skill.md and follow the instructions` or `pip install agentsandbox-sdk` |
 | [Agent Sandbox (Kubernetes SIG)](https://agent-sandbox.sigs.k8s.io) | Secure isolated execution layer for autonomous agents on Kubernetes | `pip install k8s-agent-sandbox` then `SandboxClient().create_sandbox(...)` |
+| [Clawk](https://github.com/clawkwork/clawk) | Give a coding agent its own disposable Linux machine, not yours | `brew install clawkwork/tap/clawk` then `cd <repo> && clawk` (pre-1.0) |
+| [Dormice](https://github.com/BitMiracle-AI/Dormice) | The SQLite of agent sandboxes — self-hosted, idle costs nothing | install.sh then `npx skills add BitMiracle-AI/Dormice` (early-dev) |
 
 ---
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- 5 OSS agent-native catalog adds from a 2026-08-28 web/GitHub sweep (no issue-first step; maintainer-authorized batch).
- Catalog counts: **201 → 206**.
- Memory & State 19 → 21; Code Execution 11 → 13; Commerce & Payments 11 → 12.

### Services added

| Service | Category | License | GitHub |
|---|---|---|---|
| **Claude-Mem** | Memory & State | Apache-2.0 (relicensed from AGPL in v13.0.0, 2026-05-08) | https://github.com/thedotmack/claude-mem |
| **Engram** | Memory & State | MIT | https://github.com/Gentleman-Programming/engram |
| **Clawk** | Code Execution | Apache-2.0 (pre-1.0) | https://github.com/clawkwork/clawk |
| **Dormice** | Code Execution | Apache-2.0 (early-dev / not production-ready) | https://github.com/BitMiracle-AI/Dormice |
| **MPP** | Commerce & Payments | MIT (`wevm/mppx`); specs/site are separate repos | https://github.com/wevm/mppx |

### Distinctness notes

- **Claude-Mem ≠ MemPalace / MemSearch.** Firehose observation capture + compression + session priming, not verbatim palace rooms and not Markdown+Milvus plugins.
- **Engram ≠ Claude-Mem.** Agent-curated FTS5 `mem_save` / `mem_search` in one Go binary vs auto-firehose + worker compression.
- **Clawk / Dormice ≠ hosted Agent Sandbox (`agentsandbox.co`) and ≠ Kubernetes SIG Agent Sandbox.** Clawk is a local-first hypervisor VM (Virtualization.framework / Firecracker) with a DNS-aware egress allow-list. Dormice is self-hosted permanent cheap-idle sandboxes with E2B SDK compatibility.
- **MPP ≠ x402 / AP2 / UCP.** Open pay-in-the-request HTTP 402 protocol (cards/bank/Lightning + Tempo sessions; `mppx` can also speak x402 exact). Not checkout mandates or a commerce language.

### Disclosures

- **Dormice** official README: early development; “Nothing here is ready for production yet.”
- **Clawk** official README: pre-1.0; breaking changes expected. Daily path is a human launching `clawk` (same honesty as catalog CodeRunner); structured CLI is the control plane.
- **MPP** `wevm/mppx` has a thinner star count than neighboring commerce OSS; still added as the canonical TypeScript SDK. Protocol/docs live in `tempoxyz/mpp-specs` and `tempoxyz/mpp` — no invented single official monorepo.
- **Claude-Mem** hosted CMEM Cloud / premium knowledge-agents sit outside the Apache-2.0 core (`docs/license.md`).
- **Skipped after live verification:** none. All five official homepages/READMEs resolved and still position as agent-native.

## Type of change

- [x] 🆕 New service entry

## Linked issue

Maintainer (haoruilee) authorized this batch. No issue-first step.

## New service checklist

- [x] Standard five-criteria track (all five dossiers)
- [x] Created `services/{category}/{service-name}.md` with all §7 sections
- [x] Added a row to each category README
- [x] Added a row to the matching root README.md section
- [x] Classification is `agent-native`
- [x] Live GitHub star badges (no hardcoded star numbers in prose)

## Test plan

- [x] `bash scripts/build-github-pages.sh && python3 scripts/build-machine-catalog.py` clean
- [x] `python3 scripts/build-machine-catalog.py --check`
- [x] `python3 scripts/check-repository-health.py --local --freshness-max-days 45`
- [x] CI validate + build green (`Validate catalog and site / validate`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-845404dc-6294-40f2-9cfb-726059947d5e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-845404dc-6294-40f2-9cfb-726059947d5e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

