### PR TITLE
[Maintenance] Fix Respan and AP2 canonical URLs

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -11,7 +11,7 @@
     "service_directory": "services",
     "content_digest": {
       "algorithm": "sha256",
-      "value": "e49c559e4f106007f0c783256fbd7fd87462b1dae92310cd72a71932dc3114c0",
+      "value": "f63a78fa2fe8407462e7a721af15efd39399c91c33046982f90be33e3a57a57c",
       "input_paths": [
         "README.md",
         "skill.md",
@@ -2442,8 +2442,8 @@
       "onboarding": {
         "type": "sdk",
         "pattern": "SDK + scenario samples",
-        "instruction": "# Types package (PyPI later; official install is from git)\nuv pip install git+https://github.com/google-agentic-commerce/AP2.git@main",
-        "url": "https://github.com/google-agentic-commerce/AP2.git@main"
+        "instruction": "# Types package (PyPI later; official install is from git): https://github.com/google-agentic-commerce/AP2\nuv pip install git+https://github.com/google-agentic-commerce/AP2.git@main",
+        "url": "https://github.com/google-agentic-commerce/AP2"
       },
       "protocols": [
         "sdk",

--- a/docs/catalog.json
+++ b/docs/catalog.json
@@ -11,7 +11,7 @@
     "service_directory": "services",
     "content_digest": {
       "algorithm": "sha256",
-      "value": "e49c559e4f106007f0c783256fbd7fd87462b1dae92310cd72a71932dc3114c0",
+      "value": "f63a78fa2fe8407462e7a721af15efd39399c91c33046982f90be33e3a57a57c",
       "input_paths": [
         "README.md",
         "skill.md",
@@ -2442,8 +2442,8 @@
       "onboarding": {
         "type": "sdk",
         "pattern": "SDK + scenario samples",
-        "instruction": "# Types package (PyPI later; official install is from git)\nuv pip install git+https://github.com/google-agentic-commerce/AP2.git@main",
-        "url": "https://github.com/google-agentic-commerce/AP2.git@main"
+        "instruction": "# Types package (PyPI later; official install is from git): https://github.com/google-agentic-commerce/AP2\nuv pip install git+https://github.com/google-agentic-commerce/AP2.git@main",
+        "url": "https://github.com/google-agentic-commerce/AP2"
       },
       "protocols": [
         "sdk",

--- a/services/commerce-and-payments/ap2.md
+++ b/services/commerce-and-payments/ap2.md
@@ -32,8 +32,10 @@ https://github.com/google-agentic-commerce/AP2
 
 **Interaction pattern:** `SDK` + scenario samples
 
+Install the types package from [google-agentic-commerce/AP2](https://github.com/google-agentic-commerce/AP2) (PyPI later; official install is from git):
+
 ```bash
-# Types package (PyPI later; official install is from git)
+# Types package (PyPI later; official install is from git): https://github.com/google-agentic-commerce/AP2
 uv pip install git+https://github.com/google-agentic-commerce/AP2.git@main
 ```
 

--- a/services/llm-gateway-and-routing/keywords-ai.md
+++ b/services/llm-gateway-and-routing/keywords-ai.md
@@ -23,7 +23,7 @@ Title: *Respan | LLM Engineering Platform*. [About](https://www.respan.ai/about)
 
 ## Official Repo
 
-No primary open-source gateway repo — integration is **OpenAI-compatible** HTTP. Live gateway copy uses base URL `https://api.respan.ai/api` ([AI Gateway](https://www.respan.ai/ai-gateway), [provider inference docs](https://www.respan.ai/docs/integrations/gateway/model-providers/inference.md)). `https://api.keywordsai.co` still returned HTTP 200 on 2026-08-29; prefer the Respan host the current docs publish.
+No primary open-source gateway repo — integration is **OpenAI-compatible** HTTP. Live gateway host: https://api.respan.ai/ (`{"status":"ok"}`). SDK/docs still use base URL `https://api.respan.ai/api` ([AI Gateway](https://www.respan.ai/ai-gateway), [provider inference docs](https://www.respan.ai/docs/integrations/gateway/model-providers/inference.md)). `https://api.keywordsai.co` still returned HTTP 200 on 2026-08-29; prefer the Respan host the current docs publish.
 
 ---
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Type of change

- [x] 🔧 Repository maintenance (canonical URL hygiene for the scheduled freshness check)

---

## Why

Scheduled workflow **Catalog freshness and links** failed on `main` ([run 33398418266](https://github.com/haoruilee/awesome-agent-native-services/actions/runs/33398418266), 2026-08-31). Job `audit` / `scripts/check-repository-health.py --external-canonical`: 509 checked, 2 FAIL. Both services are alive; the checkable canonical URLs were wrong.

No services added or removed. Catalog stays **208 / 16**.

---

## Fixes

| Service | What the checker extracted | Why it failed | New checkable URL |
|---|---|---|---|
| **Respan** (`keywords-ai.md`) | `https://api.respan.ai/api` | GET 404 (`"/api" endpoint does not exist`) | `https://api.respan.ai/` — GET 200 `{"status":"ok"}` |
| **AP2** (`ap2.md`) | `https://github.com/google-agentic-commerce/AP2.git@main` | pip `git+…@main` scraped as a naked HTTP URL → 404 | `https://github.com/google-agentic-commerce/AP2` — GET 200 |

SDK `base_url="https://api.respan.ai/api/"` and `uv pip install git+https://github.com/google-agentic-commerce/AP2.git@main` stay in samples / the fenced install command.

`--external-canonical` reads Official Website/Repo first URLs plus catalog `website`, `repository`, `onboarding.url`, and `verification_sources`. These edits only change those extracted fields.

---

## Test plan

- [x] `python3 scripts/build-machine-catalog.py` — 208 services / 16 categories
- [x] `python3 scripts/build-machine-catalog.py --check`
- [x] `python3 scripts/check-repository-health.py --local` — 699 links, 208 services
- [x] Checker-style GET of the two new canonicals: 200 / 200
- [x] Old failers (`/api`, `.git@main`) are no longer in the canonical URL set
- [x] Local `--external-canonical`: Respan + AP2 **OK**. Remaining 2 FAILs are unrelated `cymetica.com` timeouts (not touched).
- [x] PR CI `Validate catalog and site` green

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5498efc7-23d2-41f8-a2b0-bb37c5a8c937?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5498efc7-23d2-41f8-a2b0-bb37c5a8c937&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

