### PR TITLE
[New Service] September 3 OSS catalog additions

### DIFF
--- a/.skills/add-to-awesome-list/SKILL.md
+++ b/.skills/add-to-awesome-list/SKILL.md
@@ -9,7 +9,7 @@ license: CC0-1.0
 compatibility: Works with agents that can read repository files and browse official sources.
 metadata:
   repo: https://github.com/haoruilee/awesome-agent-native-services
-  catalog-version: "2026-08-29"
+  catalog-version: "2026-09-03"
 allowed-tools: WebSearch Read Bash
 ---
 

--- a/.skills/evaluate-agent-native/SKILL.md
+++ b/.skills/evaluate-agent-native/SKILL.md
@@ -8,7 +8,7 @@ license: CC0-1.0
 compatibility: Works with agents that can inspect official websites, repositories, and protocol documentation.
 metadata:
   repo: https://github.com/haoruilee/awesome-agent-native-services
-  catalog-version: "2026-08-29"
+  catalog-version: "2026-09-03"
 allowed-tools: WebSearch Read
 ---
 

--- a/.skills/find-agent-service/SKILL.md
+++ b/.skills/find-agent-service/SKILL.md
@@ -9,7 +9,7 @@ license: CC0-1.0
 compatibility: Works with any agent that can read markdown files and call web searches.
 metadata:
   repo: https://github.com/haoruilee/awesome-agent-native-services
-  catalog-version: "2026-08-29"
+  catalog-version: "2026-09-03"
 allowed-tools: WebSearch Read
 ---
 

--- a/.skills/install-agent-service/SKILL.md
+++ b/.skills/install-agent-service/SKILL.md
@@ -9,7 +9,7 @@ license: CC0-1.0
 compatibility: Works with Claude Code plugin skills and agents that can read SKILL.md.
 metadata:
   repo: https://github.com/haoruilee/awesome-agent-native-services
-  catalog-version: "2026-08-29"
+  catalog-version: "2026-09-03"
 allowed-tools: WebSearch Read Bash
 ---
 

--- a/README.md
+++ b/README.md
@@ -83,23 +83,23 @@ Recommended flow for agents: start with `skill.md` for quick discovery, switch t
 
 ## Categories
 
-**208 services across 16 categories.**
+**216 services across 16 categories.**
 
 | # | Category | Services | Description |
 |---|---|---|---|
 | 1 | [Communication](#1-communication-services) | 15 | Give agents a communication identity on the internet |
 | 2 | [Browser & Web Execution](#2-browser--web-execution-services) | 25 | Remote browser and web data extraction for agents |
-| 3 | [Tool Access & Integration](#3-tool-access--integration-services) | 19 | Runtime tool discovery, auth, and execution |
+| 3 | [Tool Access & Integration](#3-tool-access--integration-services) | 21 | Runtime tool discovery, auth, and execution |
 | 4 | [Oversight & Approval](#4-oversight--approval-services) | 5 | Human-in-the-loop approval and escalation |
 | 5 | [Commerce & Payments](#5-commerce--payment-services) | 12 | Agent-native wallets, identity, and transactions |
 | 6 | [Agent Runtime & Infrastructure](#6-agent-runtime--infrastructure-services) | 29 | Execution, session isolation, secrets, and gateway |
 | 7 | [Agent Harnesses & Operator Surfaces](#7-agent-harnesses--operator-surfaces) | 10 | Durable agent-loop control and live operator visibility |
-| 8 | [Memory & State](#8-memory--state-services) | 21 | Persistent agent memory across sessions |
+| 8 | [Memory & State](#8-memory--state-services) | 26 | Persistent agent memory across sessions |
 | 9 | [Search & Web Intelligence](#9-search--web-intelligence-services) | 9 | LLM-optimized web search and content retrieval |
 | 10 | [Code Execution](#10-code-execution-services) | 13 | Secure sandboxes for AI-generated code |
 | 11 | [Observability & Tracing](#11-observability--tracing-services) | 13 | Agent trajectory tracing and evaluation |
 | 12 | [Durable Execution & Scheduling](#12-durable-execution--scheduling-services) | 6 | Fault-tolerant long-running agent workflows |
-| 13 | [Meeting & Conversation](#13-meeting--conversation-services) | 7 | Agent presence in voice and video meetings |
+| 13 | [Meeting & Conversation](#13-meeting--conversation-services) | 8 | Agent presence in voice and video meetings |
 | 14 | [Voice & Phone](#14-voice--phone-services) | 7 | Agent-controlled voice calls and phone infrastructure |
 | 15 | [LLM Gateway & Routing](#15-llm-gateway--routing-services) | 10 | Per-agent budget, routing, caching, and observability for LLM calls |
 | 16 | [Agent Social & Community](#16-agent-social--community-services) | 7 | Social networks where agents are first-class participants |
@@ -199,6 +199,8 @@ Recommended flow for agents: start with `skill.md` for quick discovery, switch t
 | [SandBase CLI](services/tool-access-and-integration/sandbase-cli.md) [![⭐](https://img.shields.io/github/stars/sandbaseai/cli?style=social)](https://github.com/sandbaseai/cli) | Give your AI agent superpowers. One command. 2,000+ AI models. | Local MCP bridge · discover/inspect/run · client-scoped credentials · Agent Skill | ✅ | Immutable `v0.1.17` tarball: `npx -y https://github.com/sandbaseai/cli/releases/download/v0.1.17/sandbaseai-cli-0.1.17.tgz connect`, then `npx skills add sandbaseai/cli --skill sandbase` |
 | [ContextForge](services/tool-access-and-integration/contextforge.md) [![⭐](https://img.shields.io/github/stars/IBM/mcp-context-forge?style=social)](https://github.com/IBM/mcp-context-forge) | Registry and proxy that federates MCP, A2A, and REST/gRPC | Federated MCP · A2A routing · gRPC-to-MCP · UAID · OTEL | ✅ | `uvx --from mcp-contextforge-gateway mcpgateway --host 0.0.0.0 --port 4444` — or `docker pull ghcr.io/ibm/mcp-context-forge:latest` |
 | [MCP Gateway & Registry](services/tool-access-and-integration/mcp-gateway-registry.md) [![⭐](https://img.shields.io/github/stars/agentic-community/mcp-gateway-registry?style=social)](https://github.com/agentic-community/mcp-gateway-registry) | Unified Agent & MCP Server Registry – Gateway for AI Development Tools | IdP gateway · virtual MCP · A2A registry · 3LO egress · audit | ✅ | `git clone https://github.com/agentic-community/mcp-gateway-registry && ./build_and_run.sh --prebuilt` |
+| [MCPHub](services/tool-access-and-integration/mcphub.md) [![⭐](https://img.shields.io/github/stars/samanhappy/mcphub?style=social)](https://github.com/samanhappy/mcphub) | One gateway for all your MCP servers. | Unified `/mcp` · groups · `$smart` routing · bearer/OAuth · Docker | ✅ | `docker run -p 3000:3000 -v ./data:/app/data samanhappy/mcphub` — then connect to `http://localhost:3000/mcp` |
+| [MCPJungle](services/tool-access-and-integration/mcpjungle.md) [![⭐](https://img.shields.io/github/stars/mcpjungle/MCPJungle?style=social)](https://github.com/mcpjungle/MCPJungle) | Run all your MCP servers behind one endpoint | One `/mcp` · tool groups · enterprise client tokens · MPL-2.0 | ✅ | `docker compose up -d` then `mcpjungle register --name context7 --url https://mcp.context7.com/mcp` |
 
 ---
 
@@ -333,6 +335,11 @@ Recommended flow for agents: start with `skill.md` for quick discovery, switch t
 | [MemSearch](services/memory-and-state/memsearch.md) [![⭐](https://img.shields.io/github/stars/zilliztech/memsearch?style=social)](https://github.com/zilliztech/memsearch) | Cross-platform semantic memory for AI coding agents | Markdown + Milvus hybrid search · progressive recall · harness plugins | ⚠️ | `uv tool install "memsearch[onnx]"` or `/plugin marketplace add zilliztech/memsearch` |
 | [Claude-Mem](services/memory-and-state/claude-mem.md) [![⭐](https://img.shields.io/github/stars/thedotmack/claude-mem?style=social)](https://github.com/thedotmack/claude-mem) | Persistent memory compression system for Claude Code | Auto-firehose observations · compression worker · session priming · MCP search | ✅ | `npx claude-mem install` or `/plugin marketplace add thedotmack/claude-mem` then `/plugin install claude-mem` |
 | [Engram](services/memory-and-state/engram.md) [![⭐](https://img.shields.io/github/stars/Gentleman-Programming/engram?style=social)](https://github.com/Gentleman-Programming/engram) | Persistent memory for AI coding agents | Agent-curated `mem_save`/`mem_search` · SQLite FTS5 · single Go binary | ✅ | `brew install gentleman-programming/tap/engram` then `claude plugin install engram` or `engram setup <agent>` |
+| [Beads](services/memory-and-state/beads.md) [![⭐](https://img.shields.io/github/stars/gastownhall/beads?style=social)](https://github.com/gastownhall/beads) | Dependency-aware, Dolt-backed issue tracker built for AI coding agents that survive context loss | `bd ready`/`claim` · hash IDs · Dolt sync · `bd prime` | ✅ | `brew install beads` then `bd init --quiet` and `bd setup claude` |
+| [projectmem](services/memory-and-state/projectmem.md) [![⭐](https://img.shields.io/github/stars/riponcm/projectmem?style=social)](https://github.com/riponcm/projectmem) | We don't make AI smarter. We make it experienced. | Typed event log · `pjm precheck` · one MCP for every project | ✅ | `pip install -U projectmem` then `pjm doctor --fix` and wire `python -m projectmem.mcp_server` |
+| [Memoir](services/memory-and-state/memoir.md) [![⭐](https://img.shields.io/github/stars/zhangfengcdt/memoir?style=social)](https://github.com/zhangfengcdt/memoir) | Git for AI Memory | Semantic paths · branch/merge · `memoir-mcp` · Alpha | ✅ | `pip install memoir-ai` or `/plugin marketplace add zhangfengcdt/memoir` |
+| [Memorix](services/memory-and-state/memorix.md) [![⭐](https://img.shields.io/github/stars/AVIDS2/memorix?style=social)](https://github.com/AVIDS2/memorix) | Local-first shared memory layer for AI coding agents. | Git-root daemon · Workset · Git Memory · `memorix serve` | ✅ | `npm install -g memorix` then `memorix setup --agent claude --global` |
+| [Compartment](services/memory-and-state/compartment.md) [![⭐](https://img.shields.io/github/stars/MaxFreedomPollard/Compartment?style=social)](https://github.com/MaxFreedomPollard/Compartment) | Encrypted, fully offline memory for AI agents. | Encrypted vault · one-claim memories · `compartment serve` | ✅ | `pip install compartment && compartment init && compartment integrate claude` |
 
 ---
 
@@ -436,6 +443,7 @@ Recommended flow for agents: start with `skill.md` for quick discovery, switch t
 | [Daily Agent Toolkit](services/meeting-and-conversation/daily-agent.md) [![⭐](https://img.shields.io/github/stars/daily-co/daily-python?style=social)](https://github.com/daily-co/daily-python) | Build realtime meeting agents on Daily | Programmatic room control · Media stream hooks · Bot orchestration | ⚠️ | `pip install daily-python` then integrate room/bot lifecycle APIs |
 | [Looped Meet](services/meeting-and-conversation/looped-meet.md) [![⭐](https://img.shields.io/github/stars/loopedautomation/meet?style=social)](https://github.com/loopedautomation/meet) | Dial your agent into your next meeting | Agent participant · LiveKit media · TTY WebSocket bridge · self-hosted room | ⚠️ | Clone [loopedautomation/meet](https://github.com/loopedautomation/meet), set the documented secrets, then `docker compose up` |
 | [AgentCall](services/meeting-and-conversation/agentcall.md) [![⭐](https://img.shields.io/github/stars/pattern-ai-labs/agentcall?style=social)](https://github.com/pattern-ai-labs/agentcall) | Your AI agent, in every meeting. | join-meeting skill · live TTS/transcript · screenshot/screenshare · Meet/Zoom/Teams | ⚠️ | `/plugin marketplace add pattern-ai-labs/agentcall` then `/plugin install join-meeting@agentcall` |
+| [joinly.ai](services/meeting-and-conversation/joinly.md) [![⭐](https://img.shields.io/github/stars/joinly-ai/joinly?style=social)](https://github.com/joinly-ai/joinly) | Make your meetings accessible to AI Agents! | MCP join/speak/transcript · Zoom/Meet/Teams · `joinly-client` | ✅ | `docker run -p 127.0.0.1:8000:8000 ghcr.io/joinly-ai/joinly:latest` then `uvx joinly-client --env-file .env <MeetingUrl>` |
 
 ---
 

--- a/catalog.json
+++ b/catalog.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://lihaorui.com/awesome-agent-native-services/catalog.schema.json",
   "schema_version": "1.0.0",
-  "catalog_version": "2026-08-29",
-  "generated_at": "2026-08-29",
+  "catalog_version": "2026-09-03",
+  "generated_at": "2026-09-03",
   "license": "CC0-1.0",
   "source": {
     "repository": "https://github.com/haoruilee/awesome-agent-native-services",
@@ -11,7 +11,7 @@
     "service_directory": "services",
     "content_digest": {
       "algorithm": "sha256",
-      "value": "717b3953c24756672538776775910bff9c25a971bd10f3cf06eebbd9479bc741",
+      "value": "0b712151afe6ec98343ec5e01c07e3e622ef8f009b7a111b034abf4beee2694b",
       "input_paths": [
         "README.md",
         "skill.md",
@@ -68,6 +68,8 @@
         "services/tool-access-and-integration/google-mcp-toolbox.md",
         "services/tool-access-and-integration/mcp-gateway-registry.md",
         "services/tool-access-and-integration/mcpgateway.md",
+        "services/tool-access-and-integration/mcphub.md",
+        "services/tool-access-and-integration/mcpjungle.md",
         "services/tool-access-and-integration/nango.md",
         "services/tool-access-and-integration/obot.md",
         "services/tool-access-and-integration/openchatcut.md",
@@ -139,8 +141,10 @@
         "services/agent-harnesses-and-control-planes/ruflo.md",
         "services/memory-and-state/README.md",
         "services/memory-and-state/agentmemory.md",
+        "services/memory-and-state/beads.md",
         "services/memory-and-state/claude-mem.md",
         "services/memory-and-state/cognee.md",
+        "services/memory-and-state/compartment.md",
         "services/memory-and-state/engram.md",
         "services/memory-and-state/ensue.md",
         "services/memory-and-state/hindsight.md",
@@ -150,12 +154,15 @@
         "services/memory-and-state/mem9.md",
         "services/memory-and-state/memmachine.md",
         "services/memory-and-state/memmy-agent.md",
+        "services/memory-and-state/memoir.md",
         "services/memory-and-state/memoria.md",
+        "services/memory-and-state/memorix.md",
         "services/memory-and-state/memos.md",
         "services/memory-and-state/mempalace.md",
         "services/memory-and-state/memsearch.md",
         "services/memory-and-state/memu.md",
         "services/memory-and-state/openviking.md",
+        "services/memory-and-state/projectmem.md",
         "services/memory-and-state/recall.md",
         "services/memory-and-state/tencentdb-agent-memory.md",
         "services/memory-and-state/zep.md",
@@ -207,6 +214,7 @@
         "services/meeting-and-conversation/README.md",
         "services/meeting-and-conversation/agentcall.md",
         "services/meeting-and-conversation/daily-agent.md",
+        "services/meeting-and-conversation/joinly.md",
         "services/meeting-and-conversation/looped-meet.md",
         "services/meeting-and-conversation/meeting-baas.md",
         "services/meeting-and-conversation/meetstream.md",
@@ -244,7 +252,7 @@
   },
   "counts": {
     "categories": 16,
-    "services": 208
+    "services": 216
   },
   "categories": [
     {
@@ -266,7 +274,7 @@
       "name": "Tool Access & Integration",
       "description": "Services that let AI agents discover, authenticate, and invoke external tools at runtime — without a human pre-configuring credentials or selecting which integrations to activate.",
       "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/README.md",
-      "service_count": 19
+      "service_count": 21
     },
     {
       "id": "oversight-and-approval",
@@ -301,7 +309,7 @@
       "name": "Memory & State",
       "description": "Services that give AI agents persistent, queryable memory across sessions — treating memory as infrastructure rather than application logic, and managing the full lifecycle of what agents remember, forget, and retrieve.",
       "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/README.md",
-      "service_count": 21
+      "service_count": 26
     },
     {
       "id": "search-and-web-intelligence",
@@ -336,7 +344,7 @@
       "name": "Meeting & Conversation",
       "description": "Services that give AI agents a programmatic presence in voice and video conversations — letting agents join meetings, process real-time audio, and participate in synchronous communication without a human operating a client.",
       "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/meeting-and-conversation/README.md",
-      "service_count": 7
+      "service_count": 8
     },
     {
       "id": "voice-and-phone",
@@ -1950,6 +1958,72 @@
       "latest_month_signal": null,
       "verified_at": null,
       "verification_sources": []
+    },
+    {
+      "id": "tool-access-and-integration/mcphub",
+      "slug": "mcphub",
+      "name": "MCPHub",
+      "tagline": "One gateway for all your MCP servers.",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "tool-access-and-integration",
+      "website": "https://www.mcphub.app",
+      "repository": "https://github.com/samanhappy/mcphub",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/mcphub.md",
+      "source_path": "services/tool-access-and-integration/mcphub.md",
+      "onboarding": {
+        "type": "mcp",
+        "pattern": "CLI + MCP gateway",
+        "instruction": "docker run -p 3000:3000 \\\n  -v ./mcp_settings.json:/app/mcp_settings.json \\\n  -v ./data:/app/data \\\n  samanhappy/mcphub",
+        "url": "http://localhost:3000/mcp"
+      },
+      "protocols": [
+        "mcp",
+        "cli",
+        "http"
+      ],
+      "mcp_status": "available",
+      "agent_skill_status": "unavailable",
+      "latest_month_signal": "Last GitHub push 2026-09-03 (repo metadata); Docker samanhappy/mcphub; demo https://demo.mcphub.app/",
+      "verified_at": "2026-09-03",
+      "verification_sources": [
+        "https://api.github.com/repos/samanhappy/mcphub",
+        "https://demo.mcphub.app/"
+      ]
+    },
+    {
+      "id": "tool-access-and-integration/mcpjungle",
+      "slug": "mcpjungle",
+      "name": "MCPJungle",
+      "tagline": "Run all your MCP servers behind one endpoint",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "tool-access-and-integration",
+      "website": "https://docs.mcpjungle.com",
+      "repository": "https://github.com/mcpjungle/MCPJungle",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/mcpjungle.md",
+      "source_path": "services/tool-access-and-integration/mcpjungle.md",
+      "onboarding": {
+        "type": "mcp",
+        "pattern": "CLI + MCP gateway",
+        "instruction": "curl -O https://raw.githubusercontent.com/mcpjungle/MCPJungle/refs/heads/main/docker-compose.yaml\ndocker compose up -d\nbrew install mcpjungle/mcpjungle/mcpjungle\nmcpjungle register --name context7 --url https://mcp.context7.com/mcp",
+        "url": "https://raw.githubusercontent.com/mcpjungle/MCPJungle/refs/heads/main/docker-compose.yaml"
+      },
+      "protocols": [
+        "mcp",
+        "cli",
+        "http",
+        "api"
+      ],
+      "mcp_status": "available",
+      "agent_skill_status": "unavailable",
+      "latest_month_signal": "Last GitHub push 2026-08-02 (repo metadata) — quieter than neighboring gateways; docs site and Docker Compose path still live as of 2026-09-03",
+      "verified_at": "2026-09-03",
+      "verification_sources": [
+        "https://api.github.com/repos/mcpjungle/MCPJungle"
+      ]
     },
     {
       "id": "tool-access-and-integration/nango",
@@ -4014,6 +4088,40 @@
       ]
     },
     {
+      "id": "memory-and-state/beads",
+      "slug": "beads",
+      "name": "Beads",
+      "tagline": "Dependency-aware, Dolt-backed issue tracker built for AI coding agents that survive context loss",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "memory-and-state",
+      "website": "https://beads.gascity.com",
+      "repository": "https://github.com/gastownhall/beads",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/beads.md",
+      "source_path": "services/memory-and-state/beads.md",
+      "onboarding": {
+        "type": "mcp",
+        "pattern": "CLI + optional MCP / agent setup recipes",
+        "instruction": "brew install beads\n# or: curl -fsSL https://raw.githubusercontent.com/gastownhall/beads/main/scripts/install.sh | bash\n# or: npm install -g @beads/bd\n\ncd your-project\nbd init --quiet\nbd setup claude    # also: codex, cursor, factory, mux, gemini, copilot, …\nbd ready --json",
+        "url": "https://raw.githubusercontent.com/gastownhall/beads/main/scripts/install.sh"
+      },
+      "protocols": [
+        "agent-skill",
+        "mcp",
+        "cli",
+        "stdio",
+        "http"
+      ],
+      "mcp_status": "optional",
+      "agent_skill_status": "available",
+      "latest_month_signal": "Last GitHub push 2026-09-03 (repo metadata); Homebrew beads, npm @beads/bd, PyPI beads-mcp",
+      "verified_at": "2026-09-03",
+      "verification_sources": [
+        "https://api.github.com/repos/gastownhall/beads"
+      ]
+    },
+    {
       "id": "memory-and-state/claude-mem",
       "slug": "claude-mem",
       "name": "Claude-Mem",
@@ -4076,6 +4184,39 @@
       "latest_month_signal": null,
       "verified_at": null,
       "verification_sources": []
+    },
+    {
+      "id": "memory-and-state/compartment",
+      "slug": "compartment",
+      "name": "Compartment",
+      "tagline": "Encrypted, fully offline memory for AI agents.",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "memory-and-state",
+      "website": "https://maxfreedompollard.github.io/Compartment/",
+      "repository": "https://github.com/MaxFreedomPollard/Compartment",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/compartment.md",
+      "source_path": "services/memory-and-state/compartment.md",
+      "onboarding": {
+        "type": "mcp",
+        "pattern": "CLI + MCP (compartment serve)",
+        "instruction": "pip install compartment && compartment init\ncompartment integrate claude      # also: hermes, openclaw, or --all\n# MCP clients without a recipe:\n# { \"mcpServers\": { \"compartment\": { \"command\": \"compartment\", \"args\": [\"serve\"] } } }",
+        "url": null
+      },
+      "protocols": [
+        "agent-skill",
+        "mcp",
+        "cli",
+        "stdio"
+      ],
+      "mcp_status": "available",
+      "agent_skill_status": "available",
+      "latest_month_signal": "Last GitHub push 2026-09-02 (repo metadata); PyPI compartment",
+      "verified_at": "2026-09-03",
+      "verification_sources": [
+        "https://api.github.com/repos/MaxFreedomPollard/Compartment"
+      ]
     },
     {
       "id": "memory-and-state/engram",
@@ -4366,6 +4507,39 @@
       ]
     },
     {
+      "id": "memory-and-state/memoir",
+      "slug": "memoir",
+      "name": "Memoir",
+      "tagline": "Git for AI Memory",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "memory-and-state",
+      "website": "https://www.memoir-ai.dev",
+      "repository": "https://github.com/zhangfengcdt/memoir",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/memoir.md",
+      "source_path": "services/memory-and-state/memoir.md",
+      "onboarding": {
+        "type": "mcp",
+        "pattern": "SDK / CLI + plugins / MCP",
+        "instruction": "pip install memoir-ai\n# Claude Code:\n#   /plugin marketplace add zhangfengcdt/memoir\n#   /plugin install memoir@memoir",
+        "url": null
+      },
+      "protocols": [
+        "agent-skill",
+        "mcp",
+        "cli",
+        "sdk"
+      ],
+      "mcp_status": "available",
+      "agent_skill_status": "available",
+      "latest_month_signal": "Last GitHub push 2026-09-03 (repo metadata); PyPI memoir-ai; Claude Code / Codex plugins",
+      "verified_at": "2026-09-03",
+      "verification_sources": [
+        "https://api.github.com/repos/zhangfengcdt/memoir"
+      ]
+    },
+    {
       "id": "memory-and-state/memoria",
       "slug": "memoria",
       "name": "Memoria",
@@ -4395,6 +4569,41 @@
       "latest_month_signal": null,
       "verified_at": null,
       "verification_sources": []
+    },
+    {
+      "id": "memory-and-state/memorix",
+      "slug": "memorix",
+      "name": "Memorix",
+      "tagline": "Local-first shared memory layer for AI coding agents.",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "memory-and-state",
+      "website": "https://github.com/AVIDS2/memorix",
+      "repository": "https://github.com/AVIDS2/memorix",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/memorix.md",
+      "source_path": "services/memory-and-state/memorix.md",
+      "onboarding": {
+        "type": "mcp",
+        "pattern": "CLI + MCP / memorix setup",
+        "instruction": "npm install -g memorix\nmemorix setup --agent claude --global\n# also: codex, copilot, cursor, pi, gemini-cli, opencode, windsurf,\n# kiro, antigravity, trae, openclaw, hermes, omp, dsh, workbuddy, …",
+        "url": null
+      },
+      "protocols": [
+        "agent-skill",
+        "mcp",
+        "cli",
+        "sdk",
+        "stdio",
+        "http"
+      ],
+      "mcp_status": "optional",
+      "agent_skill_status": "available",
+      "latest_month_signal": "Last GitHub push 2026-09-02 (repo metadata); npm memorix; listed in the official MCP Registry",
+      "verified_at": "2026-09-03",
+      "verification_sources": [
+        "https://api.github.com/repos/AVIDS2/memorix"
+      ]
     },
     {
       "id": "memory-and-state/memos",
@@ -4560,6 +4769,38 @@
       "latest_month_signal": null,
       "verified_at": null,
       "verification_sources": []
+    },
+    {
+      "id": "memory-and-state/projectmem",
+      "slug": "projectmem",
+      "name": "projectmem",
+      "tagline": "We don't make AI smarter. We make it experienced.",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "memory-and-state",
+      "website": "https://www.projectmem.dev",
+      "repository": "https://github.com/riponcm/projectmem",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/projectmem.md",
+      "source_path": "services/memory-and-state/projectmem.md",
+      "onboarding": {
+        "type": "mcp",
+        "pattern": "SDK / CLI + MCP",
+        "instruction": "pip install -U projectmem\npjm doctor\npjm doctor --fix\npjm init    # per repo — writes .projectmem/ and git hooks",
+        "url": null
+      },
+      "protocols": [
+        "mcp",
+        "cli",
+        "stdio"
+      ],
+      "mcp_status": "available",
+      "agent_skill_status": "unavailable",
+      "latest_month_signal": "Last GitHub push 2026-09-01 (repo metadata); PyPI projectmem v0.3.1 — one MCP server for every project",
+      "verified_at": "2026-09-03",
+      "verification_sources": [
+        "https://api.github.com/repos/riponcm/projectmem"
+      ]
     },
     {
       "id": "memory-and-state/recall",
@@ -6013,6 +6254,37 @@
       "latest_month_signal": null,
       "verified_at": null,
       "verification_sources": []
+    },
+    {
+      "id": "meeting-and-conversation/joinly",
+      "slug": "joinly",
+      "name": "joinly.ai",
+      "tagline": "Make your meetings accessible to AI Agents!",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "meeting-and-conversation",
+      "website": "https://joinly.ai",
+      "repository": "https://github.com/joinly-ai/joinly",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/meeting-and-conversation/joinly.md",
+      "source_path": "services/meeting-and-conversation/joinly.md",
+      "onboarding": {
+        "type": "mcp",
+        "pattern": "CLI + MCP server",
+        "instruction": "docker pull ghcr.io/joinly-ai/joinly:latest\n# Quickstart client-in-container (no external MCP):\ndocker run --env-file .env ghcr.io/joinly-ai/joinly:latest --client <MeetingURL>\n\n# Server mode — bind localhost only:\ndocker run -p 127.0.0.1:8000:8000 ghcr.io/joinly-ai/joinly:latest\nuvx joinly-client --env-file .env <MeetingUrl>",
+        "url": null
+      },
+      "protocols": [
+        "mcp"
+      ],
+      "mcp_status": "available",
+      "agent_skill_status": "unavailable",
+      "latest_month_signal": "Last GitHub push 2026-09-01 (repo metadata); image ghcr.io/joinly-ai/joinly; PyPI joinly-client; optional cloud https://cloud.joinly.ai",
+      "verified_at": "2026-09-03",
+      "verification_sources": [
+        "https://api.github.com/repos/joinly-ai/joinly",
+        "https://cloud.joinly.ai"
+      ]
     },
     {
       "id": "meeting-and-conversation/looped-meet",

--- a/docs/catalog.json
+++ b/docs/catalog.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://lihaorui.com/awesome-agent-native-services/catalog.schema.json",
   "schema_version": "1.0.0",
-  "catalog_version": "2026-08-29",
-  "generated_at": "2026-08-29",
+  "catalog_version": "2026-09-03",
+  "generated_at": "2026-09-03",
   "license": "CC0-1.0",
   "source": {
     "repository": "https://github.com/haoruilee/awesome-agent-native-services",
@@ -11,7 +11,7 @@
     "service_directory": "services",
     "content_digest": {
       "algorithm": "sha256",
-      "value": "717b3953c24756672538776775910bff9c25a971bd10f3cf06eebbd9479bc741",
+      "value": "0b712151afe6ec98343ec5e01c07e3e622ef8f009b7a111b034abf4beee2694b",
       "input_paths": [
         "README.md",
         "skill.md",
@@ -68,6 +68,8 @@
         "services/tool-access-and-integration/google-mcp-toolbox.md",
         "services/tool-access-and-integration/mcp-gateway-registry.md",
         "services/tool-access-and-integration/mcpgateway.md",
+        "services/tool-access-and-integration/mcphub.md",
+        "services/tool-access-and-integration/mcpjungle.md",
         "services/tool-access-and-integration/nango.md",
         "services/tool-access-and-integration/obot.md",
         "services/tool-access-and-integration/openchatcut.md",
@@ -139,8 +141,10 @@
         "services/agent-harnesses-and-control-planes/ruflo.md",
         "services/memory-and-state/README.md",
         "services/memory-and-state/agentmemory.md",
+        "services/memory-and-state/beads.md",
         "services/memory-and-state/claude-mem.md",
         "services/memory-and-state/cognee.md",
+        "services/memory-and-state/compartment.md",
         "services/memory-and-state/engram.md",
         "services/memory-and-state/ensue.md",
         "services/memory-and-state/hindsight.md",
@@ -150,12 +154,15 @@
         "services/memory-and-state/mem9.md",
         "services/memory-and-state/memmachine.md",
         "services/memory-and-state/memmy-agent.md",
+        "services/memory-and-state/memoir.md",
         "services/memory-and-state/memoria.md",
+        "services/memory-and-state/memorix.md",
         "services/memory-and-state/memos.md",
         "services/memory-and-state/mempalace.md",
         "services/memory-and-state/memsearch.md",
         "services/memory-and-state/memu.md",
         "services/memory-and-state/openviking.md",
+        "services/memory-and-state/projectmem.md",
         "services/memory-and-state/recall.md",
         "services/memory-and-state/tencentdb-agent-memory.md",
         "services/memory-and-state/zep.md",
@@ -207,6 +214,7 @@
         "services/meeting-and-conversation/README.md",
         "services/meeting-and-conversation/agentcall.md",
         "services/meeting-and-conversation/daily-agent.md",
+        "services/meeting-and-conversation/joinly.md",
         "services/meeting-and-conversation/looped-meet.md",
         "services/meeting-and-conversation/meeting-baas.md",
         "services/meeting-and-conversation/meetstream.md",
@@ -244,7 +252,7 @@
   },
   "counts": {
     "categories": 16,
-    "services": 208
+    "services": 216
   },
   "categories": [
     {
@@ -266,7 +274,7 @@
       "name": "Tool Access & Integration",
       "description": "Services that let AI agents discover, authenticate, and invoke external tools at runtime — without a human pre-configuring credentials or selecting which integrations to activate.",
       "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/README.md",
-      "service_count": 19
+      "service_count": 21
     },
     {
       "id": "oversight-and-approval",
@@ -301,7 +309,7 @@
       "name": "Memory & State",
       "description": "Services that give AI agents persistent, queryable memory across sessions — treating memory as infrastructure rather than application logic, and managing the full lifecycle of what agents remember, forget, and retrieve.",
       "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/README.md",
-      "service_count": 21
+      "service_count": 26
     },
     {
       "id": "search-and-web-intelligence",
@@ -336,7 +344,7 @@
       "name": "Meeting & Conversation",
       "description": "Services that give AI agents a programmatic presence in voice and video conversations — letting agents join meetings, process real-time audio, and participate in synchronous communication without a human operating a client.",
       "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/meeting-and-conversation/README.md",
-      "service_count": 7
+      "service_count": 8
     },
     {
       "id": "voice-and-phone",
@@ -1950,6 +1958,72 @@
       "latest_month_signal": null,
       "verified_at": null,
       "verification_sources": []
+    },
+    {
+      "id": "tool-access-and-integration/mcphub",
+      "slug": "mcphub",
+      "name": "MCPHub",
+      "tagline": "One gateway for all your MCP servers.",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "tool-access-and-integration",
+      "website": "https://www.mcphub.app",
+      "repository": "https://github.com/samanhappy/mcphub",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/mcphub.md",
+      "source_path": "services/tool-access-and-integration/mcphub.md",
+      "onboarding": {
+        "type": "mcp",
+        "pattern": "CLI + MCP gateway",
+        "instruction": "docker run -p 3000:3000 \\\n  -v ./mcp_settings.json:/app/mcp_settings.json \\\n  -v ./data:/app/data \\\n  samanhappy/mcphub",
+        "url": "http://localhost:3000/mcp"
+      },
+      "protocols": [
+        "mcp",
+        "cli",
+        "http"
+      ],
+      "mcp_status": "available",
+      "agent_skill_status": "unavailable",
+      "latest_month_signal": "Last GitHub push 2026-09-03 (repo metadata); Docker samanhappy/mcphub; demo https://demo.mcphub.app/",
+      "verified_at": "2026-09-03",
+      "verification_sources": [
+        "https://api.github.com/repos/samanhappy/mcphub",
+        "https://demo.mcphub.app/"
+      ]
+    },
+    {
+      "id": "tool-access-and-integration/mcpjungle",
+      "slug": "mcpjungle",
+      "name": "MCPJungle",
+      "tagline": "Run all your MCP servers behind one endpoint",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "tool-access-and-integration",
+      "website": "https://docs.mcpjungle.com",
+      "repository": "https://github.com/mcpjungle/MCPJungle",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/mcpjungle.md",
+      "source_path": "services/tool-access-and-integration/mcpjungle.md",
+      "onboarding": {
+        "type": "mcp",
+        "pattern": "CLI + MCP gateway",
+        "instruction": "curl -O https://raw.githubusercontent.com/mcpjungle/MCPJungle/refs/heads/main/docker-compose.yaml\ndocker compose up -d\nbrew install mcpjungle/mcpjungle/mcpjungle\nmcpjungle register --name context7 --url https://mcp.context7.com/mcp",
+        "url": "https://raw.githubusercontent.com/mcpjungle/MCPJungle/refs/heads/main/docker-compose.yaml"
+      },
+      "protocols": [
+        "mcp",
+        "cli",
+        "http",
+        "api"
+      ],
+      "mcp_status": "available",
+      "agent_skill_status": "unavailable",
+      "latest_month_signal": "Last GitHub push 2026-08-02 (repo metadata) — quieter than neighboring gateways; docs site and Docker Compose path still live as of 2026-09-03",
+      "verified_at": "2026-09-03",
+      "verification_sources": [
+        "https://api.github.com/repos/mcpjungle/MCPJungle"
+      ]
     },
     {
       "id": "tool-access-and-integration/nango",
@@ -4014,6 +4088,40 @@
       ]
     },
     {
+      "id": "memory-and-state/beads",
+      "slug": "beads",
+      "name": "Beads",
+      "tagline": "Dependency-aware, Dolt-backed issue tracker built for AI coding agents that survive context loss",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "memory-and-state",
+      "website": "https://beads.gascity.com",
+      "repository": "https://github.com/gastownhall/beads",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/beads.md",
+      "source_path": "services/memory-and-state/beads.md",
+      "onboarding": {
+        "type": "mcp",
+        "pattern": "CLI + optional MCP / agent setup recipes",
+        "instruction": "brew install beads\n# or: curl -fsSL https://raw.githubusercontent.com/gastownhall/beads/main/scripts/install.sh | bash\n# or: npm install -g @beads/bd\n\ncd your-project\nbd init --quiet\nbd setup claude    # also: codex, cursor, factory, mux, gemini, copilot, …\nbd ready --json",
+        "url": "https://raw.githubusercontent.com/gastownhall/beads/main/scripts/install.sh"
+      },
+      "protocols": [
+        "agent-skill",
+        "mcp",
+        "cli",
+        "stdio",
+        "http"
+      ],
+      "mcp_status": "optional",
+      "agent_skill_status": "available",
+      "latest_month_signal": "Last GitHub push 2026-09-03 (repo metadata); Homebrew beads, npm @beads/bd, PyPI beads-mcp",
+      "verified_at": "2026-09-03",
+      "verification_sources": [
+        "https://api.github.com/repos/gastownhall/beads"
+      ]
+    },
+    {
       "id": "memory-and-state/claude-mem",
       "slug": "claude-mem",
       "name": "Claude-Mem",
@@ -4076,6 +4184,39 @@
       "latest_month_signal": null,
       "verified_at": null,
       "verification_sources": []
+    },
+    {
+      "id": "memory-and-state/compartment",
+      "slug": "compartment",
+      "name": "Compartment",
+      "tagline": "Encrypted, fully offline memory for AI agents.",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "memory-and-state",
+      "website": "https://maxfreedompollard.github.io/Compartment/",
+      "repository": "https://github.com/MaxFreedomPollard/Compartment",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/compartment.md",
+      "source_path": "services/memory-and-state/compartment.md",
+      "onboarding": {
+        "type": "mcp",
+        "pattern": "CLI + MCP (compartment serve)",
+        "instruction": "pip install compartment && compartment init\ncompartment integrate claude      # also: hermes, openclaw, or --all\n# MCP clients without a recipe:\n# { \"mcpServers\": { \"compartment\": { \"command\": \"compartment\", \"args\": [\"serve\"] } } }",
+        "url": null
+      },
+      "protocols": [
+        "agent-skill",
+        "mcp",
+        "cli",
+        "stdio"
+      ],
+      "mcp_status": "available",
+      "agent_skill_status": "available",
+      "latest_month_signal": "Last GitHub push 2026-09-02 (repo metadata); PyPI compartment",
+      "verified_at": "2026-09-03",
+      "verification_sources": [
+        "https://api.github.com/repos/MaxFreedomPollard/Compartment"
+      ]
     },
     {
       "id": "memory-and-state/engram",
@@ -4366,6 +4507,39 @@
       ]
     },
     {
+      "id": "memory-and-state/memoir",
+      "slug": "memoir",
+      "name": "Memoir",
+      "tagline": "Git for AI Memory",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "memory-and-state",
+      "website": "https://www.memoir-ai.dev",
+      "repository": "https://github.com/zhangfengcdt/memoir",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/memoir.md",
+      "source_path": "services/memory-and-state/memoir.md",
+      "onboarding": {
+        "type": "mcp",
+        "pattern": "SDK / CLI + plugins / MCP",
+        "instruction": "pip install memoir-ai\n# Claude Code:\n#   /plugin marketplace add zhangfengcdt/memoir\n#   /plugin install memoir@memoir",
+        "url": null
+      },
+      "protocols": [
+        "agent-skill",
+        "mcp",
+        "cli",
+        "sdk"
+      ],
+      "mcp_status": "available",
+      "agent_skill_status": "available",
+      "latest_month_signal": "Last GitHub push 2026-09-03 (repo metadata); PyPI memoir-ai; Claude Code / Codex plugins",
+      "verified_at": "2026-09-03",
+      "verification_sources": [
+        "https://api.github.com/repos/zhangfengcdt/memoir"
+      ]
+    },
+    {
       "id": "memory-and-state/memoria",
       "slug": "memoria",
       "name": "Memoria",
@@ -4395,6 +4569,41 @@
       "latest_month_signal": null,
       "verified_at": null,
       "verification_sources": []
+    },
+    {
+      "id": "memory-and-state/memorix",
+      "slug": "memorix",
+      "name": "Memorix",
+      "tagline": "Local-first shared memory layer for AI coding agents.",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "memory-and-state",
+      "website": "https://github.com/AVIDS2/memorix",
+      "repository": "https://github.com/AVIDS2/memorix",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/memorix.md",
+      "source_path": "services/memory-and-state/memorix.md",
+      "onboarding": {
+        "type": "mcp",
+        "pattern": "CLI + MCP / memorix setup",
+        "instruction": "npm install -g memorix\nmemorix setup --agent claude --global\n# also: codex, copilot, cursor, pi, gemini-cli, opencode, windsurf,\n# kiro, antigravity, trae, openclaw, hermes, omp, dsh, workbuddy, …",
+        "url": null
+      },
+      "protocols": [
+        "agent-skill",
+        "mcp",
+        "cli",
+        "sdk",
+        "stdio",
+        "http"
+      ],
+      "mcp_status": "optional",
+      "agent_skill_status": "available",
+      "latest_month_signal": "Last GitHub push 2026-09-02 (repo metadata); npm memorix; listed in the official MCP Registry",
+      "verified_at": "2026-09-03",
+      "verification_sources": [
+        "https://api.github.com/repos/AVIDS2/memorix"
+      ]
     },
     {
       "id": "memory-and-state/memos",
@@ -4560,6 +4769,38 @@
       "latest_month_signal": null,
       "verified_at": null,
       "verification_sources": []
+    },
+    {
+      "id": "memory-and-state/projectmem",
+      "slug": "projectmem",
+      "name": "projectmem",
+      "tagline": "We don't make AI smarter. We make it experienced.",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "memory-and-state",
+      "website": "https://www.projectmem.dev",
+      "repository": "https://github.com/riponcm/projectmem",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/projectmem.md",
+      "source_path": "services/memory-and-state/projectmem.md",
+      "onboarding": {
+        "type": "mcp",
+        "pattern": "SDK / CLI + MCP",
+        "instruction": "pip install -U projectmem\npjm doctor\npjm doctor --fix\npjm init    # per repo — writes .projectmem/ and git hooks",
+        "url": null
+      },
+      "protocols": [
+        "mcp",
+        "cli",
+        "stdio"
+      ],
+      "mcp_status": "available",
+      "agent_skill_status": "unavailable",
+      "latest_month_signal": "Last GitHub push 2026-09-01 (repo metadata); PyPI projectmem v0.3.1 — one MCP server for every project",
+      "verified_at": "2026-09-03",
+      "verification_sources": [
+        "https://api.github.com/repos/riponcm/projectmem"
+      ]
     },
     {
       "id": "memory-and-state/recall",
@@ -6013,6 +6254,37 @@
       "latest_month_signal": null,
       "verified_at": null,
       "verification_sources": []
+    },
+    {
+      "id": "meeting-and-conversation/joinly",
+      "slug": "joinly",
+      "name": "joinly.ai",
+      "tagline": "Make your meetings accessible to AI Agents!",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "meeting-and-conversation",
+      "website": "https://joinly.ai",
+      "repository": "https://github.com/joinly-ai/joinly",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/meeting-and-conversation/joinly.md",
+      "source_path": "services/meeting-and-conversation/joinly.md",
+      "onboarding": {
+        "type": "mcp",
+        "pattern": "CLI + MCP server",
+        "instruction": "docker pull ghcr.io/joinly-ai/joinly:latest\n# Quickstart client-in-container (no external MCP):\ndocker run --env-file .env ghcr.io/joinly-ai/joinly:latest --client <MeetingURL>\n\n# Server mode — bind localhost only:\ndocker run -p 127.0.0.1:8000:8000 ghcr.io/joinly-ai/joinly:latest\nuvx joinly-client --env-file .env <MeetingUrl>",
+        "url": null
+      },
+      "protocols": [
+        "mcp"
+      ],
+      "mcp_status": "available",
+      "agent_skill_status": "unavailable",
+      "latest_month_signal": "Last GitHub push 2026-09-01 (repo metadata); image ghcr.io/joinly-ai/joinly; PyPI joinly-client; optional cloud https://cloud.joinly.ai",
+      "verified_at": "2026-09-03",
+      "verification_sources": [
+        "https://api.github.com/repos/joinly-ai/joinly",
+        "https://cloud.joinly.ai"
+      ]
     },
     {
       "id": "meeting-and-conversation/looped-meet",

--- a/docs/categories/index.md
+++ b/docs/categories/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Agent-Native Collections"
-description: "Browse 208 agent-native services across 16 curated infrastructure collections."
+description: "Browse 216 agent-native services across 16 curated infrastructure collections."
 permalink: /categories/
 page_kind: document
 ---
@@ -27,7 +27,7 @@ page_kind: document
     <span class="collection-card__copy">
     <span class="collection-card__number">03</span>
     <span class="collection-card__title">Tool Access &amp; Integration</span>
-    <span class="collection-card__count">19</span>
+    <span class="collection-card__count">21</span>
     </span>
   </a>
   <a class="collection-card atlas-visual--04" href="{{ '/categories/oversight-and-approval/' | relative_url }}">
@@ -67,7 +67,7 @@ page_kind: document
     <span class="collection-card__copy">
     <span class="collection-card__number">08</span>
     <span class="collection-card__title">Memory &amp; State</span>
-    <span class="collection-card__count">21</span>
+    <span class="collection-card__count">26</span>
     </span>
   </a>
   <a class="collection-card atlas-visual--09" href="{{ '/categories/search-and-web-intelligence/' | relative_url }}">
@@ -107,7 +107,7 @@ page_kind: document
     <span class="collection-card__copy">
     <span class="collection-card__number">13</span>
     <span class="collection-card__title">Meeting &amp; Conversation</span>
-    <span class="collection-card__count">7</span>
+    <span class="collection-card__count">8</span>
     </span>
   </a>
   <a class="collection-card atlas-visual--14" href="{{ '/categories/voice-and-phone/' | relative_url }}">

--- a/docs/categories/meeting-and-conversation.md
+++ b/docs/categories/meeting-and-conversation.md
@@ -6,7 +6,7 @@ hero_image: "/assets/images/editorial-resonance.webp"
 permalink: /categories/meeting-and-conversation/
 page_kind: collection
 collection_number: "13"
-service_count: 7
+service_count: 8
 ---
 
 <p class="collection-source"><a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/meeting-and-conversation/README.md">Collection notes ↗</a></p>
@@ -38,6 +38,17 @@ service_count: 7
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
+    <h2 class="service-card__title">joinly.ai</h2>
+    <div class="service-card__actions">
+      <a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/meeting-and-conversation/joinly.md">Open dossier ↗</a>
+      <a href="https://github.com/joinly-ai/joinly">Official repo ↗</a>
+    </div>
+    </div>
+  </article>
+  <article class="service-card service-card--new atlas-sheet--service atlas-visual--04">
+    <span class="service-card__image" aria-hidden="true"></span>
+    <div class="service-card__copy">
+    <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
     <h2 class="service-card__title">Looped Meet</h2>
     <div class="service-card__actions">
       <a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/meeting-and-conversation/looped-meet.md">Open dossier ↗</a>
@@ -45,7 +56,7 @@ service_count: 7
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--04">
+  <article class="service-card atlas-sheet--service atlas-visual--05">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -56,7 +67,7 @@ service_count: 7
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--05">
+  <article class="service-card atlas-sheet--service atlas-visual--06">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -66,7 +77,7 @@ service_count: 7
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--06">
+  <article class="service-card atlas-sheet--service atlas-visual--07">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -77,7 +88,7 @@ service_count: 7
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--07">
+  <article class="service-card atlas-sheet--service atlas-visual--08">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>

--- a/docs/categories/memory-and-state.md
+++ b/docs/categories/memory-and-state.md
@@ -6,7 +6,7 @@ hero_image: "/assets/images/editorial-memory.webp"
 permalink: /categories/memory-and-state/
 page_kind: collection
 collection_number: "08"
-service_count: 21
+service_count: 26
 ---
 
 <p class="collection-source"><a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/README.md">Collection notes ↗</a></p>
@@ -27,6 +27,17 @@ service_count: 21
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
+    <h2 class="service-card__title">Beads</h2>
+    <div class="service-card__actions">
+      <a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/beads.md">Open dossier ↗</a>
+      <a href="https://github.com/gastownhall/beads">Official repo ↗</a>
+    </div>
+    </div>
+  </article>
+  <article class="service-card service-card--new atlas-sheet--arrival atlas-visual--03">
+    <span class="service-card__image" aria-hidden="true"></span>
+    <div class="service-card__copy">
+    <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
     <h2 class="service-card__title">Claude-Mem</h2>
     <div class="service-card__actions">
       <a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/claude-mem.md">Open dossier ↗</a>
@@ -34,7 +45,7 @@ service_count: 21
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--03">
+  <article class="service-card atlas-sheet--arrival atlas-visual--04">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -45,7 +56,18 @@ service_count: 21
     </div>
     </div>
   </article>
-  <article class="service-card service-card--new atlas-sheet--arrival atlas-visual--04">
+  <article class="service-card service-card--new atlas-sheet--arrival atlas-visual--05">
+    <span class="service-card__image" aria-hidden="true"></span>
+    <div class="service-card__copy">
+    <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
+    <h2 class="service-card__title">Compartment</h2>
+    <div class="service-card__actions">
+      <a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/compartment.md">Open dossier ↗</a>
+      <a href="https://github.com/MaxFreedomPollard/Compartment">Official repo ↗</a>
+    </div>
+    </div>
+  </article>
+  <article class="service-card service-card--new atlas-sheet--arrival atlas-visual--06">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
@@ -56,7 +78,7 @@ service_count: 21
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--05">
+  <article class="service-card atlas-sheet--arrival atlas-visual--07">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -67,7 +89,7 @@ service_count: 21
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--06">
+  <article class="service-card atlas-sheet--arrival atlas-visual--08">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -78,7 +100,7 @@ service_count: 21
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--07">
+  <article class="service-card atlas-sheet--arrival atlas-visual--09">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -89,7 +111,7 @@ service_count: 21
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--08">
+  <article class="service-card atlas-sheet--arrival atlas-visual--10">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -100,7 +122,7 @@ service_count: 21
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--09">
+  <article class="service-card atlas-sheet--arrival atlas-visual--11">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -111,7 +133,7 @@ service_count: 21
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--10">
+  <article class="service-card atlas-sheet--arrival atlas-visual--12">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -122,7 +144,7 @@ service_count: 21
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--11">
+  <article class="service-card atlas-sheet--arrival atlas-visual--13">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -133,7 +155,7 @@ service_count: 21
     </div>
     </div>
   </article>
-  <article class="service-card service-card--new atlas-sheet--arrival atlas-visual--12">
+  <article class="service-card service-card--new atlas-sheet--arrival atlas-visual--14">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
@@ -144,7 +166,18 @@ service_count: 21
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--13">
+  <article class="service-card service-card--new atlas-sheet--arrival atlas-visual--15">
+    <span class="service-card__image" aria-hidden="true"></span>
+    <div class="service-card__copy">
+    <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
+    <h2 class="service-card__title">Memoir</h2>
+    <div class="service-card__actions">
+      <a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/memoir.md">Open dossier ↗</a>
+      <a href="https://github.com/zhangfengcdt/memoir">Official repo ↗</a>
+    </div>
+    </div>
+  </article>
+  <article class="service-card atlas-sheet--arrival atlas-visual--16">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -155,7 +188,18 @@ service_count: 21
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--14">
+  <article class="service-card service-card--new atlas-sheet--service atlas-visual--01">
+    <span class="service-card__image" aria-hidden="true"></span>
+    <div class="service-card__copy">
+    <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
+    <h2 class="service-card__title">Memorix</h2>
+    <div class="service-card__actions">
+      <a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/memorix.md">Open dossier ↗</a>
+      <a href="https://github.com/AVIDS2/memorix">Official repo ↗</a>
+    </div>
+    </div>
+  </article>
+  <article class="service-card atlas-sheet--service atlas-visual--02">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -166,7 +210,7 @@ service_count: 21
     </div>
     </div>
   </article>
-  <article class="service-card service-card--new atlas-sheet--arrival atlas-visual--15">
+  <article class="service-card service-card--new atlas-sheet--service atlas-visual--03">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
@@ -177,7 +221,7 @@ service_count: 21
     </div>
     </div>
   </article>
-  <article class="service-card service-card--new atlas-sheet--arrival atlas-visual--16">
+  <article class="service-card service-card--new atlas-sheet--service atlas-visual--04">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
@@ -188,7 +232,7 @@ service_count: 21
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--01">
+  <article class="service-card atlas-sheet--service atlas-visual--05">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -199,7 +243,7 @@ service_count: 21
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--02">
+  <article class="service-card atlas-sheet--service atlas-visual--06">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -210,7 +254,18 @@ service_count: 21
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--03">
+  <article class="service-card service-card--new atlas-sheet--service atlas-visual--07">
+    <span class="service-card__image" aria-hidden="true"></span>
+    <div class="service-card__copy">
+    <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
+    <h2 class="service-card__title">projectmem</h2>
+    <div class="service-card__actions">
+      <a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/projectmem.md">Open dossier ↗</a>
+      <a href="https://github.com/riponcm/projectmem">Official repo ↗</a>
+    </div>
+    </div>
+  </article>
+  <article class="service-card atlas-sheet--service atlas-visual--08">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -221,7 +276,7 @@ service_count: 21
     </div>
     </div>
   </article>
-  <article class="service-card service-card--new atlas-sheet--service atlas-visual--04">
+  <article class="service-card service-card--new atlas-sheet--service atlas-visual--09">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
@@ -232,7 +287,7 @@ service_count: 21
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--05">
+  <article class="service-card atlas-sheet--service atlas-visual--10">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>

--- a/docs/categories/tool-access-and-integration.md
+++ b/docs/categories/tool-access-and-integration.md
@@ -6,7 +6,7 @@ hero_image: "/assets/images/editorial-network.webp"
 permalink: /categories/tool-access-and-integration/
 page_kind: collection
 collection_number: "03"
-service_count: 19
+service_count: 21
 ---
 
 <p class="collection-source"><a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/README.md">Collection notes ↗</a></p>
@@ -110,7 +110,29 @@ service_count: 19
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--10">
+  <article class="service-card service-card--new atlas-sheet--service atlas-visual--10">
+    <span class="service-card__image" aria-hidden="true"></span>
+    <div class="service-card__copy">
+    <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
+    <h2 class="service-card__title">MCPHub</h2>
+    <div class="service-card__actions">
+      <a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/mcphub.md">Open dossier ↗</a>
+      <a href="https://github.com/samanhappy/mcphub">Official repo ↗</a>
+    </div>
+    </div>
+  </article>
+  <article class="service-card service-card--new atlas-sheet--service atlas-visual--11">
+    <span class="service-card__image" aria-hidden="true"></span>
+    <div class="service-card__copy">
+    <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
+    <h2 class="service-card__title">MCPJungle</h2>
+    <div class="service-card__actions">
+      <a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/mcpjungle.md">Open dossier ↗</a>
+      <a href="https://github.com/mcpjungle/MCPJungle">Official repo ↗</a>
+    </div>
+    </div>
+  </article>
+  <article class="service-card atlas-sheet--service atlas-visual--12">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -121,7 +143,7 @@ service_count: 19
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--11">
+  <article class="service-card atlas-sheet--service atlas-visual--13">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -132,7 +154,7 @@ service_count: 19
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--12">
+  <article class="service-card atlas-sheet--service atlas-visual--14">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -143,7 +165,7 @@ service_count: 19
     </div>
     </div>
   </article>
-  <article class="service-card service-card--new atlas-sheet--service atlas-visual--13">
+  <article class="service-card service-card--new atlas-sheet--service atlas-visual--15">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
@@ -154,7 +176,7 @@ service_count: 19
     </div>
     </div>
   </article>
-  <article class="service-card service-card--new atlas-sheet--service atlas-visual--14">
+  <article class="service-card service-card--new atlas-sheet--service atlas-visual--16">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
@@ -165,7 +187,7 @@ service_count: 19
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--15">
+  <article class="service-card atlas-sheet--arrival atlas-visual--01">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -176,7 +198,7 @@ service_count: 19
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--16">
+  <article class="service-card atlas-sheet--arrival atlas-visual--02">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -187,7 +209,7 @@ service_count: 19
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--01">
+  <article class="service-card atlas-sheet--arrival atlas-visual--03">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -198,7 +220,7 @@ service_count: 19
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--02">
+  <article class="service-card atlas-sheet--arrival atlas-visual--04">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -209,7 +231,7 @@ service_count: 19
     </div>
     </div>
   </article>
-  <article class="service-card service-card--new atlas-sheet--arrival atlas-visual--03">
+  <article class="service-card service-card--new atlas-sheet--arrival atlas-visual--05">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,9 +3,9 @@ title: "The Agent-Native Index"
 description: "A curated 2026 collection of agent-native infrastructure: MCP tools, harnesses, identity, memory, sandboxes, browsers, payments, and runtimes."
 image: /assets/images/social-preview.png
 page_kind: home
-service_count: 208
+service_count: 216
 collection_count: 16
-new_arrivals_count: 53
+new_arrivals_count: 61
 ---
 
 <section id="new-arrivals" aria-labelledby="new-arrivals-title">
@@ -103,7 +103,63 @@ new_arrivals_count: 53
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--12" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/ruflo.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--12" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/memoir.md">
+      <span class="arrival-card__image" aria-hidden="true"></span>
+      <span class="arrival-card__copy">
+        <span class="arrival-card__category">Memory &amp; State</span>
+        <strong class="arrival-card__name">Memoir</strong>
+        <span class="arrival-card__arrow" aria-hidden="true">↗</span>
+      </span>
+    </a>
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--13" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/beads.md">
+      <span class="arrival-card__image" aria-hidden="true"></span>
+      <span class="arrival-card__copy">
+        <span class="arrival-card__category">Memory &amp; State</span>
+        <strong class="arrival-card__name">Beads</strong>
+        <span class="arrival-card__arrow" aria-hidden="true">↗</span>
+      </span>
+    </a>
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--14" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/mcphub.md">
+      <span class="arrival-card__image" aria-hidden="true"></span>
+      <span class="arrival-card__copy">
+        <span class="arrival-card__category">Tool Access &amp; Integration</span>
+        <strong class="arrival-card__name">MCPHub</strong>
+        <span class="arrival-card__arrow" aria-hidden="true">↗</span>
+      </span>
+    </a>
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--15" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/memorix.md">
+      <span class="arrival-card__image" aria-hidden="true"></span>
+      <span class="arrival-card__copy">
+        <span class="arrival-card__category">Memory &amp; State</span>
+        <strong class="arrival-card__name">Memorix</strong>
+        <span class="arrival-card__arrow" aria-hidden="true">↗</span>
+      </span>
+    </a>
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--16" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/compartment.md">
+      <span class="arrival-card__image" aria-hidden="true"></span>
+      <span class="arrival-card__copy">
+        <span class="arrival-card__category">Memory &amp; State</span>
+        <strong class="arrival-card__name">Compartment</strong>
+        <span class="arrival-card__arrow" aria-hidden="true">↗</span>
+      </span>
+    </a>
+    <a class="arrival-card atlas-sheet--service atlas-visual--01" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/meeting-and-conversation/joinly.md">
+      <span class="arrival-card__image" aria-hidden="true"></span>
+      <span class="arrival-card__copy">
+        <span class="arrival-card__category">Meeting &amp; Conversation</span>
+        <strong class="arrival-card__name">joinly.ai</strong>
+        <span class="arrival-card__arrow" aria-hidden="true">↗</span>
+      </span>
+    </a>
+    <a class="arrival-card atlas-sheet--service atlas-visual--02" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/projectmem.md">
+      <span class="arrival-card__image" aria-hidden="true"></span>
+      <span class="arrival-card__copy">
+        <span class="arrival-card__category">Memory &amp; State</span>
+        <strong class="arrival-card__name">projectmem</strong>
+        <span class="arrival-card__arrow" aria-hidden="true">↗</span>
+      </span>
+    </a>
+    <a class="arrival-card atlas-sheet--service atlas-visual--03" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/ruflo.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Agent Harnesses &amp; Operator Surfaces</span>
@@ -111,7 +167,7 @@ new_arrivals_count: 53
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--13" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/engram.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--04" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/engram.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Memory &amp; State</span>
@@ -119,7 +175,7 @@ new_arrivals_count: 53
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--14" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/claude-mem.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--05" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/claude-mem.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Memory &amp; State</span>
@@ -127,7 +183,7 @@ new_arrivals_count: 53
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--15" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/commerce-and-payments/ucp.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--06" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/commerce-and-payments/ucp.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Commerce &amp; Payments</span>
@@ -135,7 +191,7 @@ new_arrivals_count: 53
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--16" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/agent-substrate.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--07" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/agent-substrate.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Agent Runtime &amp; Infrastructure</span>
@@ -143,7 +199,7 @@ new_arrivals_count: 53
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--01" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/observability-and-tracing/agentsight.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--08" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/observability-and-tracing/agentsight.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Observability &amp; Tracing</span>
@@ -151,7 +207,7 @@ new_arrivals_count: 53
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--02" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/mempalace.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--09" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/mempalace.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Memory &amp; State</span>
@@ -159,7 +215,7 @@ new_arrivals_count: 53
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--03" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/kubernetes-agent-sandbox.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--10" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/kubernetes-agent-sandbox.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Code Execution</span>
@@ -167,7 +223,7 @@ new_arrivals_count: 53
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--04" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/contextforge.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--11" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/contextforge.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Tool Access &amp; Integration</span>
@@ -175,7 +231,7 @@ new_arrivals_count: 53
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--05" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/mcp-gateway-registry.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--12" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/mcp-gateway-registry.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Tool Access &amp; Integration</span>
@@ -183,7 +239,7 @@ new_arrivals_count: 53
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--06" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/sandbase-cli.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--13" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/sandbase-cli.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Tool Access &amp; Integration</span>
@@ -191,7 +247,7 @@ new_arrivals_count: 53
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--07" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/memsearch.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--14" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/memsearch.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Memory &amp; State</span>
@@ -199,7 +255,7 @@ new_arrivals_count: 53
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--08" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/deepseek-harness.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--15" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/deepseek-harness.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Agent Harnesses &amp; Operator Surfaces</span>
@@ -207,7 +263,7 @@ new_arrivals_count: 53
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--09" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-social-network/agentgram.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--16" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-social-network/agentgram.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Agent Social &amp; Community</span>
@@ -215,7 +271,7 @@ new_arrivals_count: 53
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--10" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/toolport.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--01" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/toolport.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Tool Access &amp; Integration</span>
@@ -223,7 +279,7 @@ new_arrivals_count: 53
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--11" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/loopx.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--02" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/loopx.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Agent Harnesses &amp; Operator Surfaces</span>
@@ -231,7 +287,7 @@ new_arrivals_count: 53
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--12" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/cloudflare-computer.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--03" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/cloudflare-computer.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Agent Runtime &amp; Infrastructure</span>
@@ -239,7 +295,7 @@ new_arrivals_count: 53
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--13" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/oversight-and-approval/preloop.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--04" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/oversight-and-approval/preloop.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Oversight &amp; Approval</span>
@@ -247,7 +303,7 @@ new_arrivals_count: 53
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--14" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/claude-hud.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--05" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/claude-hud.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Agent Harnesses &amp; Operator Surfaces</span>
@@ -255,7 +311,7 @@ new_arrivals_count: 53
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--15" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/search-and-web-intelligence/agent-search-mcp.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--06" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/search-and-web-intelligence/agent-search-mcp.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Search &amp; Web Intelligence</span>
@@ -263,7 +319,7 @@ new_arrivals_count: 53
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--16" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/agentmemory.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--07" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/agentmemory.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Memory &amp; State</span>
@@ -271,7 +327,7 @@ new_arrivals_count: 53
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--01" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/dormice.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--08" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/dormice.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Code Execution</span>
@@ -279,7 +335,7 @@ new_arrivals_count: 53
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--02" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/google-ax.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--09" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/google-ax.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Agent Runtime &amp; Infrastructure</span>
@@ -287,7 +343,7 @@ new_arrivals_count: 53
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--03" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/voice-and-phone/patter.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--10" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/voice-and-phone/patter.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Voice &amp; Phone</span>
@@ -295,7 +351,7 @@ new_arrivals_count: 53
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--04" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/clawk.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--11" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/clawk.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Code Execution</span>
@@ -303,7 +359,7 @@ new_arrivals_count: 53
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--05" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/communication/atomic-mail.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--12" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/communication/atomic-mail.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Communication</span>
@@ -311,7 +367,7 @@ new_arrivals_count: 53
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--06" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/meeting-and-conversation/agentcall.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--13" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/meeting-and-conversation/agentcall.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Meeting &amp; Conversation</span>
@@ -319,7 +375,15 @@ new_arrivals_count: 53
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--07" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/communication/agentteam-email.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--14" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/mcpjungle.md">
+      <span class="arrival-card__image" aria-hidden="true"></span>
+      <span class="arrival-card__copy">
+        <span class="arrival-card__category">Tool Access &amp; Integration</span>
+        <strong class="arrival-card__name">MCPJungle</strong>
+        <span class="arrival-card__arrow" aria-hidden="true">↗</span>
+      </span>
+    </a>
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--15" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/communication/agentteam-email.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Communication</span>
@@ -327,7 +391,7 @@ new_arrivals_count: 53
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--08" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/browser-and-web-execution/stealth-browser-mcp.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--16" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/browser-and-web-execution/stealth-browser-mcp.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Browser &amp; Web Execution</span>
@@ -335,7 +399,7 @@ new_arrivals_count: 53
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--09" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/commerce-and-payments/ap2.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--01" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/commerce-and-payments/ap2.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Commerce &amp; Payments</span>
@@ -343,7 +407,7 @@ new_arrivals_count: 53
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--10" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/tencentdb-agent-memory.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--02" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/tencentdb-agent-memory.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Memory &amp; State</span>
@@ -351,7 +415,7 @@ new_arrivals_count: 53
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--11" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/longhorizon-harness.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--03" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/longhorizon-harness.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Agent Harnesses &amp; Operator Surfaces</span>
@@ -359,7 +423,7 @@ new_arrivals_count: 53
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--12" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/search-and-web-intelligence/contextx.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--04" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/search-and-web-intelligence/contextx.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Search &amp; Web Intelligence</span>
@@ -367,7 +431,7 @@ new_arrivals_count: 53
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--13" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/qm.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--05" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/qm.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Agent Harnesses &amp; Operator Surfaces</span>
@@ -375,7 +439,7 @@ new_arrivals_count: 53
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--14" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/axern.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--06" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/axern.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Code Execution</span>
@@ -383,7 +447,7 @@ new_arrivals_count: 53
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--15" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-social-network/agent-chamber.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--07" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-social-network/agent-chamber.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Agent Social &amp; Community</span>
@@ -391,7 +455,7 @@ new_arrivals_count: 53
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--16" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/voice-and-phone/qwen-audio-agent.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--08" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/voice-and-phone/qwen-audio-agent.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Voice &amp; Phone</span>
@@ -399,7 +463,7 @@ new_arrivals_count: 53
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--01" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/llm-gateway-and-routing/sageroute.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--09" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/llm-gateway-and-routing/sageroute.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">LLM Gateway &amp; Routing</span>
@@ -407,7 +471,7 @@ new_arrivals_count: 53
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--02" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/observability-and-tracing/numbat.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--10" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/observability-and-tracing/numbat.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Observability &amp; Tracing</span>
@@ -415,7 +479,7 @@ new_arrivals_count: 53
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--03" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/memmy-agent.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--11" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/memmy-agent.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Memory &amp; State</span>
@@ -423,7 +487,7 @@ new_arrivals_count: 53
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--04" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/meeting-and-conversation/looped-meet.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--12" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/meeting-and-conversation/looped-meet.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Meeting &amp; Conversation</span>
@@ -431,7 +495,7 @@ new_arrivals_count: 53
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--05" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/durable-execution-and-scheduling/pi-dispatch.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--13" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/durable-execution-and-scheduling/pi-dispatch.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Durable Execution &amp; Scheduling</span>
@@ -455,7 +519,7 @@ new_arrivals_count: 53
   <div class="section-intro">
     <span class="section-number">02</span>
     <h2 class="section-title" id="collections-title">The collections</h2>
-    <p class="section-note">16 fields · 208 dossiers</p>
+    <p class="section-note">16 fields · 216 dossiers</p>
   </div>
   <div class="collection-grid">
     <a class="collection-card atlas-visual--01" href="{{ '/categories/communication/' | relative_url }}">
@@ -479,7 +543,7 @@ new_arrivals_count: 53
       <span class="collection-card__copy">
       <span class="collection-card__number">03</span>
       <span class="collection-card__title">Tool Access &amp; Integration</span>
-      <span class="collection-card__count">19</span>
+      <span class="collection-card__count">21</span>
       </span>
     </a>
     <a class="collection-card atlas-visual--04" href="{{ '/categories/oversight-and-approval/' | relative_url }}">
@@ -519,7 +583,7 @@ new_arrivals_count: 53
       <span class="collection-card__copy">
       <span class="collection-card__number">08</span>
       <span class="collection-card__title">Memory &amp; State</span>
-      <span class="collection-card__count">21</span>
+      <span class="collection-card__count">26</span>
       </span>
     </a>
     <a class="collection-card atlas-visual--09" href="{{ '/categories/search-and-web-intelligence/' | relative_url }}">
@@ -559,7 +623,7 @@ new_arrivals_count: 53
       <span class="collection-card__copy">
       <span class="collection-card__number">13</span>
       <span class="collection-card__title">Meeting &amp; Conversation</span>
-      <span class="collection-card__count">7</span>
+      <span class="collection-card__count">8</span>
       </span>
     </a>
     <a class="collection-card atlas-visual--14" href="{{ '/categories/voice-and-phone/' | relative_url }}">
@@ -606,6 +670,6 @@ new_arrivals_count: 53
   <div>
   <span class="section-number">03</span>
   <h2 class="section-title">Full source.</h2>
-  <a class="source-gateway__link" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/README.md">Open 208 dossiers ↗</a>
+  <a class="source-gateway__link" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/README.md">Open 216 dossiers ↗</a>
   </div>
 </section>

--- a/docs/skill.md
+++ b/docs/skill.md
@@ -60,7 +60,7 @@ These services can be joined with a single instruction, right now, with no human
 
 ---
 
-## Full Catalog — 16 Categories, 208 Services
+## Full Catalog — 16 Categories, 216 Services
 
 ### 1. Communication (15 services)
 *Give agents a first-class communication identity on the internet.*
@@ -118,7 +118,7 @@ These services can be joined with a single instruction, right now, with no human
 
 ---
 
-### 3. Tool Access & Integration (19 services)
+### 3. Tool Access & Integration (21 services)
 *Runtime tool discovery, auth, and execution without human pre-configuration.*
 
 | Service | Tagline | Onboarding |
@@ -142,6 +142,8 @@ These services can be joined with a single instruction, right now, with no human
 | [SandBase CLI](https://github.com/sandbaseai/cli) | Give your AI agent superpowers. One command. 2,000+ AI models. | GitHub `v0.1.17` tarball `connect`, then `npx skills add sandbaseai/cli --skill sandbase` |
 | [ContextForge](https://ibm.github.io/mcp-context-forge/) | Registry and proxy that federates MCP, A2A, and REST/gRPC | `uvx --from mcp-contextforge-gateway mcpgateway --host 0.0.0.0 --port 4444` |
 | [MCP Gateway & Registry](https://agentic-community.github.io/mcp-gateway-registry/) | Unified Agent & MCP Server Registry | `git clone https://github.com/agentic-community/mcp-gateway-registry && ./build_and_run.sh --prebuilt` |
+| [MCPHub](https://www.mcphub.app) | One gateway for all your MCP servers. | `docker run -p 3000:3000 -v ./data:/app/data samanhappy/mcphub` then connect to `http://localhost:3000/mcp` |
+| [MCPJungle](https://docs.mcpjungle.com) | Run all your MCP servers behind one endpoint | `docker compose up -d` then `mcpjungle register --name context7 --url https://mcp.context7.com/mcp` |
 
 ---
 
@@ -233,7 +235,7 @@ These services can be joined with a single instruction, right now, with no human
 
 ---
 
-### 8. Memory & State (21 services)
+### 8. Memory & State (26 services)
 *Persistent, queryable memory across sessions — memory as infrastructure, not application logic.*
 
 | Service | Tagline | Onboarding |
@@ -259,6 +261,11 @@ These services can be joined with a single instruction, right now, with no human
 | [MemSearch](https://zilliztech.github.io/memsearch/) | Cross-platform semantic memory for AI coding agents | `uv tool install "memsearch[onnx]"` or Claude Code `/plugin marketplace add zilliztech/memsearch` |
 | [Claude-Mem](https://cmem.ai/) | Persistent memory compression system for Claude Code | `npx claude-mem install` or `/plugin marketplace add thedotmack/claude-mem` |
 | [Engram](https://gentleman-programming-engram.mintlify.app/introduction) | Persistent memory for AI coding agents | `brew install gentleman-programming/tap/engram` then `engram setup <agent>` |
+| [Beads](https://beads.gascity.com) | Dependency-aware, Dolt-backed issue tracker built for AI coding agents that survive context loss | `brew install beads` then `bd init --quiet` and `bd setup claude` |
+| [projectmem](https://www.projectmem.dev) | We don't make AI smarter. We make it experienced. | `pip install -U projectmem` then `pjm doctor --fix` and wire `python -m projectmem.mcp_server` |
+| [Memoir](https://www.memoir-ai.dev) | Git for AI Memory | `pip install memoir-ai` or `/plugin marketplace add zhangfengcdt/memoir` |
+| [Memorix](https://github.com/AVIDS2/memorix) | Local-first shared memory layer for AI coding agents. | `npm install -g memorix` then `memorix setup --agent claude --global` |
+| [Compartment](https://maxfreedompollard.github.io/Compartment/) | Encrypted, fully offline memory for AI agents. | `pip install compartment && compartment init && compartment integrate claude` |
 
 ---
 
@@ -335,7 +342,7 @@ These services can be joined with a single instruction, right now, with no human
 
 ---
 
-### 13. Meeting & Conversation (7 services)
+### 13. Meeting & Conversation (8 services)
 *Programmatic agent presence in voice and video meetings.*
 
 | Service | Tagline | Onboarding |
@@ -347,6 +354,7 @@ These services can be joined with a single instruction, right now, with no human
 | [Daily Agent Toolkit](https://github.com/daily-co/daily-python) | Build realtime meeting agents on Daily | `pip install daily-python` then integrate the room/bot lifecycle APIs |
 | [Looped Meet](https://meet.looped.sh) | Dial your agent into your next meeting | Clone [loopedautomation/meet](https://github.com/loopedautomation/meet), configure secrets, then `docker compose up` |
 | [AgentCall](https://agentcall.dev) | Your AI agent, in every meeting. | `/plugin marketplace add pattern-ai-labs/agentcall` then `/plugin install join-meeting@agentcall` |
+| [joinly.ai](https://joinly.ai) | Make your meetings accessible to AI Agents! | `docker run -p 127.0.0.1:8000:8000 ghcr.io/joinly-ai/joinly:latest` then `uvx joinly-client --env-file .env <MeetingUrl>` |
 
 ---
 

--- a/services/meeting-and-conversation/README.md
+++ b/services/meeting-and-conversation/README.md
@@ -25,6 +25,7 @@ Agent-native meeting services provide a unified API for bot lifecycle management
 | [Daily Agent Toolkit](daily-agent.md) [![⭐](https://img.shields.io/github/stars/daily-co/daily-python?style=social)](https://github.com/daily-co/daily-python) | Build realtime meeting agents on Daily | Programmatic room control, media stream hooks, bot orchestration | ⚠️ |
 | [Looped Meet](looped-meet.md) [![⭐](https://img.shields.io/github/stars/loopedautomation/meet?style=social)](https://github.com/loopedautomation/meet) | Self-hostable video meetings with first-class, full-duplex AI agent participants | TTY WebSocket/webhook brain bridge, LiveKit/WebRTC, HTTP routes, cal.com webhook | ❌ |
 | [AgentCall](agentcall.md) [![⭐](https://img.shields.io/github/stars/pattern-ai-labs/agentcall?style=social)](https://github.com/pattern-ai-labs/agentcall) | Your AI agent, in every meeting. | join-meeting Skill, REST/WSS, Meet/Zoom/Teams voice bot | ⚠️ |
+| [joinly.ai](joinly.md) [![⭐](https://img.shields.io/github/stars/joinly-ai/joinly?style=social)](https://github.com/joinly-ai/joinly) | Make your meetings accessible to AI Agents! | Docker MCP, `joinly-client`, Zoom/Meet/Teams tools | ✅ |
 
 
 ---

--- a/services/meeting-and-conversation/joinly.md
+++ b/services/meeting-and-conversation/joinly.md
@@ -1,0 +1,189 @@
+# joinly.ai
+
+> **"Make your meetings accessible to AI Agents!"**
+
+| | |
+|---|---|
+| **Website** | https://joinly.ai |
+| **Docs** | https://github.com/joinly-ai/joinly#readme |
+| **GitHub** | https://github.com/joinly-ai/joinly |
+| **Stars** | [![GitHub Stars](https://img.shields.io/github/stars/joinly-ai/joinly?style=social)](https://github.com/joinly-ai/joinly) |
+| **Classification** | `agent-native` |
+| **Category** | [Meeting & Conversation](README.md) |
+| **License** | MIT |
+| **Latest-month signal** | Last GitHub push 2026-09-01 ([repo metadata](https://api.github.com/repos/joinly-ai/joinly)); image `ghcr.io/joinly-ai/joinly`; PyPI `joinly-client`; optional cloud https://cloud.joinly.ai |
+| **Verified at** | 2026-09-03 |
+
+---
+
+## Official Website
+
+https://joinly.ai
+
+Homepage H1 (live 2026-09-03): **"Make your meetings accessible to AI Agents!"** (exclamation mark is official).
+
+---
+
+## Official Repo
+
+https://github.com/joinly-ai/joinly
+
+README lead: **"Make your meetings accessible to AI Agents 🤖"** — same sentence, emoji instead of `!`. GitHub description matches the homepage wording without the bang. The catalog tagline is the **homepage H1**.
+
+**joinly.ai** is OSS **MCP meeting middleware**: a connector that gives any agent `join_meeting` / `speak_text` / live transcript tools. Optional [joinly cloud](https://cloud.joinly.ai) is a hosted convenience, not the listed core.
+
+---
+
+## How to Use (Agent Onboarding)
+
+**Interaction pattern:** `CLI` + MCP server
+
+```bash
+docker pull ghcr.io/joinly-ai/joinly:latest
+# Quickstart client-in-container (no external MCP):
+docker run --env-file .env ghcr.io/joinly-ai/joinly:latest --client <MeetingURL>
+
+# Server mode — bind localhost only:
+docker run -p 127.0.0.1:8000:8000 ghcr.io/joinly-ai/joinly:latest
+uvx joinly-client --env-file .env <MeetingUrl>
+```
+
+`.env` needs an LLM key (`JOINLY_LLM_PROVIDER` / `OPENAI_API_KEY` or Anthropic / Ollama — see `.env.example`). Extra MCP servers can be attached to `joinly-client` via `--mcp-config`.
+
+**Official warning:** the MCP server has **no authentication** and accepts client-supplied configuration. Bind to `localhost`; do not expose the port.
+
+There is no URL-onboarding document.
+
+---
+
+## Agent Skills
+
+**Status:** ⚠️ No official `npx skills add` package published yet.
+
+```bash
+npx clawhub@latest search joinly
+```
+
+See: https://agentskills.io/specification to contribute one.
+
+---
+
+## MCP
+
+**Status:** ✅ Available — MCP is the backbone (homepage: “MCP: The backbone of joinly”)
+
+| Detail | Value |
+|---|---|
+| **MCP Repo** | https://github.com/joinly-ai/joinly |
+| **Transport** | Streamable HTTP (Docker `:8000`); client package speaks MCP to that server |
+| **Compatible Clients** | `joinly-client`, custom MCP agents, extra MCP servers via JSON config |
+| **Auth** | **None** — local trusted client only |
+
+### Tools (upstream README)
+
+`join_meeting`, `leave_meeting`, `speak_text`, `send_chat_message`, `mute_yourself` / `unmute_yourself`, `get_chat_history`, `get_participants`, `get_transcript`, `get_video_snapshot`
+
+### Resources
+
+`transcript://live` — subscribable live transcript with timestamps and speakers.
+
+---
+
+## What It Does
+
+joinly.ai puts an **AI participant** into Zoom, Google Meet, or Microsoft Teams (browser-based). Official README: live voice/chat interaction, interruption-aware conversational flow, bring-your-own LLM, pluggable STT/TTS (Whisper/Kokoro local defaults; Deepgram/ElevenLabs optional). Self-host via Docker (~2.3 GB with browser + models); CUDA image available.
+
+**Distinct from catalog peers:**
+
+| Peer | Difference |
+|---|---|
+| [Vexa](vexa.md) | Self-host **transcription + interactive bot API** (17 MCP tools, REST). joinly is middleware: any agent talks MCP to a meeting connector |
+| [AgentCall](agentcall.md) | Hosted **join-meeting Skill** (`ak_ac_` keys), not an OSS MCP server you run |
+| [Looped Meet](looped-meet.md) | Self-hosted **room product** with a TTY brain bridge — you host the meeting, not join Zoom/Meet/Teams |
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | Homepage H1: **"Make your meetings accessible to AI Agents!"** — [joinly.ai](https://joinly.ai). README: connector middleware whose MCP server equips **any** AI agent |
+| **Agent-specific primitive** | Meeting as MCP tools/resources: join/leave/speak/chat/transcript/snapshot + `transcript://live` |
+| **Autonomy-compatible control plane** | After Docker + `.env`, `joinly-client` or a custom agent joins and speaks without a human operating Zoom |
+| **M2M integration surface** | Docker MCP server, `uvx joinly-client`, extra MCP servers via JSON, Python client package |
+| **Identity / delegation** | **C5-weak:** MCP server is **unauthenticated** (documented). Meeting identity is `--name` (default `joinly`). LLM/STT/TTS keys are provider credentials, not a per-agent KYA token. Cloud is a separate hosted identity. Do not expose `:8000` |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **`join_meeting` / `leave_meeting`** | URL + display name + optional passcode |
+| **`speak_text`** | TTS into the call |
+| **`transcript://live`** | Subscribable diarized transcript |
+| **Chat / mute / snapshot** | In-meeting I/O tools |
+| **BYO LLM + STT/TTS** | OpenAI, Anthropic, Ollama; Whisper/Kokoro or cloud providers |
+| **Client package** | `joinly-client` — reference agent; attach more MCP servers |
+
+---
+
+## Autonomy Model
+
+```
+Start joinly Docker as MCP server on 127.0.0.1:8000
+    -> joinly-client (or custom agent) connects
+    -> join_meeting <url>
+    -> Live transcript resource updates; agent speaks / chats / calls other MCP tools
+    -> leave_meeting
+```
+
+No human in the Zoom client. Calendar auto-join is not the primary documented path (unlike some SaaS bots).
+
+---
+
+## Identity and Delegation Model
+
+- **Participant name:** `--name` in the meeting roster.
+- **MCP trust boundary:** localhost, single trusted client — **no auth**.
+- **Provider keys:** LLM/STT/TTS in `.env`; not delegated attendee OAuth.
+- **Cloud (optional):** hosted identity at cloud.joinly.ai — outside the MIT self-host core.
+- **Honest C5:** observation and speech are attributable to the joinly participant, not to a minted user-delegated meeting token.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| Docker MCP | `ghcr.io/joinly-ai/joinly:latest` (`--client` or server `:8000`) |
+| Client | `uvx joinly-client` / PyPI `joinly-client` |
+| Extra tools | `--mcp-config` JSON (`mcpServers`) |
+| Cloud | https://cloud.joinly.ai (optional, not required) |
+
+---
+
+## Human-in-the-Loop Support
+
+A human supplies the meeting URL and `.env` keys. Optional VNC (`--vnc-server`) for debugging the browser. Roadmap lists an in-meeting human-approval mechanism — not shipped. During the call the agent is the participant.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **Vexa** | Bot platform + REST/MCP for transcription/TTS. joinly is OSS **middleware** so *your* agent (plus extra MCP servers) sits in the meeting |
+| **AgentCall** | Hosted skill + API keys; not a self-hosted MCP connector |
+| **Looped Meet** | You host the room; joinly **joins** Zoom/Meet/Teams |
+| **Recall.ai / Meeting BaaS** | SaaS bot APIs already in this catalog — not OSS MCP middleware |
+| **A raw WebRTC SDK** | No meeting join, VAD/barge-in, or MCP tool surface |
+
+---
+
+## Use Cases
+
+- **Agent in standup** — speak, listen, open a GitHub issue mid-call (demo)
+- **Notion/docs in the meeting** — attach extra MCP servers to the client
+- **Self-hosted, privacy-first** — browser + models in your Docker
+- **Custom meeting agent** — write a client against the documented tools/resources

--- a/services/memory-and-state/README.md
+++ b/services/memory-and-state/README.md
@@ -45,6 +45,11 @@ Agent-native memory services solve this by providing:
 | [MemSearch](memsearch.md) [![⭐](https://img.shields.io/github/stars/zilliztech/memsearch?style=social)](https://github.com/zilliztech/memsearch) | Cross-platform semantic memory for AI coding agents | CLI, Python API, Claude/Codex/DSH/OpenClaw/OpenCode plugins | ⚠️ |
 | [Claude-Mem](claude-mem.md) [![⭐](https://img.shields.io/github/stars/thedotmack/claude-mem?style=social)](https://github.com/thedotmack/claude-mem) | Persistent memory compression system for Claude Code | Installer, lifecycle hooks, local worker, MCP search | ✅ |
 | [Engram](engram.md) [![⭐](https://img.shields.io/github/stars/Gentleman-Programming/engram?style=social)](https://github.com/Gentleman-Programming/engram) | Persistent memory for AI coding agents | CLI, stdio MCP, HTTP API, TUI, `engram setup` | ✅ |
+| [Beads](beads.md) [![⭐](https://img.shields.io/github/stars/gastownhall/beads?style=social)](https://github.com/gastownhall/beads) | Dependency-aware, Dolt-backed issue tracker built for AI coding agents that survive context loss | `bd` CLI, `beads-mcp`, `bd setup` recipes, Dolt sync | ✅ |
+| [projectmem](projectmem.md) [![⭐](https://img.shields.io/github/stars/riponcm/projectmem?style=social)](https://github.com/riponcm/projectmem) | We don't make AI smarter. We make it experienced. | Typed event log, `pjm` CLI, stdio MCP, precheck gate | ✅ |
+| [Memoir](memoir.md) [![⭐](https://img.shields.io/github/stars/zhangfengcdt/memoir?style=social)](https://github.com/zhangfengcdt/memoir) | Git for AI Memory | CLI, `memoir-mcp`, Claude Code/Codex plugins (Alpha) | ✅ |
+| [Memorix](memorix.md) [![⭐](https://img.shields.io/github/stars/AVIDS2/memorix?style=social)](https://github.com/AVIDS2/memorix) | Local-first shared memory layer for AI coding agents. | Git-root daemon, `memorix serve`, orchestration, skills | ✅ |
+| [Compartment](compartment.md) [![⭐](https://img.shields.io/github/stars/MaxFreedomPollard/Compartment?style=social)](https://github.com/MaxFreedomPollard/Compartment) | Encrypted, fully offline memory for AI agents. | Encrypted vault, `compartment serve` MCP, integrate CLI | ✅ |
 
 
 

--- a/services/memory-and-state/beads.md
+++ b/services/memory-and-state/beads.md
@@ -1,0 +1,186 @@
+# Beads
+
+> **"Dependency-aware, Dolt-backed issue tracker built for AI coding agents that survive context loss"**
+
+| | |
+|---|---|
+| **Website** | https://beads.gascity.com |
+| **Docs** | https://beads.gascity.com |
+| **GitHub** | https://github.com/gastownhall/beads |
+| **Stars** | [![GitHub Stars](https://img.shields.io/github/stars/gastownhall/beads?style=social)](https://github.com/gastownhall/beads) |
+| **Classification** | `agent-native` |
+| **Category** | [Memory & State Services](README.md) |
+| **License** | MIT |
+| **Latest-month signal** | Last GitHub push 2026-09-03 ([repo metadata](https://api.github.com/repos/gastownhall/beads)); Homebrew `beads`, npm `@beads/bd`, PyPI `beads-mcp` |
+| **Verified at** | 2026-09-03 |
+
+---
+
+## Official Website
+
+https://beads.gascity.com
+
+Docs H1 quote (live 2026-09-03): **"Dependency-aware, Dolt-backed issue tracker built for AI coding agents that survive context loss"**
+
+---
+
+## Official Repo
+
+https://github.com/gastownhall/beads
+
+README H1 is `bd - Beads`. Supporting line: **"Distributed graph issue tracker for AI agents, powered by Dolt."** GitHub description: **"Beads - A memory upgrade for your coding agent"**
+
+---
+
+## How to Use (Agent Onboarding)
+
+**Interaction pattern:** `CLI` + optional MCP / agent setup recipes
+
+```bash
+brew install beads
+# or: curl -fsSL https://raw.githubusercontent.com/gastownhall/beads/main/scripts/install.sh | bash
+# or: npm install -g @beads/bd
+
+cd your-project
+bd init --quiet
+bd setup claude    # also: codex, cursor, factory, mux, gemini, copilot, …
+bd ready --json
+```
+
+`bd init` writes `AGENTS.md` and project Claude/Codex integrations unless `--skip-agents` or `--stealth`. `bd prime` injects workflow context and `bd remember` memories. JSON is the agent path: `bd list --json`, `bd show <id> --json`.
+
+MCP-only hosts (Claude Desktop, no shell):
+
+```bash
+pip install beads-mcp
+# or: uv tool install beads-mcp
+```
+
+Then point the host at `"command": "beads-mcp"`.
+
+There is no URL-onboarding document. Docs expose `https://beads.gascity.com/llms.txt` as a documentation index, not a join protocol.
+
+---
+
+## Agent Skills
+
+**Status:** ✅ Bundled with `bd setup` (not `npx skills add`)
+
+| Skill | What It Teaches the Agent |
+|---|---|
+| Codex beads skill | `.agents/skills/beads/SKILL.md` installed by `bd setup codex` — when to `bd ready` / `bd claim` / `bd close` |
+| `bd prime` workflow | SessionStart hook injects commands, ready work, and `bd remember` memories |
+| `bd onboard` snippet | Printed AGENTS.md block for unsupported hosts |
+
+```bash
+npx clawhub@latest search beads
+```
+
+---
+
+## MCP
+
+**Status:** ✅ Available — optional; the primary surface is the `bd` CLI
+
+| Detail | Value |
+|---|---|
+| **MCP Repo** | https://github.com/gastownhall/beads (`beads-mcp` on PyPI) |
+| **Transport** | stdio (`beads-mcp`) |
+| **Compatible Clients** | VS Code Copilot, Claude Desktop, and any MCP host |
+| **Official note** | Docs: MCP is for hosts without a shell; CLI + `bd prime` is preferred (tool schemas cost 10–50k tokens) |
+
+---
+
+## What It Does
+
+Beads (`bd`) is a **dependency-aware work graph** for coding agents, stored in a [Dolt](https://github.com/dolthub/dolt) version-controlled SQL database. Official docs: traditional trackers were not designed for agents; Beads uses hash IDs (`bd-a1b2`) so concurrent agents do not collide, `bd ready` so an agent only claims unblocked work, and Dolt push/pull so the graph survives context loss across machines.
+
+This is **not fact memory**. Distinct from [LycheeMem](lycheemem.md) (working/semantic/procedural stores), [agentmemory](agentmemory.md) (shared memory server), and [Claude-Mem](claude-mem.md) (tool-call firehose + compression): Beads tracks issues, blockers, formulas/molecules, and `bd remember` project insights as a **work graph**, not a fact/RAG store.
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | Docs: **"Dependency-aware, Dolt-backed issue tracker built for AI coding agents that survive context loss"** — [beads.gascity.com](https://beads.gascity.com). README: **"Distributed graph issue tracker for AI agents, powered by Dolt."** |
+| **Agent-specific primitive** | Hash-based IDs; `bd ready` unblocked-work queue; `bd update --claim`; formulas/molecules/gates; `bd remember` + `bd prime` session injection |
+| **Autonomy-compatible control plane** | After `bd init` / `bd setup`, SessionStart hooks run `bd prime`; agents create, claim, and close beads with `--json` and no dashboard click. Git authority is gated by `agent.profile` (`conservative` default) |
+| **M2M integration surface** | `bd` CLI (JSON), `beads-mcp`, `bd setup <agent>` recipes, Homebrew/npm/install.sh |
+| **Identity / delegation** | Hash IDs + `--claim` assignee; `prepare-commit-msg` **agent identity trailers**; Dolt audit history. **C5 note:** no hosted KYA token — identity is the local/Dolt actor plus optional `BD_AGENT_PROFILE`. `team-maintainer` must be set explicitly; Beads does not infer commit/push authority from a remote |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **Bead** | Work item with priority, type, labels, dependencies |
+| **`bd ready`** | Only unblocked, claimable work |
+| **`bd update --claim`** | Atomic assignee + `in_progress` |
+| **Dependencies** | `blocks`, `parent-child`, `discovered-from`, `related` |
+| **Formulas / molecules / gates** | Declarative workflow templates, instantiated graphs, async human/timer/GitHub gates |
+| **`bd remember` / `bd prime`** | Persistent project insights injected at session start |
+| **Dolt sync** | `bd dolt push` / `bd dolt pull` — the DB is the source of truth |
+| **Hash IDs** | `bd-a1b2` (hierarchical `bd-a3f8.1.1`) — collision-safe multi-agent IDs |
+
+---
+
+## Autonomy Model
+
+```
+Operator installs bd and runs `bd init` (+ optional `bd setup <agent>`)
+    -> SessionStart / AGENTS.md tells the agent to run `bd prime`
+    -> Agent lists `bd ready --json`, claims a bead, implements, closes
+    -> Discovered work is `bd create … --deps discovered-from:<id>`
+    -> `bd dolt push` shares the graph (when the profile allows)
+```
+
+No per-action human confirmation on the issue graph. Commit/push stays conservative unless `agent.profile=team-maintainer`.
+
+---
+
+## Identity and Delegation Model
+
+- **Issue identity:** Hash IDs prevent two agents from minting the same key.
+- **Claim:** `--claim` records the acting agent as assignee.
+- **Audit:** Dolt history plus `bd show` trail; git hooks add agent identity trailers.
+- **Authority knob:** `conservative` (default) vs `team-maintainer` for commit/`bd dolt push`.
+- **No hosted agent passport.** Stealth / `--contributor` modes keep planning beads out of shared PRs.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| CLI | `bd` — `--json` on list/show/create |
+| MCP | `beads-mcp` stdio |
+| Agent setup | `bd setup claude\|codex\|cursor\|…` |
+| Sync | `bd dolt push` / `bd dolt pull` |
+| Docs | https://beads.gascity.com — also `/llms.txt` index |
+
+---
+
+## Human-in-the-Loop Support
+
+Gates can wait on a human, a timer, or GitHub. `conservative` profile tells the agent to report diffs and not commit. Aider integration is explicitly human-run (`/run`). The operational loop for claim/close does not require a tracker UI.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **GitHub Issues / Jira** | Human dashboards; no `bd ready` graph, hash IDs, or `bd prime` injection |
+| **LycheeMem / agentmemory / Claude-Mem** | Fact or session memory. Beads is a **work graph** (issues, blockers, formulas), not a recall store |
+| **Markdown TODO in the repo** | No dependency-aware ready queue, no collision-safe IDs, no Dolt sync |
+
+---
+
+## Use Cases
+
+- **Long-horizon coding agents** that lose the chat but must resume the next unblocked bead
+- **Multi-agent / multi-clone work** — hash IDs + Dolt remotes
+- **Discovered-from bugs** — create a child bead mid-implementation without a human filing it
+- **Session priming** — `bd prime` + `bd remember` instead of rewriting MEMORY.md

--- a/services/memory-and-state/compartment.md
+++ b/services/memory-and-state/compartment.md
@@ -1,0 +1,176 @@
+# Compartment
+
+> **"Encrypted, fully offline memory for AI agents."**
+
+| | |
+|---|---|
+| **Website** | https://maxfreedompollard.github.io/Compartment/ |
+| **Docs** | https://github.com/MaxFreedomPollard/Compartment#readme |
+| **GitHub** | https://github.com/MaxFreedomPollard/Compartment |
+| **Stars** | [![GitHub Stars](https://img.shields.io/github/stars/MaxFreedomPollard/Compartment?style=social)](https://github.com/MaxFreedomPollard/Compartment) |
+| **Classification** | `agent-native` |
+| **Category** | [Memory & State Services](README.md) |
+| **License** | Apache-2.0 |
+| **Latest-month signal** | Last GitHub push 2026-09-02 ([repo metadata](https://api.github.com/repos/MaxFreedomPollard/Compartment)); PyPI `compartment` |
+| **Verified at** | 2026-09-03 |
+
+---
+
+## Official Website
+
+https://maxfreedompollard.github.io/Compartment/
+
+Page H1 body (live 2026-09-03): **"Encrypted, fully offline memory for AI agents."** Site `<title>` uses the close variant “Encrypted, fully offline **agentic** memory…” — the catalog tagline is the **H1 sentence**, which matches the README bold lead.
+
+---
+
+## Official Repo
+
+https://github.com/MaxFreedomPollard/Compartment
+
+README: **"Encrypted, fully offline memory for AI agents."** One vault on the machine, read and written by Claude Code, Claude Desktop, Hermes, OpenClaw, Cursor, Codex, and any MCP client. No API key, no account, no network, no telemetry.
+
+---
+
+## How to Use (Agent Onboarding)
+
+**Interaction pattern:** `CLI` + MCP (`compartment serve`)
+
+```bash
+pip install compartment && compartment init
+compartment integrate claude      # also: hermes, openclaw, or --all
+# MCP clients without a recipe:
+# { "mcpServers": { "compartment": { "command": "compartment", "args": ["serve"] } } }
+```
+
+`integrate --list` documents ~28 MCP clients (Cursor, VS Code, Cline, Codex CLI, Gemini CLI, …). `integrate claude` can install a PostToolUse capture hook (`--no-hooks` skips it) plus the `/compartmentalize` skill.
+
+**The GUI is secondary.** The menu-bar / tray / Linux window unlocks the vault and opens a 127.0.0.1 read-only dashboard. The agent operational surface is **MCP + CLI**, not the panel.
+
+There is no URL-onboarding document.
+
+---
+
+## Agent Skills
+
+**Status:** ✅ `/compartmentalize` installed by `integrate claude|hermes|openclaw` (not `npx skills add`)
+
+| Skill | What It Teaches the Agent |
+|---|---|
+| `/compartmentalize` | Store one-claim memories, recall, supersede opinions |
+| Claude Code plugin | Marketplace: `/plugin marketplace add MaxFreedomPollard/Compartment` then `/plugin install compartment@maxfreedompollard` |
+
+```bash
+npx clawhub@latest search compartment
+```
+
+---
+
+## MCP
+
+**Status:** ✅ Available — this is the agent surface
+
+| Detail | Value |
+|---|---|
+| **MCP Repo** | https://github.com/MaxFreedomPollard/Compartment |
+| **Transport** | stdio (`compartment serve`) |
+| **Compatible Clients** | Any of the 28 `integrate` targets + generic MCP hosts |
+| **Tools (upstream)** | `memory_store` / `memory_store_many`, recall, `memory_recent`, `memory_link` / `memory_relations`, expire, supersede |
+
+While the vault is locked, tools no-op (hooks always exit 0 so they cannot break the editor).
+
+---
+
+## What It Does
+
+Compartment is an **encrypted, fully offline** memory vault for AI agents. Official docs: one claim per memory (hard 200-character / no-list rule), required `source` + `discovered` date, optional `expires`, opinions that supersede rather than duplicate, hybrid vector+keyword recall (~12 ms) over an in-memory index, and a hash-chained audit log. Embeddings are a bundled ONNX model; **no LLM inside**, **CI-enforced no network**. Vectors are encrypted at rest; only the passphrase opens the vault.
+
+A new vault includes ~6,700 reference facts (toggle-able). Capture does not depend on the model calling a tool: the Claude hook writes memory files even if the host’s system prompt overrides tool instructions.
+
+Distinct from [Claude-Mem](claude-mem.md) / [agentmemory](agentmemory.md): Compartment’s differentiator is **offline + encryption + one-claim discipline**, not session compression or a shared unencrypted server.
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | README/site H1: **"Encrypted, fully offline memory for AI agents."** — [Compartment](https://maxfreedompollard.github.io/Compartment/), [repo](https://github.com/MaxFreedomPollard/Compartment) |
+| **Agent-specific primitive** | One-claim memories with source/date; opinion supersede; MCP store/recall; hook capture that cannot be overridden by a host system prompt |
+| **Autonomy-compatible control plane** | After unlock + `integrate`, MCP store/recall runs without the GUI. Auto-lock is a safety timer, not a per-write approval |
+| **M2M integration surface** | `compartment` CLI, `compartment serve` MCP, plugin marketplace, 28-client `integrate` |
+| **Identity / delegation** | **C5-local / passphrase:** the vault secret is the operator passphrase (+ optional 2FA/keyfile). Memories record `source`; dashboard shows per-agent counts. Recalled text is wrapped as data (not instructions); `quarantined` adds a warning. No minted KYA token — unlock is authorization |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **Encrypted vault** | `memory.vault` under `.compartment`; vectors encrypted |
+| **One-claim memory** | `max_memory_chars` (200); lists/headings rejected |
+| **Source + discovered** | Required provenance clause on every record |
+| **Opinion supersede** | Replace-in-place with audit pointer; facts accumulate |
+| **`expires`** | Date or duration; swept by `compartment expire` |
+| **`memory_link`** | Deterministic subject–predicate–object graph |
+| **MCP `serve`** | Agent read/write while unlocked |
+| **Hook capture** | PostToolUse write path independent of the model |
+
+---
+
+## Autonomy Model
+
+```
+pip install compartment → compartment init → unlock → integrate <agent>
+    -> Agent calls MCP store/recall (or the Claude hook writes files)
+    -> Opinions supersede; facts accumulate; expiry sweeps stale claims
+    -> Next session / next MCP client on this machine uses the same vault
+    -> Lock (or auto-lock) seals the file; agents no-op until unlock
+```
+
+---
+
+## Identity and Delegation Model
+
+- **Unlock = capability:** passphrase (and optional 2FA) opens the vault for every integrated agent on the machine.
+- **Attribution:** `source` / `discovered` on each claim; per-agent dashboard counts.
+- **Data vs instructions:** recall is wrapped; `quarantined` sources are warned.
+- **Honest C5:** shared machine vault, not per-agent OAuth. Do not treat the GUI connect buttons as a KYA layer.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| CLI | `compartment init`, `serve`, `integrate`, `unlock`/`lock`, `audit verify` |
+| MCP | `compartment serve` (stdio) |
+| Plugin | Claude Code / Codex marketplace |
+| GUI / dashboard | Secondary; 127.0.0.1 read-only map |
+| Packs | `compartment pack` / `setup airgap-bundle` |
+
+---
+
+## Human-in-the-Loop Support
+
+Unlock, passphrase change, and 2FA are operator actions. The dashboard is read-only. Opinion-overlap audit (`compartment opinions audit`) can be manual. Store/recall after unlock does not need a click.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **@modelcontextprotocol/server-memory** | Plaintext `memory.jsonl`, substring search, no encryption |
+| **Claude-Mem / agentmemory** | Local but not CI-enforced offline + encrypted vectors + one-claim store |
+| **Hosted mem0 / cloud memory** | Network + API keys — fails the offline contract |
+| **The Compartment GUI alone** | Operator panel; without MCP it would not be agent-native |
+
+---
+
+## Use Cases
+
+- **Air-gapped agents** — memory never leaves the machine (CI-enforced)
+- **Encrypted shared vault** — several MCP clients, one passphrase
+- **Preference updates** — opinions supersede; facts stay in the audit chain
+- **Time-bounded secrets** — door codes / sale prices with `expires`

--- a/services/memory-and-state/memoir.md
+++ b/services/memory-and-state/memoir.md
@@ -1,0 +1,191 @@
+# Memoir
+
+> **"Git for AI Memory"**
+
+| | |
+|---|---|
+| **Website** | https://www.memoir-ai.dev |
+| **Docs** | https://zhangfengcdt.github.io/memoir/ |
+| **GitHub** | https://github.com/zhangfengcdt/memoir |
+| **Stars** | [![GitHub Stars](https://img.shields.io/github/stars/zhangfengcdt/memoir?style=social)](https://github.com/zhangfengcdt/memoir) |
+| **Classification** | `agent-native` |
+| **Category** | [Memory & State Services](README.md) |
+| **License** | Apache-2.0 |
+| **Status** | **Alpha** — official README badge `Status-Alpha`; contributing section: “Memoir is alpha” |
+| **Latest-month signal** | Last GitHub push 2026-09-03 ([repo metadata](https://api.github.com/repos/zhangfengcdt/memoir)); PyPI `memoir-ai`; Claude Code / Codex plugins |
+| **Verified at** | 2026-09-03 |
+
+---
+
+## Official Website
+
+https://www.memoir-ai.dev
+
+Homepage H1 (live 2026-09-03): **"Git for AI Memory"** — “Local-first memory your agents can explain, rewind, and branch.”
+
+GitHub Pages docs (`https://zhangfengcdt.github.io/memoir/`) use a different intro: “Welcome to Memoir's Documentation” / “semantic memory system for AI agents… Git-like version control.” The catalog tagline is the **homepage/README H1**, not the docs welcome heading.
+
+---
+
+## Official Repo
+
+https://github.com/zhangfengcdt/memoir
+
+README H1 quote: **Git for AI Memory** / *Hierarchical Memory with Git-Like Version Control*. GitHub description: **"Hierarchical Agent Memory with Git-Like Version Control"**
+
+**Alpha caveat (keep):** README ships `[Status-Alpha]` and says contributions are welcome because the project is alpha and optimized for coding agents.
+
+---
+
+## How to Use (Agent Onboarding)
+
+**Interaction pattern:** `SDK / CLI` + plugins / MCP
+
+```bash
+pip install memoir-ai
+# Claude Code:
+#   /plugin marketplace add zhangfengcdt/memoir
+#   /plugin install memoir@memoir
+```
+
+Any MCP host (no extra install if `uv` is on PATH):
+
+```json
+{
+  "mcpServers": {
+    "memoir": {
+      "command": "uvx",
+      "args": ["--from", "memoir-ai[mcp]", "memoir-mcp"],
+      "env": { "MEMOIR_STORE": "~/.memoir/mcp" }
+    }
+  }
+}
+```
+
+CLI loop: `memoir new ./store` → `memoir remember "…" -p path` → `memoir recall "…" --json`. Codex: `codex plugin marketplace add zhangfengcdt/memoir` and enable hooks. Hermes / OpenClaw / OpenCode plugins are documented on the homepage.
+
+There is no URL-onboarding document.
+
+---
+
+## Agent Skills
+
+**Status:** ✅ Bundled with Claude Code / Codex plugins (not `npx skills add`)
+
+| Skill | What It Teaches the Agent |
+|---|---|
+| `memory-recall` / `memoir-remember` | When to recall vs write a path |
+| `memoir-onboard` | Project snapshot / taxonomy onboarding |
+| `memoir-status` / `memoir-ui` | Store health and visual explorer |
+
+```bash
+npx clawhub@latest search memoir
+```
+
+---
+
+## MCP
+
+**Status:** ✅ Available — `memoir-mcp`
+
+| Detail | Value |
+|---|---|
+| **MCP Repo** | https://github.com/zhangfengcdt/memoir |
+| **Transport** | stdio (`uvx --from memoir-ai[mcp] memoir-mcp`); remote HTTP documented for ChatGPT / Claude.ai connectors |
+| **Compatible Clients** | Claude Desktop, Cursor, Cline, Windsurf, VS Code, Zed, Continue, LibreChat, and any MCP host |
+| **Tools (upstream)** | `memoir_recall`, `memoir_remember`, `memoir_forget`, `memoir_status`, `memoir_branches`, `memoir_checkout`, `memoir_commits` |
+
+---
+
+## What It Does
+
+Memoir replaces opaque vector memory with a **local-first, taxonomy-structured, Git-versioned store**. Official homepage: recall by path (`memoir get api.v2.auth`), time-travel to reproduce bugs, branch to test risky strategies. Claude Code hooks shadow git branches so a `git checkout` does not contaminate `main` memory. Merges review feature-branch lessons into the main knowledge base.
+
+**Alpha:** APIs, plugins, and taxonomy may change. Treat as an early coding-agent memory VCS, not a frozen production SLA.
+
+Distinct from [Memoria](memoria.md) (also git-like, different product) and from [Claude-Mem](claude-mem.md) (compressed observation firehose): Memoir’s claim is **hierarchical semantic paths + cryptographic git operations** (`blame` / `checkout` / `merge`), not session-log compression.
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | Homepage/README H1: **"Git for AI Memory"** — [memoir-ai.dev](https://www.memoir-ai.dev), [README](https://github.com/zhangfengcdt/memoir). Copy: built for coding agents and custom runtimes |
+| **Agent-specific primitive** | Path-addressed memory (`profile.professional.skills.python`); branch-shadowing hooks; `memoir_branches` / `memoir_checkout` / `memoir_commits` MCP tools |
+| **Autonomy-compatible control plane** | After plugin/MCP install, session-start injection and stop-hook capture run without a save click. CLI `--json` + stable exit codes |
+| **M2M integration surface** | `memoir` CLI, Python SDK, `memoir-mcp`, Claude Code / Codex / Hermes / OpenClaw plugins, LangGraph `BaseStore` |
+| **Identity / delegation** | Namespaces + git-like blame (“who taught this rule”). **C5-weak / local:** store path (`MEMOIR_STORE`) and namespace isolate data; no hosted KYA token. Alpha — do not treat blame as a production audit product yet |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **Semantic path** | Hierarchical key (`api.v2.auth`) instead of a vector UUID |
+| **Branch / merge / checkout** | Git operations on the memory store; hooks follow `git checkout` |
+| **`memoir remember` / `recall`** | Write (explicit path or LLM classify) and search |
+| **Time-travel** | `memoir time-travel HEAD~5` to reproduce a poisoned state |
+| **`memoir blame`** | Audit which session taught a rule |
+| **MCP versioning tools** | `memoir_branches`, `memoir_checkout`, `memoir_commits` |
+
+---
+
+## Autonomy Model
+
+```
+Install plugin or memoir-mcp
+    -> Session start injects relevant paths
+    -> Agent remembers/recalls via MCP or slash commands
+    -> git checkout switches the memory branch (hooks)
+    -> Session stop auto-captures durable facts
+    -> Optional memoir merge to promote a feature-branch lesson
+```
+
+---
+
+## Identity and Delegation Model
+
+- **Namespace / store path:** `MEMOIR_STORE` or `./my_store`; MCP default `~/.memoir/mcp`.
+- **Blame:** cryptographic history of who wrote a path — still **Alpha**.
+- **Branch isolation:** feature-branch memories do not leak onto `main` until merge.
+- **No hosted agent passport.** LLM keys (optional) are for classification/recall modes, not identity.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| PyPI | `pip install memoir-ai` (import `memoir`, CLI `memoir`) |
+| MCP | `memoir-mcp` via `uvx --from memoir-ai[mcp]` |
+| Plugins | Claude Code, Codex, Hermes, OpenClaw, community OpenCode |
+| SDK | Async `MemoryClient`; LangGraph `LangGraphMemoryStore` |
+| UI | `memoir ui` — local explorer (secondary) |
+
+---
+
+## Human-in-the-Loop Support
+
+`memoir ui` and `memoir merge` are operator/review surfaces. Auto-capture and recall do not require the UI. Merge conflicts on memory paths are the HITL analog of a git merge.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **Vector DB / “vibe search”** | No path addressing, branch shadowing, or `blame`/`checkout` |
+| **CLAUDE.md as a global store** | Official anti-pattern: token rent + cache invalidation |
+| **Claude-Mem** | Firehose compression, not a git-versioned taxonomy |
+| **Memoria** | Separate git-like memory product; different store and plugin matrix |
+
+---
+
+## Use Cases
+
+- **Branch-aware coding agents** — experimental refactor memory stays off `main`
+- **Reproducible memory bugs** — time-travel to the commit that poisoned recall
+- **Prefix-cache-friendly prompts** — fetch ten tokens at `api.v2.auth` instead of a blob
+- **Alpha evaluation** — try the VCS model; expect breaking changes

--- a/services/memory-and-state/memorix.md
+++ b/services/memory-and-state/memorix.md
@@ -1,0 +1,186 @@
+# Memorix
+
+> **"Local-first shared memory layer for AI coding agents."**
+
+| | |
+|---|---|
+| **Website** | https://github.com/AVIDS2/memorix |
+| **Docs** | https://github.com/AVIDS2/memorix#readme |
+| **GitHub** | https://github.com/AVIDS2/memorix |
+| **Stars** | [![GitHub Stars](https://img.shields.io/github/stars/AVIDS2/memorix?style=social)](https://github.com/AVIDS2/memorix) |
+| **Classification** | `agent-native` |
+| **Category** | [Memory & State Services](README.md) |
+| **License** | Apache-2.0 |
+| **Latest-month signal** | Last GitHub push 2026-09-02 ([repo metadata](https://api.github.com/repos/AVIDS2/memorix)); npm `memorix`; listed in the official MCP Registry |
+| **Verified at** | 2026-09-03 |
+
+---
+
+## Official Website
+
+https://github.com/AVIDS2/memorix
+
+No separate marketing domain is published (`homepage` is empty on the GitHub repo). The README is the canonical surface.
+
+README H1 quote (live 2026-09-03): **"Local-first shared memory layer for AI coding agents."**
+
+---
+
+## Official Repo
+
+https://github.com/AVIDS2/memorix
+
+GitHub description: open-source **cross-agent** memory layer via MCP for Claude Code, Codex, Cursor, Windsurf, Gemini CLI, Antigravity, OpenClaw, Hermes, and other MCP-capable agents.
+
+---
+
+## How to Use (Agent Onboarding)
+
+**Interaction pattern:** `CLI` + MCP / `memorix setup`
+
+```bash
+npm install -g memorix
+memorix setup --agent claude --global
+# also: codex, copilot, cursor, pi, gemini-cli, opencode, windsurf,
+# kiro, antigravity, trae, openclaw, hermes, omp, dsh, workbuddy, …
+```
+
+Manual MCP (stdio; default tool profile `micro`):
+
+```json
+{
+  "mcpServers": {
+    "memorix": {
+      "command": "memorix",
+      "args": ["serve"]
+    }
+  }
+}
+```
+
+Requires Node.js `>=22.18.0` and a real Git root — **project identity is the git project**, not a chat window. `memorix background start` / `memorix serve-http` expose a shared HTTP endpoint and dashboard when several clients need one daemon.
+
+There is no URL-onboarding document.
+
+---
+
+## Agent Skills
+
+**Status:** ✅ Generated / bundled by `memorix setup` and `memorix skills` (not `npx skills add`)
+
+| Skill | What It Teaches the Agent |
+|---|---|
+| Official per-agent skills | When to search, store, promote, and resume a Workset |
+| `memorix_promote` | Turn durable knowledge into a reusable project skill |
+
+```bash
+npx clawhub@latest search memorix
+```
+
+---
+
+## MCP
+
+**Status:** ✅ Available — stdio is the default; HTTP optional
+
+| Detail | Value |
+|---|---|
+| **MCP Repo** | https://github.com/AVIDS2/memorix |
+| **Transport** | stdio (`memorix serve`); HTTP via `memorix serve-http` / `background start` |
+| **Compatible Clients** | Claude Code, Codex, Cursor, Windsurf, Copilot, Gemini CLI, OpenCode, OpenClaw, Hermes, Oh-my-Pi, Pi, Kiro, Antigravity, Trae, DeepSeek Harness, WorkBuddy, any MCP client |
+| **Default profile** | `micro` — compact core tools (`memorix_project_context`, search, store, resolve) |
+
+---
+
+## What It Does
+
+Memorix is a **local-first shared memory daemon anchored to the Git project**. Official README: the agent can change (Claude Code today, Codex tomorrow, Cursor in the afternoon); the project memory stays. SQLite is canonical; Orama searches; LLM formation/embedding is optional — without keys it still does local full-text retrieval.
+
+It is more than a note store: **Git Memory** turns commits into engineering facts; **Reasoning Memory** keeps alternatives and trade-offs; **Memory Autopilot** builds a bounded Workset (`memorix context` / `memorix resume`); **orchestration** (`memorix orchestrate`) coordinates locks, handoffs, and review loops. Long-term curated items cross projects only when explicitly marked portable.
+
+Distinct from [agentmemory](agentmemory.md) (one memory server, chat/wiki style) and [Claude-Mem](claude-mem.md) (per-user observation firehose): Memorix’s identity key is the **git root**, and the surface is a cross-agent local daemon plus setup matrix.
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | README: **"Local-first shared memory layer for AI coding agents."** / “One project memory system for Claude Code, Codex, … and any MCP-capable agent.” — [AVIDS2/memorix](https://github.com/AVIDS2/memorix) |
+| **Agent-specific primitive** | Git-anchored shared pool; Workset autopilot; Git Memory; Reasoning Memory; `memorix orchestrate` locks/handoffs |
+| **Autonomy-compatible control plane** | After `memorix setup`, hooks and MCP run without a curator. Orchestration review loops are optional gates, not a required GUI |
+| **M2M integration surface** | `memorix` CLI, stdio/HTTP MCP, SDK `createMemoryClient()`, per-agent plugins/hooks/skills |
+| **Identity / delegation** | **C5-local:** “project identity is derived from the real Git root.” Teams/locks/messages attribute work to the calling agent process. No hosted KYA token. Only an explicitly portable user item may leave the project |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **Git-project memory pool** | SQLite + Orama under the repo, shared across agents |
+| **Workset / Autopilot** | `memorix context` / `resume` — start files, cautions, verification |
+| **Git Memory** | Commit-derived facts (`memorix ingest commit`) |
+| **Reasoning Memory** | Design rationale, alternatives, trade-offs |
+| **Orchestration** | Task context, handoffs, file locks, review loops |
+| **`memorix serve`** | stdio MCP bridge (`micro` tool profile) |
+| **Background daemon** | HTTP MCP + dashboard for multi-client use |
+
+---
+
+## Autonomy Model
+
+```
+npm i -g memorix → memorix setup --agent <host> --global
+    -> Agent opens the git project; MCP resolves the repo root
+    -> context/resume injects a Workset; agent searches/stores via MCP
+    -> Optional hooks capture prompts and session lifecycle
+    -> Next agent on the same repo sees the same pool
+```
+
+---
+
+## Identity and Delegation Model
+
+- **Project key:** Git root. No git → no project identity (by design).
+- **Caller:** the wired agent/MCP client; orchestration locks name workers.
+- **Portability:** long-term items stay local unless marked portable.
+- **Honest C5:** filesystem + git scoping, not a delegated cloud credential.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| CLI | `memorix setup`, `serve`, `memory`, `orchestrate`, `doctor` |
+| MCP stdio | `memorix serve` |
+| MCP HTTP | `memorix serve-http` / `background start` |
+| SDK | `createMemoryClient()` |
+| Dashboard | local web UI (operator, not required) |
+
+---
+
+## Human-in-the-Loop Support
+
+Dashboard preview-first cleanup/dedup/retention. Knowledge workspace is review-gated (proposals do not silently overwrite reviewed pages). Orchestration review loops are optional HITL. Day-to-day recall/store does not need the GUI.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **agentmemory** | Shared server across hosts; not a git-root daemon with Git Memory + orchestration |
+| **Claude-Mem** | Per-user firehose compression, not a cross-agent project pool |
+| **Notes file / CLAUDE.md** | No Workset, Git Memory, or multi-agent locks |
+| **Raw SQLite** | No MCP setup matrix or reasoning/git ingest |
+
+---
+
+## Use Cases
+
+- **Handoff across IDEs** — same repo memory in Claude Code, Codex, and Cursor
+- **Commit-aware recall** — “what changed and why” from Git Memory
+- **Parallel agents** — `memorix orchestrate` locks and handoffs
+- **Keyless local search** — FTS without an embedding vendor

--- a/services/memory-and-state/projectmem.md
+++ b/services/memory-and-state/projectmem.md
@@ -1,0 +1,180 @@
+# projectmem
+
+> **"We don't make AI smarter. We make it experienced."**
+
+| | |
+|---|---|
+| **Website** | https://www.projectmem.dev |
+| **Docs** | https://www.projectmem.dev |
+| **GitHub** | https://github.com/riponcm/projectmem |
+| **Stars** | [![GitHub Stars](https://img.shields.io/github/stars/riponcm/projectmem?style=social)](https://github.com/riponcm/projectmem) |
+| **Classification** | `agent-native` |
+| **Category** | [Memory & State Services](README.md) |
+| **License** | MIT |
+| **Latest-month signal** | Last GitHub push 2026-09-01 ([repo metadata](https://api.github.com/repos/riponcm/projectmem)); PyPI `projectmem` v0.3.1 — one MCP server for every project |
+| **Verified at** | 2026-09-03 |
+
+---
+
+## Official Website
+
+https://www.projectmem.dev
+
+Homepage H1 (live 2026-09-03): **"We don't make AI smarter. We make it experienced."** Supporting line: **"Local-first, open-source coding agent memory for Claude Code, Cursor, Codex, Antigravity and every MCP agent"**
+
+---
+
+## Official Repo
+
+https://github.com/riponcm/projectmem
+
+README repeats the same H1. GitHub description: open-source coding-agent memory that records issues, attempts, fixes, and decisions, then warns before the agent repeats a failed approach.
+
+---
+
+## How to Use (Agent Onboarding)
+
+**Interaction pattern:** `SDK / CLI` + MCP
+
+```bash
+pip install -U projectmem
+pjm doctor
+pjm doctor --fix
+pjm init    # per repo — writes .projectmem/ and git hooks
+```
+
+One MCP server serves every registered project (no `--root`):
+
+```json
+{
+  "mcpServers": {
+    "projectmem": {
+      "command": "/absolute/path/to/python",
+      "args": ["-m", "projectmem.mcp_server"]
+    }
+  }
+}
+```
+
+`pjm init` prints this block with the local Python path. Fast-restart the client after editing MCP config. Optional: `pjm wrap claude` injects a token-budgeted memory block before the session.
+
+There is no URL-onboarding document.
+
+---
+
+## Agent Skills
+
+**Status:** ⚠️ No official `npx skills add` package published yet.
+
+```bash
+npx clawhub@latest search projectmem
+```
+
+See: https://agentskills.io/specification to contribute one.
+
+---
+
+## MCP
+
+**Status:** ✅ Available — native stdio server, 17 tools (homepage); README comparison table also says “15 focused tools”
+
+| Detail | Value |
+|---|---|
+| **MCP Repo** | https://github.com/riponcm/projectmem |
+| **Transport** | stdio (`python -m projectmem.mcp_server`) — no persistent server |
+| **Compatible Clients** | Claude Desktop, Claude Code, Cursor, Antigravity, Codex, and any MCP client |
+| **Tools (upstream)** | Distilled summary + per-issue fetch; agent reads memory and logs work on its own |
+
+---
+
+## What It Does
+
+projectmem is a **local-first typed event log** plus a **pre-action judgment gate** for coding agents. Memory lives in `.projectmem/` (append-only `events.jsonl`: issues, attempts, fixes, decisions, notes). Git hooks classify commits (`revert` → failed attempt, `fix:` → fix). `pjm precheck` warns *before* a commit if the staged files match a failed approach.
+
+**Judgment, not just recall:** official positioning is “memory + judgment” — stale memories are flagged, never silently deleted; `pjm score` reports a Prevention Score (hours/tokens/dollars). Cross-project gotchas live in `~/.projectmem/global/`. No cloud, no account, no telemetry (optional `--online` update check only).
+
+Distinct from [Claude-Mem](claude-mem.md) (session firehose) and [agentmemory](agentmemory.md) (shared memory server): projectmem’s contract is a **typed development log** and a **pre-commit / pre-action warning**, not chat-memory extraction.
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | Homepage/README H1: **"We don't make AI smarter. We make it experienced."** — [projectmem.dev](https://www.projectmem.dev), [repo](https://github.com/riponcm/projectmem) |
+| **Agent-specific primitive** | Typed events (issue/attempt/fix/decision) + `pjm precheck` failure warnings + MCP tools that log and recall without a human curator |
+| **Autonomy-compatible control plane** | After MCP wiring, the agent reads `get_summary` / writes events; git hooks capture commits. No per-turn dashboard |
+| **M2M integration surface** | `pjm` CLI (25 commands), stdio MCP, `pjm wrap`, optional local dashboard |
+| **Identity / delegation** | **C5-weak / local:** memory is scoped to the git repo (`.projectmem/`) plus optional `~/.projectmem/global/`. No minted KYA token, no multi-tenant agent passport — filesystem + MCP process identity only |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **Typed event log** | `events.jsonl` — issues, attempts, fixes, decisions, notes |
+| **`pjm precheck`** | Pre-commit / pre-action warning against failed approaches |
+| **MCP server** | One stdio process for every registered project |
+| **`pjm wrap`** | Token-budgeted context injection into CLAUDE.md / session |
+| **Global memory** | `~/.projectmem/global/` library-scoped gotchas |
+| **Prevention Score** | `pjm score` — A+–F plus hours/tokens/USD |
+| **Stale-flag, never delete** | Git-verified staleness; history is superseded, not erased |
+
+---
+
+## Autonomy Model
+
+```
+pip install projectmem → pjm doctor --fix → wire MCP → pjm init per repo
+    -> Agent calls get_summary / get_issue at session start
+    -> Agent logs issues, attempts, fixes, decisions via MCP
+    -> Git hooks classify commits; pjm precheck warns before repeat failures
+    -> Next session reads distilled memory (~800–1,500 tokens in MCP mode)
+```
+
+---
+
+## Identity and Delegation Model
+
+- **Project scope:** `.projectmem/` inside the repository; global gotchas under `~/.projectmem/global/`.
+- **No cloud identity:** no account, no API key, no telemetry by default.
+- **Author of an event** is the agent (or git hook) that wrote it — not a hosted agent ID.
+- **Honest C5:** this is local filesystem isolation, not delegated OAuth or a KYA token.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| CLI | `pjm init`, `doctor`, `precheck`, `wrap`, `score`, `dashboard` |
+| MCP | `python -m projectmem.mcp_server` (stdio) |
+| Store | `.projectmem/events.jsonl` + distilled markdown |
+| Wrap | `pjm wrap claude` / Cursor rules / clipboard |
+
+---
+
+## Human-in-the-Loop Support
+
+Optional `pjm dashboard` (ephemeral local viewer) and `pjm score` for operators. The agent loop does not require the GUI. Pre-commit warnings surface to whoever runs `git commit` — often the agent.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **Claude-Mem** | Auto-firehose + compression of tool calls. projectmem is a typed event log + judgment gate |
+| **agentmemory** | Shared memory server across hosts. No pre-commit failure warning or `events.jsonl` vocabulary |
+| **mem0 / chat memory** | Chat-level facts, not development-history events |
+| **CLAUDE.md alone** | Static rules. projectmem is dynamic history of what failed |
+
+---
+
+## Use Cases
+
+- **Stop repeating a failed approach** — `pjm precheck` names the dead end before the commit
+- **Cheaper session start** — distilled MCP summary instead of re-reading the tree
+- **Cross-project gotchas** — Pydantic/SQLAlchemy lessons follow the next repo
+- **Air-gapped memory** — 100% local, MIT, no telemetry

--- a/services/tool-access-and-integration/README.md
+++ b/services/tool-access-and-integration/README.md
@@ -35,6 +35,8 @@ Agent-native tool access services solve all three problems with primitives that 
 | [SandBase CLI](sandbase-cli.md) [![⭐](https://img.shields.io/github/stars/sandbaseai/cli?style=social)](https://github.com/sandbaseai/cli) | Give your AI agent superpowers. One command. 2,000+ AI models. | local stdio MCP · `discover → inspect → run` · CLI connect/doctor/catalog · Agent Skill | ✅ |
 | [ContextForge](contextforge.md) [![⭐](https://img.shields.io/github/stars/IBM/mcp-context-forge?style=social)](https://github.com/IBM/mcp-context-forge) | Registry and proxy that federates MCP, A2A, and REST/gRPC | `mcpgateway` CLI, Docker, MCP/A2A/REST/gRPC, UAID routing | ✅ |
 | [MCP Gateway & Registry](mcp-gateway-registry.md) [![⭐](https://img.shields.io/github/stars/agentic-community/mcp-gateway-registry?style=social)](https://github.com/agentic-community/mcp-gateway-registry) | Unified Agent & MCP Server Registry – Gateway for AI Development Tools | nginx gateway, FastAPI registry, MCP, REST, Helm/Terraform | ✅ |
+| [MCPHub](mcphub.md) [![⭐](https://img.shields.io/github/stars/samanhappy/mcphub?style=social)](https://github.com/samanhappy/mcphub) | One gateway for all your MCP servers. | Docker hub, `/mcp` routes, `$smart`, bearer/OAuth, CLI | ✅ |
+| [MCPJungle](mcpjungle.md) [![⭐](https://img.shields.io/github/stars/mcpjungle/MCPJungle?style=social)](https://github.com/mcpjungle/MCPJungle) | Run all your MCP servers behind one endpoint | Compose `/mcp`, tool groups, enterprise tokens, MPL-2.0 | ✅ |
 
 
 

--- a/services/tool-access-and-integration/mcphub.md
+++ b/services/tool-access-and-integration/mcphub.md
@@ -1,0 +1,183 @@
+# MCPHub
+
+> **"One gateway for all your MCP servers."**
+
+| | |
+|---|---|
+| **Website** | https://www.mcphub.app |
+| **Docs** | https://docs.mcphub.app/ |
+| **GitHub** | https://github.com/samanhappy/mcphub |
+| **Stars** | [![GitHub Stars](https://img.shields.io/github/stars/samanhappy/mcphub?style=social)](https://github.com/samanhappy/mcphub) |
+| **Classification** | `agent-native` |
+| **Category** | [Tool Access & Integration Services](README.md) |
+| **License** | Apache-2.0 |
+| **Latest-month signal** | Last GitHub push 2026-09-03 ([repo metadata](https://api.github.com/repos/samanhappy/mcphub)); Docker `samanhappy/mcphub`; demo https://demo.mcphub.app/ |
+| **Verified at** | 2026-09-03 |
+
+---
+
+## Official Website
+
+https://www.mcphub.app
+
+Homepage H1 (live 2026-09-03): **"One gateway for all your MCP servers."** Supporting line: “Connect, organize, control, and operate your MCP servers through a self-hosted unified gateway.”
+
+---
+
+## Official Repo
+
+https://github.com/samanhappy/mcphub
+
+README lead: **"A self-hosted MCP gateway and management platform for connecting, managing, and operating MCP servers."** GitHub description matches that sentence.
+
+---
+
+## How to Use (Agent Onboarding)
+
+**Interaction pattern:** `CLI` + MCP gateway
+
+```bash
+docker run -p 3000:3000 \
+  -v ./mcp_settings.json:/app/mcp_settings.json \
+  -v ./data:/app/data \
+  samanhappy/mcphub
+```
+
+Point an MCP client at a stable URL (auth on by default):
+
+```
+http://localhost:3000/mcp           # all servers
+http://localhost:3000/mcp/{group}   # group
+http://localhost:3000/mcp/{server}  # one server
+http://localhost:3000/mcp/$smart    # semantic tool discovery
+```
+
+CLI against a running hub: `mcphub login --url http://localhost:3000 --username admin` then `mcphub servers add …` / `mcphub call …`. Headless: `DISABLE_WEB=true`. First-run admin password is random in logs unless `ADMIN_PASSWORD` is set.
+
+There is no URL-onboarding document.
+
+---
+
+## Agent Skills
+
+**Status:** ⚠️ No official `npx skills add` package published yet.
+
+```bash
+npx clawhub@latest search mcphub
+```
+
+See: https://agentskills.io/specification to contribute one.
+
+---
+
+## MCP
+
+**Status:** ✅ Available — the product **is** the gateway
+
+| Detail | Value |
+|---|---|
+| **MCP Repo** | https://github.com/samanhappy/mcphub |
+| **Transport** | Streamable HTTP (and SSE) at `/mcp`, `/mcp/{group}`, `/mcp/{server}`, `/mcp/$smart` |
+| **Compatible Clients** | Claude Desktop, Claude Code, Cursor, Cline, Continue, Windsurf, Zed, Cherry Studio, OpenWebUI, custom agents |
+| **Upstreams** | stdio, SSE, Streamable HTTP MCP servers |
+
+---
+
+## What It Does
+
+MCPHub is a **self-hosted MCP gateway**: register local and remote MCP servers once, then expose **stable endpoints** with groups, aliases, bearer/OAuth auth, health checks, logs, hot-reload, optional PostgreSQL + pgvector **smart routing**, and tool-result compression. The dashboard is an operator surface; `DISABLE_WEB=true` leaves API + MCP only.
+
+**Distinct from catalog peers:**
+
+| Peer | Difference |
+|---|---|
+| [ContextForge](contextforge.md) | IBM federation of MCP + **A2A + REST/gRPC** with UAID. MCPHub is MCP-only connect/organize/control/operate |
+| [MCP Gateway & Registry](mcp-gateway-registry.md) | Enterprise IdP registry (Keycloak/Entra), virtual MCP, 3LO egress, skill scanning |
+| [ToolHive](toolhive.md) | Secure **container runtime** for launching MCP servers |
+| [Toolport](toolport.md) | Local stdio meta-gateway + OS keychain — not a hosted/self-hosted HTTP hub |
+| [Obot](obot.md) | Full MCP platform **plus chat client** |
+| Hosted [MCP Gateway](mcpgateway.md) | Commercial one-URL tools/skills/sandboxes (`mcpgateway-sdk`) |
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | Homepage H1: **"One gateway for all your MCP servers."** — [mcphub.app](https://www.mcphub.app). README: unified endpoints for Claude Code, Cursor, and other MCP-compatible applications |
+| **Agent-specific primitive** | One MCP URL over many backends; `$smart` semantic tool discovery; group/server routes; OAuth 2.0 client+server modes |
+| **Autonomy-compatible control plane** | After register + token, agents call tools through `/mcp` with no dashboard click. Hot-swap config without downtime |
+| **M2M integration surface** | Docker, `mcphub` CLI, HTTP MCP, REST/API, marketplace `discover`/`install` |
+| **Identity / delegation** | JWT + bcrypt local users; **bearer keys**; OAuth 2.0 (client and server); server/group visibility. MCP auth is **on by default**. Social login (GitHub/Google) is optional dashboard SSO (Better Auth, database mode) — not the agent data-plane identity |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **Unified `/mcp`** | Aggregate, group, single-server, or `$smart` routes |
+| **Server groups / aliases** | Per-team or per-project tool subsets |
+| **Smart routing** | Vector index over tool descriptions |
+| **Bearer + OAuth** | Keys for agents; OAuth 2.0 for clients and upstreams |
+| **Hot-swappable config** | `mcp_settings.json` or PostgreSQL — no restart required |
+| **Health + logs** | Per-server status, latency, tool-call inspect |
+
+---
+
+## Autonomy Model
+
+```
+Operator starts Docker (or pnpm) and registers MCP servers
+    -> Issues a bearer key (or OAuth client) for the agent
+    -> Agent connects to http://localhost:3000/mcp (or $smart / group)
+    -> Gateway routes, meters, and logs; dashboard is optional
+```
+
+---
+
+## Identity and Delegation Model
+
+- **Agent callers:** bearer keys (`mcphub keys create`) or OAuth tokens on the MCP endpoints.
+- **Upstream credentials:** stored in hub config / DB — not in every client’s `mcp.json`.
+- **Visibility:** server and group ACLs decide which tools a key can see.
+- **Dashboard users** (admin / social login) are a separate control-plane identity.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| Docker | `samanhappy/mcphub` (`latest` / `latest-full`) |
+| HTTP MCP | `/mcp`, `/mcp/{group}`, `/mcp/{server}`, `/mcp/$smart` |
+| CLI | `mcphub login`, `servers`, `tools`, `call`, `discover`, `install` |
+| Config | `mcp_settings.json` or PostgreSQL (database mode) |
+| Dashboard | `:3000` — optional (`DISABLE_WEB=true`) |
+
+---
+
+## Human-in-the-Loop Support
+
+Web UI for connect/organize/operate. Data-plane tool calls do not require a click. First-time OAuth to an upstream may need a human browser once.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **ContextForge** | MCP+A2A+REST/gRPC federation + UAID — different protocol claim |
+| **MCP Gateway & Registry** | Org IdP / 3LO / skill admission registry |
+| **ToolHive** | Container runtime, not a multi-route HTTP hub with `$smart` |
+| **Toolport / Obot / hosted MCP Gateway** | Local stdio hub, chat+hosting platform, and commercial one-URL SaaS respectively |
+| **A generic reverse proxy** | No MCP tool index, smart routing, or group ACLs |
+
+---
+
+## Use Cases
+
+- **One URL for every IDE** — Claude, Cursor, Cline share the same hub
+- **Semantic tool pick** — `$smart` returns a small matching set
+- **Self-hosted MCP ops** — health, logs, hot-reload, optional Postgres
+- **CI tool calls** — `mcphub call … --json` with a scoped key

--- a/services/tool-access-and-integration/mcpjungle.md
+++ b/services/tool-access-and-integration/mcpjungle.md
@@ -1,0 +1,182 @@
+# MCPJungle
+
+> **"Run all your MCP servers behind one endpoint"**
+
+| | |
+|---|---|
+| **Website** | https://docs.mcpjungle.com |
+| **Docs** | https://docs.mcpjungle.com |
+| **GitHub** | https://github.com/mcpjungle/MCPJungle |
+| **Stars** | [![GitHub Stars](https://img.shields.io/github/stars/mcpjungle/MCPJungle?style=social)](https://github.com/mcpjungle/MCPJungle) |
+| **Classification** | `agent-native` |
+| **Category** | [Tool Access & Integration Services](README.md) |
+| **License** | **MPL-2.0** (OSI-approved; not MIT/Apache) |
+| **Latest-month signal** | Last GitHub push **2026-08-02** ([repo metadata](https://api.github.com/repos/mcpjungle/MCPJungle)) — quieter than neighboring gateways; docs site and Docker Compose path still live as of 2026-09-03 |
+| **Verified at** | 2026-09-03 |
+
+---
+
+## Official Website
+
+https://docs.mcpjungle.com
+
+Docs H1 quote (live 2026-09-03): **"Run all your MCP servers behind one endpoint"**
+
+AI clients can also read the docs via MCP at `https://docs.mcpjungle.com/mcp`.
+
+---
+
+## Official Repo
+
+https://github.com/mcpjungle/MCPJungle
+
+README repeats the same H1. GitHub description: **"One place to manage & connect to all your MCP servers"**
+
+**License:** Mozilla Public License 2.0 — OSI-approved copyleft (file-level), not MIT or Apache-2.0. Disclose that to operators who need a permissive relicensing story.
+
+---
+
+## How to Use (Agent Onboarding)
+
+**Interaction pattern:** `CLI` + MCP gateway
+
+```bash
+curl -O https://raw.githubusercontent.com/mcpjungle/MCPJungle/refs/heads/main/docker-compose.yaml
+docker compose up -d
+brew install mcpjungle/mcpjungle/mcpjungle
+mcpjungle register --name context7 --url https://mcp.context7.com/mcp
+```
+
+Default Streamable HTTP endpoint: `http://localhost:8080/mcp`. Claude Desktop example uses `npx mcp-remote http://localhost:8080/mcp --allow-http`.
+
+Enterprise mode (`mcpjungle start --enterprise` or `SERVER_MODE=enterprise`) then `mcpjungle init` writes an admin token to `~/.mcpjungle.conf` and mints per-client bearer tokens.
+
+There is no URL-onboarding document.
+
+---
+
+## Agent Skills
+
+**Status:** ⚠️ No official `npx skills add` package published yet.
+
+```bash
+npx clawhub@latest search mcpjungle
+```
+
+See: https://agentskills.io/specification to contribute one.
+
+---
+
+## MCP
+
+**Status:** ✅ Available — the gateway **is** one MCP endpoint
+
+| Detail | Value |
+|---|---|
+| **MCP Repo** | https://github.com/mcpjungle/MCPJungle |
+| **Transport** | Streamable HTTP at `/mcp` (stdio and remote upstreams register behind it) |
+| **Compatible Clients** | Claude, Cursor, Codex, Copilot, custom agents |
+| **Docs MCP** | `https://docs.mcpjungle.com/mcp` (documentation only) |
+
+---
+
+## What It Does
+
+MCPJungle is a **self-hosted MCP gateway** for a personal laptop or a team: register stdio and remote MCP servers once, then every client connects to a single `/mcp`. Tool groups expose curated subsets. Development mode is open; **enterprise mode** adds per-client tokens, server-level ACLs, and observability hooks. Upstream static bearer tokens are injected by the gateway (`--bearer-token`); OAuth to upstreams is documented as coming soon.
+
+Last code push as of verification: **2026-08-02**. Still listed because the docs, Compose file, and H1 positioning remain agent-native; operators should note the quieter cadence versus MCPHub/ContextForge.
+
+**Distinct from catalog peers:**
+
+| Peer | Difference |
+|---|---|
+| [MCPHub](mcphub.md) | Node/Docker hub with `$smart` vector routing, dashboard-first ops, Apache-2.0 |
+| [ContextForge](contextforge.md) | MCP + A2A + REST/gRPC + UAID |
+| [MCP Gateway & Registry](mcp-gateway-registry.md) | Org IdP, virtual MCP, 3LO, skill scanning |
+| [ToolHive](toolhive.md) | Secure container runtime |
+| [Toolport](toolport.md) | Local stdio meta-tools + keychain |
+| [Obot](obot.md) | Hosting + registry + chat client |
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | Docs/README H1: **"Run all your MCP servers behind one endpoint"** — [docs.mcpjungle.com](https://docs.mcpjungle.com), [repo](https://github.com/mcpjungle/MCPJungle). Copy: Claude, Cursor, Codex, or **your own agents** connect to one MCP URL |
+| **Agent-specific primitive** | Single `/mcp` over many registered servers; tool groups; enterprise per-client tokens |
+| **Autonomy-compatible control plane** | After register (+ token in enterprise), agents call tools with no UI click |
+| **M2M integration surface** | Docker Compose, `mcpjungle` CLI, HTTP `/mcp`, HTTP API, docs MCP |
+| **Identity / delegation** | Dev mode is open (local trust). **Enterprise:** admin init token in `~/.mcpjungle.conf`; `mcpjungle create client` mints `Authorization: Bearer` tokens and optional custom tokens from an identity server. Upstream SaaS tokens stay in the gateway. OAuth *to* upstreams is not shipped yet |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **One `/mcp` endpoint** | Streamable HTTP for every client |
+| **Server registry** | stdio + remote MCP, CLI `register` |
+| **Tool groups** | Curated tool subsets per client |
+| **Enterprise client token** | Per-client bearer; optional `--access-token` |
+| **Upstream bearer inject** | `--bearer-token` on register |
+| **Local vs enterprise mode** | Open laptop vs shared-team ACLs |
+
+---
+
+## Autonomy Model
+
+```
+docker compose up -d → mcpjungle register <server>
+    -> Agent connects to http://localhost:8080/mcp
+    -> (Enterprise) agent sends the minted bearer token
+    -> Gateway routes tools/prompts/resources; dashboard optional
+```
+
+---
+
+## Identity and Delegation Model
+
+- **Development:** no client auth — treat as a trusted local endpoint.
+- **Enterprise:** admin user + per-client tokens; which servers a client may reach is explicit.
+- **Upstream secrets:** stored on the gateway, not in every IDE config.
+- **Custom tokens:** `--access-token` / `access_token_ref` for an external identity server.
+- **C5 note:** solid in enterprise mode; weak in default local mode (intentional).
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| Docker Compose | default `:8080/mcp` + Postgres |
+| CLI | `mcpjungle register`, `start --enterprise`, `init`, client create |
+| HTTP MCP | Streamable HTTP `/mcp` |
+| HTTP API | documented on docs.mcpjungle.com |
+| License | MPL-2.0 |
+
+---
+
+## Human-in-the-Loop Support
+
+Optional dashboard UI. Tool calls on `/mcp` do not require a click. Admin creates clients and tool groups in enterprise mode (README: only admin can create tool groups today).
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **MCPHub** | Different stack (Node hub, `$smart`, Apache-2.0). MCPJungle is Go/Compose + MPL + enterprise client tokens |
+| **ContextForge / MCP Gateway & Registry** | Protocol federation + UAID, or org IdP registry — not this one-`/mcp` team gateway |
+| **ToolHive / Toolport / Obot** | Runtime, local stdio hub, or chat+hosting platform |
+| **nginx alone** | No MCP registry, tool groups, or enterprise client tokens |
+
+---
+
+## Use Cases
+
+- **Clean local MCP** — one endpoint instead of per-client server lists
+- **Team gateway** — enterprise tokens and server ACLs
+- **Hide SaaS MCP keys** — upstream bearer stays on the gateway
+- **MPL shops** — OSI license that is not MIT/Apache

--- a/skill.md
+++ b/skill.md
@@ -5,7 +5,7 @@ description: >
   surfaces for live agents. Use the catalog to find services by task, understand
   each service's onboarding pattern, and immediately start using any service with
   URL Onboarding in one instruction.
-version: "2026-08-29"
+version: "2026-09-03"
 license: CC0-1.0
 catalog: https://github.com/haoruilee/awesome-agent-native-services
 allowed-tools: WebSearch Read
@@ -73,7 +73,7 @@ These services can be joined with a single instruction, right now, with no human
 
 ---
 
-## Full Catalog — 16 Categories, 208 Services
+## Full Catalog — 16 Categories, 216 Services
 
 ### 1. Communication (15 services)
 *Give agents a first-class communication identity on the internet.*
@@ -131,7 +131,7 @@ These services can be joined with a single instruction, right now, with no human
 
 ---
 
-### 3. Tool Access & Integration (19 services)
+### 3. Tool Access & Integration (21 services)
 *Runtime tool discovery, auth, and execution without human pre-configuration.*
 
 | Service | Tagline | Onboarding |
@@ -155,6 +155,8 @@ These services can be joined with a single instruction, right now, with no human
 | [SandBase CLI](https://github.com/sandbaseai/cli) | Give your AI agent superpowers. One command. 2,000+ AI models. | GitHub `v0.1.17` tarball `connect`, then `npx skills add sandbaseai/cli --skill sandbase` |
 | [ContextForge](https://ibm.github.io/mcp-context-forge/) | Registry and proxy that federates MCP, A2A, and REST/gRPC | `uvx --from mcp-contextforge-gateway mcpgateway --host 0.0.0.0 --port 4444` |
 | [MCP Gateway & Registry](https://agentic-community.github.io/mcp-gateway-registry/) | Unified Agent & MCP Server Registry | `git clone https://github.com/agentic-community/mcp-gateway-registry && ./build_and_run.sh --prebuilt` |
+| [MCPHub](https://www.mcphub.app) | One gateway for all your MCP servers. | `docker run -p 3000:3000 -v ./data:/app/data samanhappy/mcphub` then connect to `http://localhost:3000/mcp` |
+| [MCPJungle](https://docs.mcpjungle.com) | Run all your MCP servers behind one endpoint | `docker compose up -d` then `mcpjungle register --name context7 --url https://mcp.context7.com/mcp` |
 
 ---
 
@@ -246,7 +248,7 @@ These services can be joined with a single instruction, right now, with no human
 
 ---
 
-### 8. Memory & State (21 services)
+### 8. Memory & State (26 services)
 *Persistent, queryable memory across sessions — memory as infrastructure, not application logic.*
 
 | Service | Tagline | Onboarding |
@@ -272,6 +274,11 @@ These services can be joined with a single instruction, right now, with no human
 | [MemSearch](https://zilliztech.github.io/memsearch/) | Cross-platform semantic memory for AI coding agents | `uv tool install "memsearch[onnx]"` or Claude Code `/plugin marketplace add zilliztech/memsearch` |
 | [Claude-Mem](https://cmem.ai/) | Persistent memory compression system for Claude Code | `npx claude-mem install` or `/plugin marketplace add thedotmack/claude-mem` |
 | [Engram](https://gentleman-programming-engram.mintlify.app/introduction) | Persistent memory for AI coding agents | `brew install gentleman-programming/tap/engram` then `engram setup <agent>` |
+| [Beads](https://beads.gascity.com) | Dependency-aware, Dolt-backed issue tracker built for AI coding agents that survive context loss | `brew install beads` then `bd init --quiet` and `bd setup claude` |
+| [projectmem](https://www.projectmem.dev) | We don't make AI smarter. We make it experienced. | `pip install -U projectmem` then `pjm doctor --fix` and wire `python -m projectmem.mcp_server` |
+| [Memoir](https://www.memoir-ai.dev) | Git for AI Memory | `pip install memoir-ai` or `/plugin marketplace add zhangfengcdt/memoir` |
+| [Memorix](https://github.com/AVIDS2/memorix) | Local-first shared memory layer for AI coding agents. | `npm install -g memorix` then `memorix setup --agent claude --global` |
+| [Compartment](https://maxfreedompollard.github.io/Compartment/) | Encrypted, fully offline memory for AI agents. | `pip install compartment && compartment init && compartment integrate claude` |
 
 ---
 
@@ -348,7 +355,7 @@ These services can be joined with a single instruction, right now, with no human
 
 ---
 
-### 13. Meeting & Conversation (7 services)
+### 13. Meeting & Conversation (8 services)
 *Programmatic agent presence in voice and video meetings.*
 
 | Service | Tagline | Onboarding |
@@ -360,6 +367,7 @@ These services can be joined with a single instruction, right now, with no human
 | [Daily Agent Toolkit](https://github.com/daily-co/daily-python) | Build realtime meeting agents on Daily | `pip install daily-python` then integrate the room/bot lifecycle APIs |
 | [Looped Meet](https://meet.looped.sh) | Dial your agent into your next meeting | Clone [loopedautomation/meet](https://github.com/loopedautomation/meet), configure secrets, then `docker compose up` |
 | [AgentCall](https://agentcall.dev) | Your AI agent, in every meeting. | `/plugin marketplace add pattern-ai-labs/agentcall` then `/plugin install join-meeting@agentcall` |
+| [joinly.ai](https://joinly.ai) | Make your meetings accessible to AI Agents! | `docker run -p 127.0.0.1:8000:8000 ghcr.io/joinly-ai/joinly:latest` then `uvx joinly-client --env-file .env <MeetingUrl>` |
 
 ---
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Maintainer search batch (issue-first waived; same pattern as merged PR #109). Adds 8 OSI-licensed OSS agent-native services from a 2026-09-03 live re-check.

Catalog counts: **208 → 216** / 16 categories.
Memory & State 21 → 26; Tool Access & Integration 19 → 21; Meeting & Conversation 7 → 8.

### Services added

| Service | Category | License | Stars (verified 2026-09-03) | GitHub |
|---|---|---|---|---|
| **Beads** (`bd`) | Memory & State | MIT | ~26,824 | https://github.com/gastownhall/beads |
| **projectmem** | Memory & State | MIT | ~794 | https://github.com/riponcm/projectmem |
| **Memoir** | Memory & State | Apache-2.0 (**Alpha**) | ~610 | https://github.com/zhangfengcdt/memoir |
| **Memorix** | Memory & State | Apache-2.0 | ~716 | https://github.com/AVIDS2/memorix |
| **Compartment** | Memory & State | Apache-2.0 | ~590 | https://github.com/MaxFreedomPollard/Compartment |
| **MCPHub** | Tool Access & Integration | Apache-2.0 | ~2,359 | https://github.com/samanhappy/mcphub |
| **MCPJungle** | Tool Access & Integration | **MPL-2.0** (OSI, not MIT/Apache) | ~1,243 | https://github.com/mcpjungle/MCPJungle |
| **joinly.ai** | Meeting & Conversation | MIT | ~564 | https://github.com/joinly-ai/joinly |

Taglines are exact homepage/README H1 quotes (re-fetched live; no paraphrase). Public-repo rows include GitHub star badges.

### Distinctness notes

- **Beads ≠ LycheeMem / agentmemory / Claude-Mem.** Work graph (`bd ready`, hash IDs, Dolt), not fact/session memory.
- **projectmem ≠ Claude-Mem / agentmemory.** Typed event log + pre-commit judgment gate; local-first.
- **Memoir** is git-versioned path memory; README still says **Alpha**.
- **Memorix** is a git-root cross-agent daemon (Workset / Git Memory / orchestrate).
- **Compartment** is encrypted offline vault; GUI is secondary, MCP is the agent surface.
- **MCPHub / MCPJungle ≠ ContextForge / MCP Gateway & Registry / ToolHive / Toolport / Obot.** Self-hosted one-endpoint MCP hubs; Jungle last push 2026-08-02; MPL-2.0 disclosed.
- **joinly.ai ≠ Vexa / AgentCall / Looped Meet.** OSS MCP meeting middleware that joins Zoom/Meet/Teams.

### Disclosures

- **Memoir:** official Alpha badge; contributing text says the project is alpha.
- **MCPJungle:** MPL-2.0; last GitHub push 2026-08-02 (quieter cadence).
- **joinly.ai:** MCP server has no auth (localhost / trusted client only) — C5-weak, documented.
- Local-first memory rows (projectmem, Memoir, Memorix, Compartment, Beads): no hosted KYA token; C5 is filesystem / git / passphrase / Dolt actor isolation.
- **Skipped after live verification:** none of the eight. Not added (per brief): Oh My OpenAgent, LazyCodex, AgentPhone, KeyID, Clawstr, Overslash, OpenAgentEmail, AgentLine, Botbook, SSSNACK (#114).

## Type of change

- [x] 🆕 New service entry

## Linked issue

Maintainer (haoruilee) authorized this catalog update batch. Issue-first waived. Closes nothing.

## New service checklist

- [x] Standard five-criteria track (all eight dossiers)
- [x] Created `services/{category}/{service-name}.md` with all §7 sections
- [x] Added a row to each category README
- [x] Added a row to the matching root README.md section
- [x] Classification is `agent-native`
- [x] Live GitHub star badges (no hardcoded star numbers in prose)

## Test plan

- [x] `bash scripts/build-github-pages.sh && python3 scripts/build-machine-catalog.py` clean
- [x] `python3 scripts/build-machine-catalog.py --check` → **216 services / 16 categories**
- [x] `python3 scripts/check-repository-health.py --local` → 749 links, 216 services
- [x] Generated `docs/**` and `catalog.json` committed
- [x] GitHub CI green on `35435d3` (`Validate catalog and site / validate`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e375d94-4cdb-4fc4-bab5-1b407983688e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e375d94-4cdb-4fc4-bab5-1b407983688e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

