### PR TITLE
[New Service] September 4 OSS catalog additions

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,20 +83,20 @@ Recommended flow for agents: start with `skill.md` for quick discovery, switch t
 
 ## Categories
 
-**217 services across 16 categories.**
+**223 services across 16 categories.**
 
 | # | Category | Services | Description |
 |---|---|---|---|
 | 1 | [Communication](#1-communication-services) | 15 | Give agents a communication identity on the internet |
 | 2 | [Browser & Web Execution](#2-browser--web-execution-services) | 25 | Remote browser and web data extraction for agents |
-| 3 | [Tool Access & Integration](#3-tool-access--integration-services) | 21 | Runtime tool discovery, auth, and execution |
+| 3 | [Tool Access & Integration](#3-tool-access--integration-services) | 22 | Runtime tool discovery, auth, and execution |
 | 4 | [Oversight & Approval](#4-oversight--approval-services) | 5 | Human-in-the-loop approval and escalation |
 | 5 | [Commerce & Payments](#5-commerce--payment-services) | 12 | Agent-native wallets, identity, and transactions |
 | 6 | [Agent Runtime & Infrastructure](#6-agent-runtime--infrastructure-services) | 29 | Execution, session isolation, secrets, and gateway |
 | 7 | [Agent Harnesses & Operator Surfaces](#7-agent-harnesses--operator-surfaces) | 10 | Durable agent-loop control and live operator visibility |
-| 8 | [Memory & State](#8-memory--state-services) | 26 | Persistent agent memory across sessions |
+| 8 | [Memory & State](#8-memory--state-services) | 28 | Persistent agent memory across sessions |
 | 9 | [Search & Web Intelligence](#9-search--web-intelligence-services) | 9 | LLM-optimized web search and content retrieval |
-| 10 | [Code Execution](#10-code-execution-services) | 13 | Secure sandboxes for AI-generated code |
+| 10 | [Code Execution](#10-code-execution-services) | 16 | Secure sandboxes for AI-generated code |
 | 11 | [Observability & Tracing](#11-observability--tracing-services) | 13 | Agent trajectory tracing and evaluation |
 | 12 | [Durable Execution & Scheduling](#12-durable-execution--scheduling-services) | 6 | Fault-tolerant long-running agent workflows |
 | 13 | [Meeting & Conversation](#13-meeting--conversation-services) | 8 | Agent presence in voice and video meetings |
@@ -201,6 +201,7 @@ Recommended flow for agents: start with `skill.md` for quick discovery, switch t
 | [MCP Gateway & Registry](services/tool-access-and-integration/mcp-gateway-registry.md) [![⭐](https://img.shields.io/github/stars/agentic-community/mcp-gateway-registry?style=social)](https://github.com/agentic-community/mcp-gateway-registry) | Unified Agent & MCP Server Registry – Gateway for AI Development Tools | IdP gateway · virtual MCP · A2A registry · 3LO egress · audit | ✅ | `git clone https://github.com/agentic-community/mcp-gateway-registry && ./build_and_run.sh --prebuilt` |
 | [MCPHub](services/tool-access-and-integration/mcphub.md) [![⭐](https://img.shields.io/github/stars/samanhappy/mcphub?style=social)](https://github.com/samanhappy/mcphub) | One gateway for all your MCP servers. | Unified `/mcp` · groups · `$smart` routing · bearer/OAuth · Docker | ✅ | `docker run -p 3000:3000 -v ./data:/app/data samanhappy/mcphub` — then connect to `http://localhost:3000/mcp` |
 | [MCPJungle](services/tool-access-and-integration/mcpjungle.md) [![⭐](https://img.shields.io/github/stars/mcpjungle/MCPJungle?style=social)](https://github.com/mcpjungle/MCPJungle) | Run all your MCP servers behind one endpoint | One `/mcp` · tool groups · enterprise client tokens · MPL-2.0 | ✅ | `docker compose up -d` then `mcpjungle register --name context7 --url https://mcp.context7.com/mcp` |
+| [MetaMCP](services/tool-access-and-integration/metamcp.md) [![⭐](https://img.shields.io/github/stars/metatool-ai/metamcp?style=social)](https://github.com/metatool-ai/metamcp) | MCP Aggregator, Orchestrator, Middleware, Gateway in one docker | Namespaces · middleware · Streamable HTTP/SSE · `sk_mt_` keys · MIT | ✅ | `git clone https://github.com/metatool-ai/metamcp.git && docker compose up -d` — last push 2026-06-22 |
 
 ---
 
@@ -319,6 +320,7 @@ Recommended flow for agents: start with `skill.md` for quick discovery, switch t
 | [Recall](services/memory-and-state/recall.md) [![⭐](https://img.shields.io/github/stars/RecallWorks/Recall?style=social)](https://github.com/RecallWorks/Recall) | Open-source memory for AI agents. MCP-native. Self-hosted. | Persistent searchable memory · Docker · MCP stdio | ✅ | `uvx ai-recallworks stdio` |
 | [Mem0](services/memory-and-state/mem0.md) [![⭐](https://img.shields.io/github/stars/mem0ai/mem0?style=social)](https://github.com/mem0ai/mem0) | The memory layer for your AI agents | Memory extraction · Conflict resolution (ADD/UPDATE/DELETE/NOOP) · Semantic retrieval · 90% token savings | ✅ | `pip install mem0ai` then `m.add(messages, user_id=...)` |
 | [Zep](services/memory-and-state/zep.md) [![⭐](https://img.shields.io/github/stars/getzep/zep?style=social)](https://github.com/getzep/zep) | Agent memory powered by a temporal knowledge graph | Temporal knowledge graph · Automatic fact invalidation · Business data fusion · Sub-200ms retrieval | ✅ | `pip install zep-python` then `zep.add_session_message(...)` |
+| [Graphiti](services/memory-and-state/graphiti.md) [![⭐](https://img.shields.io/github/stars/getzep/graphiti?style=social)](https://github.com/getzep/graphiti) | Build Real-Time Knowledge Graphs for AI Agents | Temporal context graph · episodes · hybrid search · MCP · OSS ≠ Zep | ✅ | `pip install graphiti-core` or `uv run graphiti_mcp_server.py` |
 | [Ensue](services/memory-and-state/ensue.md) [![⭐](https://img.shields.io/github/stars/mutable-state-inc/autoresearch-at-home?style=social)](https://github.com/mutable-state-inc/autoresearch-at-home) | The shared memory network for AI agents | Claim · Publish result · Hypothesis exchange · Insight network · Collective best · Hypergraph | ✅ | Read the official [Ensue Skill](https://raw.githubusercontent.com/mutable-state-inc/ensue-skill/main/skills/ensue-memory/SKILL.md) and follow its instructions |
 | [OpenViking](services/memory-and-state/openviking.md) [![⭐](https://img.shields.io/github/stars/volcengine/OpenViking?style=social)](https://github.com/volcengine/OpenViking) | The context database for AI agents | `viking://` filesystem · `viking://agent/` namespace · L0/L1/L2 tiered loading · Self-evolution loop | ✅ | `pip install openviking` → `openviking-server` → add MCP at `localhost:8000/mcp` |
 | [MemOS](services/memory-and-state/memos.md) [![⭐](https://img.shields.io/github/stars/MemTensor/MemOS?style=social)](https://github.com/MemTensor/MemOS) | A memory OS for LLM and AI agent systems | MemCube · Parametric/activation/plaintext memory · MemScheduler · +43.7% vs OpenAI Memory | ✅ | `pip install memos-core` then `memory.add(...)` / `memory.get(...)` |
@@ -340,6 +342,7 @@ Recommended flow for agents: start with `skill.md` for quick discovery, switch t
 | [Memoir](services/memory-and-state/memoir.md) [![⭐](https://img.shields.io/github/stars/zhangfengcdt/memoir?style=social)](https://github.com/zhangfengcdt/memoir) | Git for AI Memory | Semantic paths · branch/merge · `memoir-mcp` · Alpha | ✅ | `pip install memoir-ai` or `/plugin marketplace add zhangfengcdt/memoir` |
 | [Memorix](services/memory-and-state/memorix.md) [![⭐](https://img.shields.io/github/stars/AVIDS2/memorix?style=social)](https://github.com/AVIDS2/memorix) | Local-first shared memory layer for AI coding agents. | Git-root daemon · Workset · Git Memory · `memorix serve` | ✅ | `npm install -g memorix` then `memorix setup --agent claude --global` |
 | [Compartment](services/memory-and-state/compartment.md) [![⭐](https://img.shields.io/github/stars/MaxFreedomPollard/Compartment?style=social)](https://github.com/MaxFreedomPollard/Compartment) | Encrypted, fully offline memory for AI agents. | Encrypted vault · one-claim memories · `compartment serve` | ✅ | `pip install compartment && compartment init && compartment integrate claude` |
+| [mcp-memory-service](services/memory-and-state/mcp-memory-service.md) [![⭐](https://img.shields.io/github/stars/doobidoo/mcp-memory-service?style=social)](https://github.com/doobidoo/mcp-memory-service) | Memory for AI Agents — REST, MCP, OAuth, CLI | `X-Agent-ID` · causal graph · OAuth DCR · 76 REST endpoints | ✅ | `pip install mcp-memory-service` then `memory server` or `memory server --http` |
 
 ---
 
@@ -384,6 +387,9 @@ Recommended flow for agents: start with `skill.md` for quick discovery, switch t
 | [Agent Sandbox (Kubernetes SIG)](services/code-execution/kubernetes-agent-sandbox.md) [![⭐](https://img.shields.io/github/stars/kubernetes-sigs/agent-sandbox?style=social)](https://github.com/kubernetes-sigs/agent-sandbox) | Secure isolated execution layer for autonomous agents on Kubernetes | Sandbox CRD · WarmPool/Claim · RuntimeClass · Python/Go SDKs | ⚠️ | `pip install k8s-agent-sandbox` then `SandboxClient().create_sandbox(...)` — not hosted agentsandbox.co |
 | [Clawk](services/code-execution/clawk.md) [![⭐](https://img.shields.io/github/stars/clawkwork/clawk?style=social)](https://github.com/clawkwork/clawk) | Give a coding agent its own disposable Linux machine, not yours | Local hypervisor VM · DNS-aware egress allow-list · `status --json` · snapshot/destroy | ⚠️ | `brew install clawkwork/tap/clawk` then `cd <repo> && clawk` (pre-1.0; macOS Apple silicon) |
 | [Dormice](services/code-execution/dormice.md) [![⭐](https://img.shields.io/github/stars/BitMiracle-AI/Dormice?style=social)](https://github.com/BitMiracle-AI/Dormice) | The SQLite of agent sandboxes — self-hosted, idle costs nothing | Idempotent `acquireSandbox` · freeze/stop/archive · HTTP RPC · E2B SDK compat | ⚠️ | `curl -fsSL https://raw.githubusercontent.com/BitMiracle-AI/Dormice/main/deploy/install.sh \| bash` then `npx skills add BitMiracle-AI/Dormice` (early-dev) |
+| [CubeSandbox](services/code-execution/cubesandbox.md) [![⭐](https://img.shields.io/github/stars/TencentCloud/CubeSandbox?style=social)](https://github.com/TencentCloud/CubeSandbox) | Instant, Concurrent, Secure & Lightweight Sandbox Service for AI Agents | E2B-compat API · RustVMM+KVM · CubeCoW · credential vault | ⚠️ | `curl -sL https://github.com/tencentcloud/CubeSandbox/raw/master/deploy/one-click/online-install.sh \| CUBE_PVM_ENABLE=1 bash` then `pip install e2b-code-interpreter` |
+| [forkd](services/code-execution/forkd.md) [![⭐](https://img.shields.io/github/stars/deeplethe/forkd?style=social)](https://github.com/deeplethe/forkd) | A microVM sandbox runtime for AI agent fan-out. | Firecracker CoW fork · live BRANCH · `forkd-mcp` | ✅ | `curl -sSL https://github.com/deeplethe/forkd/releases/download/v0.5.3/forkd-v0.5.3-x86_64-linux.tar.gz \| sudo tar -xz -C /usr/local/bin/` then `sudo -E forkd quickstart` |
+| [SmolVM](services/code-execution/smolvm.md) [![⭐](https://img.shields.io/github/stars/CelestoAI/SmolVM?style=social)](https://github.com/CelestoAI/SmolVM) | SmolVM: secure microVM sandboxes for AI agents | Firecracker/QEMU/libkrun · browser sandbox · snapshots | ⚠️ | `curl -sSL https://celesto.ai/install.sh \| bash` then `from smolvm import SmolVM` |
 
 ---
 

--- a/catalog.json
+++ b/catalog.json
@@ -11,7 +11,7 @@
     "service_directory": "services",
     "content_digest": {
       "algorithm": "sha256",
-      "value": "7b4f96b3588b432ba998105d9b508741bc4c8d97a2ec2ca35e8e452876f27b2d",
+      "value": "be4ab7ee9f1b69e5a0337fe1d9f75076508d6bdf48b8ec4b5c6f4d6cf26a1be1",
       "input_paths": [
         "README.md",
         "skill.md",
@@ -70,6 +70,7 @@
         "services/tool-access-and-integration/mcpgateway.md",
         "services/tool-access-and-integration/mcphub.md",
         "services/tool-access-and-integration/mcpjungle.md",
+        "services/tool-access-and-integration/metamcp.md",
         "services/tool-access-and-integration/nango.md",
         "services/tool-access-and-integration/obot.md",
         "services/tool-access-and-integration/openchatcut.md",
@@ -147,9 +148,11 @@
         "services/memory-and-state/compartment.md",
         "services/memory-and-state/engram.md",
         "services/memory-and-state/ensue.md",
+        "services/memory-and-state/graphiti.md",
         "services/memory-and-state/hindsight.md",
         "services/memory-and-state/llm-wiki.md",
         "services/memory-and-state/lycheemem.md",
+        "services/memory-and-state/mcp-memory-service.md",
         "services/memory-and-state/mem0.md",
         "services/memory-and-state/mem9.md",
         "services/memory-and-state/memmachine.md",
@@ -182,13 +185,16 @@
         "services/code-execution/axern.md",
         "services/code-execution/clawk.md",
         "services/code-execution/coderunner.md",
+        "services/code-execution/cubesandbox.md",
         "services/code-execution/daytona.md",
         "services/code-execution/dormice.md",
         "services/code-execution/e2b.md",
+        "services/code-execution/forkd.md",
         "services/code-execution/kubernetes-agent-sandbox.md",
         "services/code-execution/opensandbox.md",
         "services/code-execution/riza.md",
         "services/code-execution/runloop.md",
+        "services/code-execution/smolvm.md",
         "services/code-execution/vercel-sandbox.md",
         "services/observability-and-tracing/README.md",
         "services/observability-and-tracing/agent-inspect.md",
@@ -253,7 +259,7 @@
   },
   "counts": {
     "categories": 16,
-    "services": 217
+    "services": 223
   },
   "categories": [
     {
@@ -275,7 +281,7 @@
       "name": "Tool Access & Integration",
       "description": "Services that let AI agents discover, authenticate, and invoke external tools at runtime — without a human pre-configuring credentials or selecting which integrations to activate.",
       "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/README.md",
-      "service_count": 21
+      "service_count": 22
     },
     {
       "id": "oversight-and-approval",
@@ -310,7 +316,7 @@
       "name": "Memory & State",
       "description": "Services that give AI agents persistent, queryable memory across sessions — treating memory as infrastructure rather than application logic, and managing the full lifecycle of what agents remember, forget, and retrieve.",
       "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/README.md",
-      "service_count": 26
+      "service_count": 28
     },
     {
       "id": "search-and-web-intelligence",
@@ -324,7 +330,7 @@
       "name": "Code Execution",
       "description": "Services that give AI agents a secure, isolated runtime for executing generated code — without human-side sandbox setup, without risking the host environment, and with output formatted for direct LLM consumption.",
       "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/README.md",
-      "service_count": 13
+      "service_count": 16
     },
     {
       "id": "observability-and-tracing",
@@ -2024,6 +2030,40 @@
       "verified_at": "2026-09-03",
       "verification_sources": [
         "https://api.github.com/repos/mcpjungle/MCPJungle"
+      ]
+    },
+    {
+      "id": "tool-access-and-integration/metamcp",
+      "slug": "metamcp",
+      "name": "MetaMCP",
+      "tagline": "MCP Aggregator, Orchestrator, Middleware, Gateway in one docker",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "tool-access-and-integration",
+      "website": "https://docs.metamcp.com",
+      "repository": "https://github.com/metatool-ai/metamcp",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/metamcp.md",
+      "source_path": "services/tool-access-and-integration/metamcp.md",
+      "onboarding": {
+        "type": "mcp",
+        "pattern": "CLI + MCP gateway",
+        "instruction": "git clone https://github.com/metatool-ai/metamcp.git\ncd metamcp\ncp example.env .env\ndocker compose up -d",
+        "url": "https://github.com/metatool-ai/metamcp.git"
+      },
+      "protocols": [
+        "mcp",
+        "openapi",
+        "stdio",
+        "http",
+        "api"
+      ],
+      "mcp_status": "available",
+      "agent_skill_status": "unavailable",
+      "latest_month_signal": "Last GitHub push 2026-06-22 (repo metadata) — quieter than MCPHub/ContextForge; default branch ai-dev. README notes maintenance delay while still merging PRs. Still admitted: MIT + clear MCP aggregator/gateway OSS not already listed",
+      "verified_at": "2026-09-04",
+      "verification_sources": [
+        "https://api.github.com/repos/metatool-ai/metamcp"
       ]
     },
     {
@@ -4290,6 +4330,38 @@
       "verification_sources": []
     },
     {
+      "id": "memory-and-state/graphiti",
+      "slug": "graphiti",
+      "name": "Graphiti",
+      "tagline": "Build Real-Time Knowledge Graphs for AI Agents",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "memory-and-state",
+      "website": "https://help.getzep.com/graphiti",
+      "repository": "https://github.com/getzep/graphiti",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/graphiti.md",
+      "source_path": "services/memory-and-state/graphiti.md",
+      "onboarding": {
+        "type": "mcp",
+        "pattern": "SDK + MCP",
+        "instruction": "pip install graphiti-core",
+        "url": "https://help.getzep.com/graphiti/getting-started/mcp-server"
+      },
+      "protocols": [
+        "mcp",
+        "sdk",
+        "stdio"
+      ],
+      "mcp_status": "available",
+      "agent_skill_status": "unavailable",
+      "latest_month_signal": "Last GitHub push 2026-09-03 (repo metadata); PyPI graphiti-core; MCP server in-repo",
+      "verified_at": "2026-09-04",
+      "verification_sources": [
+        "https://api.github.com/repos/getzep/graphiti"
+      ]
+    },
+    {
       "id": "memory-and-state/hindsight",
       "slug": "hindsight",
       "name": "Hindsight",
@@ -4376,6 +4448,40 @@
       "latest_month_signal": null,
       "verified_at": null,
       "verification_sources": []
+    },
+    {
+      "id": "memory-and-state/mcp-memory-service",
+      "slug": "mcp-memory-service",
+      "name": "mcp-memory-service",
+      "tagline": "Memory for AI Agents — REST, MCP, OAuth, CLI",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "memory-and-state",
+      "website": "https://mcpmemory.services",
+      "repository": "https://github.com/doobidoo/mcp-memory-service",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/mcp-memory-service.md",
+      "source_path": "services/memory-and-state/mcp-memory-service.md",
+      "onboarding": {
+        "type": "mcp",
+        "pattern": "CLI + MCP / REST",
+        "instruction": "pip install mcp-memory-service",
+        "url": "http://localhost:8000"
+      },
+      "protocols": [
+        "mcp",
+        "rest",
+        "cli",
+        "stdio",
+        "http"
+      ],
+      "mcp_status": "available",
+      "agent_skill_status": "unavailable",
+      "latest_month_signal": "Last GitHub push 2026-09-02 (repo metadata); PyPI mcp-memory-service; homepage showed v11.10.0 on 2026-09-04",
+      "verified_at": "2026-09-04",
+      "verification_sources": [
+        "https://api.github.com/repos/doobidoo/mcp-memory-service"
+      ]
     },
     {
       "id": "memory-and-state/mem0",
@@ -5343,6 +5449,38 @@
       "verification_sources": []
     },
     {
+      "id": "code-execution/cubesandbox",
+      "slug": "cubesandbox",
+      "name": "CubeSandbox",
+      "tagline": "Instant, Concurrent, Secure & Lightweight Sandbox Service for AI Agents",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "code-execution",
+      "website": "https://cubesandbox.com",
+      "repository": "https://github.com/TencentCloud/CubeSandbox",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/cubesandbox.md",
+      "source_path": "services/code-execution/cubesandbox.md",
+      "onboarding": {
+        "type": "cli",
+        "pattern": "CLI + E2B-compatible SDK",
+        "instruction": "curl -sL https://github.com/tencentcloud/CubeSandbox/raw/master/deploy/one-click/online-install.sh | CUBE_PVM_ENABLE=1 bash",
+        "url": "https://github.com/tencentcloud/CubeSandbox/raw/master/deploy/one-click/online-install.sh"
+      },
+      "protocols": [
+        "rest",
+        "cli",
+        "sdk"
+      ],
+      "mcp_status": "unavailable",
+      "agent_skill_status": "unavailable",
+      "latest_month_signal": "Last GitHub push 2026-09-03 (repo metadata); one-click installer + E2B-compatible API on :3000",
+      "verified_at": "2026-09-04",
+      "verification_sources": [
+        "https://api.github.com/repos/TencentCloud/CubeSandbox"
+      ]
+    },
+    {
       "id": "code-execution/daytona",
       "slug": "daytona",
       "name": "Daytona",
@@ -5440,6 +5578,39 @@
       "latest_month_signal": null,
       "verified_at": null,
       "verification_sources": []
+    },
+    {
+      "id": "code-execution/forkd",
+      "slug": "forkd",
+      "name": "forkd",
+      "tagline": "A microVM sandbox runtime for AI agent fan-out.",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "code-execution",
+      "website": "https://github.com/deeplethe/forkd",
+      "repository": "https://github.com/deeplethe/forkd",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/forkd.md",
+      "source_path": "services/code-execution/forkd.md",
+      "onboarding": {
+        "type": "mcp",
+        "pattern": "CLI + REST / SDK / MCP",
+        "instruction": "curl -sSL https://github.com/deeplethe/forkd/releases/download/v0.5.3/forkd-v0.5.3-x86_64-linux.tar.gz \\\n  | sudo tar -xz -C /usr/local/bin/\nsudo -E forkd quickstart",
+        "url": "https://github.com/deeplethe/forkd/releases/download/v0.5.3/forkd-v0.5.3-x86_64-linux.tar.gz"
+      },
+      "protocols": [
+        "mcp",
+        "rest",
+        "cli",
+        "sdk"
+      ],
+      "mcp_status": "available",
+      "agent_skill_status": "unavailable",
+      "latest_month_signal": "Last GitHub push 2026-09-02 (repo metadata); default branch dev; release tarball forkd-v0.5.3",
+      "verified_at": "2026-09-04",
+      "verification_sources": [
+        "https://api.github.com/repos/deeplethe/forkd"
+      ]
     },
     {
       "id": "code-execution/kubernetes-agent-sandbox",
@@ -5565,6 +5736,39 @@
       "latest_month_signal": null,
       "verified_at": null,
       "verification_sources": []
+    },
+    {
+      "id": "code-execution/smolvm",
+      "slug": "smolvm",
+      "name": "SmolVM",
+      "tagline": "SmolVM: secure microVM sandboxes for AI agents",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "code-execution",
+      "website": "https://docs.celesto.ai/smolvm",
+      "repository": "https://github.com/CelestoAI/SmolVM",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/smolvm.md",
+      "source_path": "services/code-execution/smolvm.md",
+      "onboarding": {
+        "type": "cli",
+        "pattern": "CLI + Python SDK",
+        "instruction": "curl -sSL https://celesto.ai/install.sh | bash",
+        "url": "https://celesto.ai/install.sh"
+      },
+      "protocols": [
+        "cli",
+        "sdk",
+        "http"
+      ],
+      "mcp_status": "unavailable",
+      "agent_skill_status": "unavailable",
+      "latest_month_signal": "Last GitHub push 2026-09-03 (repo metadata); PyPI smolvm; docs index at docs.celesto.ai/llms.txt",
+      "verified_at": "2026-09-04",
+      "verification_sources": [
+        "https://api.github.com/repos/CelestoAI/SmolVM",
+        "https://docs.celesto.ai/llms.txt"
+      ]
     },
     {
       "id": "code-execution/vercel-sandbox",

--- a/docs/catalog.json
+++ b/docs/catalog.json
@@ -11,7 +11,7 @@
     "service_directory": "services",
     "content_digest": {
       "algorithm": "sha256",
-      "value": "7b4f96b3588b432ba998105d9b508741bc4c8d97a2ec2ca35e8e452876f27b2d",
+      "value": "be4ab7ee9f1b69e5a0337fe1d9f75076508d6bdf48b8ec4b5c6f4d6cf26a1be1",
       "input_paths": [
         "README.md",
         "skill.md",
@@ -70,6 +70,7 @@
         "services/tool-access-and-integration/mcpgateway.md",
         "services/tool-access-and-integration/mcphub.md",
         "services/tool-access-and-integration/mcpjungle.md",
+        "services/tool-access-and-integration/metamcp.md",
         "services/tool-access-and-integration/nango.md",
         "services/tool-access-and-integration/obot.md",
         "services/tool-access-and-integration/openchatcut.md",
@@ -147,9 +148,11 @@
         "services/memory-and-state/compartment.md",
         "services/memory-and-state/engram.md",
         "services/memory-and-state/ensue.md",
+        "services/memory-and-state/graphiti.md",
         "services/memory-and-state/hindsight.md",
         "services/memory-and-state/llm-wiki.md",
         "services/memory-and-state/lycheemem.md",
+        "services/memory-and-state/mcp-memory-service.md",
         "services/memory-and-state/mem0.md",
         "services/memory-and-state/mem9.md",
         "services/memory-and-state/memmachine.md",
@@ -182,13 +185,16 @@
         "services/code-execution/axern.md",
         "services/code-execution/clawk.md",
         "services/code-execution/coderunner.md",
+        "services/code-execution/cubesandbox.md",
         "services/code-execution/daytona.md",
         "services/code-execution/dormice.md",
         "services/code-execution/e2b.md",
+        "services/code-execution/forkd.md",
         "services/code-execution/kubernetes-agent-sandbox.md",
         "services/code-execution/opensandbox.md",
         "services/code-execution/riza.md",
         "services/code-execution/runloop.md",
+        "services/code-execution/smolvm.md",
         "services/code-execution/vercel-sandbox.md",
         "services/observability-and-tracing/README.md",
         "services/observability-and-tracing/agent-inspect.md",
@@ -253,7 +259,7 @@
   },
   "counts": {
     "categories": 16,
-    "services": 217
+    "services": 223
   },
   "categories": [
     {
@@ -275,7 +281,7 @@
       "name": "Tool Access & Integration",
       "description": "Services that let AI agents discover, authenticate, and invoke external tools at runtime — without a human pre-configuring credentials or selecting which integrations to activate.",
       "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/README.md",
-      "service_count": 21
+      "service_count": 22
     },
     {
       "id": "oversight-and-approval",
@@ -310,7 +316,7 @@
       "name": "Memory & State",
       "description": "Services that give AI agents persistent, queryable memory across sessions — treating memory as infrastructure rather than application logic, and managing the full lifecycle of what agents remember, forget, and retrieve.",
       "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/README.md",
-      "service_count": 26
+      "service_count": 28
     },
     {
       "id": "search-and-web-intelligence",
@@ -324,7 +330,7 @@
       "name": "Code Execution",
       "description": "Services that give AI agents a secure, isolated runtime for executing generated code — without human-side sandbox setup, without risking the host environment, and with output formatted for direct LLM consumption.",
       "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/README.md",
-      "service_count": 13
+      "service_count": 16
     },
     {
       "id": "observability-and-tracing",
@@ -2024,6 +2030,40 @@
       "verified_at": "2026-09-03",
       "verification_sources": [
         "https://api.github.com/repos/mcpjungle/MCPJungle"
+      ]
+    },
+    {
+      "id": "tool-access-and-integration/metamcp",
+      "slug": "metamcp",
+      "name": "MetaMCP",
+      "tagline": "MCP Aggregator, Orchestrator, Middleware, Gateway in one docker",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "tool-access-and-integration",
+      "website": "https://docs.metamcp.com",
+      "repository": "https://github.com/metatool-ai/metamcp",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/metamcp.md",
+      "source_path": "services/tool-access-and-integration/metamcp.md",
+      "onboarding": {
+        "type": "mcp",
+        "pattern": "CLI + MCP gateway",
+        "instruction": "git clone https://github.com/metatool-ai/metamcp.git\ncd metamcp\ncp example.env .env\ndocker compose up -d",
+        "url": "https://github.com/metatool-ai/metamcp.git"
+      },
+      "protocols": [
+        "mcp",
+        "openapi",
+        "stdio",
+        "http",
+        "api"
+      ],
+      "mcp_status": "available",
+      "agent_skill_status": "unavailable",
+      "latest_month_signal": "Last GitHub push 2026-06-22 (repo metadata) — quieter than MCPHub/ContextForge; default branch ai-dev. README notes maintenance delay while still merging PRs. Still admitted: MIT + clear MCP aggregator/gateway OSS not already listed",
+      "verified_at": "2026-09-04",
+      "verification_sources": [
+        "https://api.github.com/repos/metatool-ai/metamcp"
       ]
     },
     {
@@ -4290,6 +4330,38 @@
       "verification_sources": []
     },
     {
+      "id": "memory-and-state/graphiti",
+      "slug": "graphiti",
+      "name": "Graphiti",
+      "tagline": "Build Real-Time Knowledge Graphs for AI Agents",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "memory-and-state",
+      "website": "https://help.getzep.com/graphiti",
+      "repository": "https://github.com/getzep/graphiti",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/graphiti.md",
+      "source_path": "services/memory-and-state/graphiti.md",
+      "onboarding": {
+        "type": "mcp",
+        "pattern": "SDK + MCP",
+        "instruction": "pip install graphiti-core",
+        "url": "https://help.getzep.com/graphiti/getting-started/mcp-server"
+      },
+      "protocols": [
+        "mcp",
+        "sdk",
+        "stdio"
+      ],
+      "mcp_status": "available",
+      "agent_skill_status": "unavailable",
+      "latest_month_signal": "Last GitHub push 2026-09-03 (repo metadata); PyPI graphiti-core; MCP server in-repo",
+      "verified_at": "2026-09-04",
+      "verification_sources": [
+        "https://api.github.com/repos/getzep/graphiti"
+      ]
+    },
+    {
       "id": "memory-and-state/hindsight",
       "slug": "hindsight",
       "name": "Hindsight",
@@ -4376,6 +4448,40 @@
       "latest_month_signal": null,
       "verified_at": null,
       "verification_sources": []
+    },
+    {
+      "id": "memory-and-state/mcp-memory-service",
+      "slug": "mcp-memory-service",
+      "name": "mcp-memory-service",
+      "tagline": "Memory for AI Agents — REST, MCP, OAuth, CLI",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "memory-and-state",
+      "website": "https://mcpmemory.services",
+      "repository": "https://github.com/doobidoo/mcp-memory-service",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/mcp-memory-service.md",
+      "source_path": "services/memory-and-state/mcp-memory-service.md",
+      "onboarding": {
+        "type": "mcp",
+        "pattern": "CLI + MCP / REST",
+        "instruction": "pip install mcp-memory-service",
+        "url": "http://localhost:8000"
+      },
+      "protocols": [
+        "mcp",
+        "rest",
+        "cli",
+        "stdio",
+        "http"
+      ],
+      "mcp_status": "available",
+      "agent_skill_status": "unavailable",
+      "latest_month_signal": "Last GitHub push 2026-09-02 (repo metadata); PyPI mcp-memory-service; homepage showed v11.10.0 on 2026-09-04",
+      "verified_at": "2026-09-04",
+      "verification_sources": [
+        "https://api.github.com/repos/doobidoo/mcp-memory-service"
+      ]
     },
     {
       "id": "memory-and-state/mem0",
@@ -5343,6 +5449,38 @@
       "verification_sources": []
     },
     {
+      "id": "code-execution/cubesandbox",
+      "slug": "cubesandbox",
+      "name": "CubeSandbox",
+      "tagline": "Instant, Concurrent, Secure & Lightweight Sandbox Service for AI Agents",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "code-execution",
+      "website": "https://cubesandbox.com",
+      "repository": "https://github.com/TencentCloud/CubeSandbox",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/cubesandbox.md",
+      "source_path": "services/code-execution/cubesandbox.md",
+      "onboarding": {
+        "type": "cli",
+        "pattern": "CLI + E2B-compatible SDK",
+        "instruction": "curl -sL https://github.com/tencentcloud/CubeSandbox/raw/master/deploy/one-click/online-install.sh | CUBE_PVM_ENABLE=1 bash",
+        "url": "https://github.com/tencentcloud/CubeSandbox/raw/master/deploy/one-click/online-install.sh"
+      },
+      "protocols": [
+        "rest",
+        "cli",
+        "sdk"
+      ],
+      "mcp_status": "unavailable",
+      "agent_skill_status": "unavailable",
+      "latest_month_signal": "Last GitHub push 2026-09-03 (repo metadata); one-click installer + E2B-compatible API on :3000",
+      "verified_at": "2026-09-04",
+      "verification_sources": [
+        "https://api.github.com/repos/TencentCloud/CubeSandbox"
+      ]
+    },
+    {
       "id": "code-execution/daytona",
       "slug": "daytona",
       "name": "Daytona",
@@ -5440,6 +5578,39 @@
       "latest_month_signal": null,
       "verified_at": null,
       "verification_sources": []
+    },
+    {
+      "id": "code-execution/forkd",
+      "slug": "forkd",
+      "name": "forkd",
+      "tagline": "A microVM sandbox runtime for AI agent fan-out.",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "code-execution",
+      "website": "https://github.com/deeplethe/forkd",
+      "repository": "https://github.com/deeplethe/forkd",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/forkd.md",
+      "source_path": "services/code-execution/forkd.md",
+      "onboarding": {
+        "type": "mcp",
+        "pattern": "CLI + REST / SDK / MCP",
+        "instruction": "curl -sSL https://github.com/deeplethe/forkd/releases/download/v0.5.3/forkd-v0.5.3-x86_64-linux.tar.gz \\\n  | sudo tar -xz -C /usr/local/bin/\nsudo -E forkd quickstart",
+        "url": "https://github.com/deeplethe/forkd/releases/download/v0.5.3/forkd-v0.5.3-x86_64-linux.tar.gz"
+      },
+      "protocols": [
+        "mcp",
+        "rest",
+        "cli",
+        "sdk"
+      ],
+      "mcp_status": "available",
+      "agent_skill_status": "unavailable",
+      "latest_month_signal": "Last GitHub push 2026-09-02 (repo metadata); default branch dev; release tarball forkd-v0.5.3",
+      "verified_at": "2026-09-04",
+      "verification_sources": [
+        "https://api.github.com/repos/deeplethe/forkd"
+      ]
     },
     {
       "id": "code-execution/kubernetes-agent-sandbox",
@@ -5565,6 +5736,39 @@
       "latest_month_signal": null,
       "verified_at": null,
       "verification_sources": []
+    },
+    {
+      "id": "code-execution/smolvm",
+      "slug": "smolvm",
+      "name": "SmolVM",
+      "tagline": "SmolVM: secure microVM sandboxes for AI agents",
+      "classification": "agent-native",
+      "status": "listed",
+      "lifecycle_status": "active",
+      "category": "code-execution",
+      "website": "https://docs.celesto.ai/smolvm",
+      "repository": "https://github.com/CelestoAI/SmolVM",
+      "dossier": "https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/smolvm.md",
+      "source_path": "services/code-execution/smolvm.md",
+      "onboarding": {
+        "type": "cli",
+        "pattern": "CLI + Python SDK",
+        "instruction": "curl -sSL https://celesto.ai/install.sh | bash",
+        "url": "https://celesto.ai/install.sh"
+      },
+      "protocols": [
+        "cli",
+        "sdk",
+        "http"
+      ],
+      "mcp_status": "unavailable",
+      "agent_skill_status": "unavailable",
+      "latest_month_signal": "Last GitHub push 2026-09-03 (repo metadata); PyPI smolvm; docs index at docs.celesto.ai/llms.txt",
+      "verified_at": "2026-09-04",
+      "verification_sources": [
+        "https://api.github.com/repos/CelestoAI/SmolVM",
+        "https://docs.celesto.ai/llms.txt"
+      ]
     },
     {
       "id": "code-execution/vercel-sandbox",

--- a/docs/categories/code-execution.md
+++ b/docs/categories/code-execution.md
@@ -8,7 +8,7 @@ image: "/assets/images/editorial-sandbox.webp"
 permalink: /categories/code-execution/
 page_kind: collection
 collection_number: "10"
-service_count: 13
+service_count: 16
 ---
 
 <p class="collection-source"><a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/README.md">Collection notes ↗</a></p>
@@ -79,7 +79,18 @@ service_count: 13
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--07">
+  <article class="service-card service-card--new atlas-sheet--arrival atlas-visual--07">
+    <span class="service-card__image" aria-hidden="true"></span>
+    <div class="service-card__copy">
+    <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
+    <h2 class="service-card__title">CubeSandbox</h2>
+    <div class="service-card__actions">
+      <a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/cubesandbox.md">Open dossier ↗</a>
+      <a href="https://github.com/TencentCloud/CubeSandbox">Official repo ↗</a>
+    </div>
+    </div>
+  </article>
+  <article class="service-card atlas-sheet--arrival atlas-visual--08">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -90,7 +101,7 @@ service_count: 13
     </div>
     </div>
   </article>
-  <article class="service-card service-card--new atlas-sheet--arrival atlas-visual--08">
+  <article class="service-card service-card--new atlas-sheet--arrival atlas-visual--09">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
@@ -101,7 +112,7 @@ service_count: 13
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--09">
+  <article class="service-card atlas-sheet--arrival atlas-visual--10">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -112,7 +123,18 @@ service_count: 13
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--10">
+  <article class="service-card service-card--new atlas-sheet--arrival atlas-visual--11">
+    <span class="service-card__image" aria-hidden="true"></span>
+    <div class="service-card__copy">
+    <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
+    <h2 class="service-card__title">forkd</h2>
+    <div class="service-card__actions">
+      <a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/forkd.md">Open dossier ↗</a>
+      <a href="https://github.com/deeplethe/forkd">Official repo ↗</a>
+    </div>
+    </div>
+  </article>
+  <article class="service-card atlas-sheet--arrival atlas-visual--12">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -123,7 +145,7 @@ service_count: 13
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--11">
+  <article class="service-card atlas-sheet--arrival atlas-visual--13">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -134,7 +156,7 @@ service_count: 13
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--12">
+  <article class="service-card atlas-sheet--arrival atlas-visual--14">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -145,7 +167,18 @@ service_count: 13
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--13">
+  <article class="service-card service-card--new atlas-sheet--arrival atlas-visual--15">
+    <span class="service-card__image" aria-hidden="true"></span>
+    <div class="service-card__copy">
+    <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
+    <h2 class="service-card__title">SmolVM</h2>
+    <div class="service-card__actions">
+      <a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/smolvm.md">Open dossier ↗</a>
+      <a href="https://github.com/CelestoAI/SmolVM">Official repo ↗</a>
+    </div>
+    </div>
+  </article>
+  <article class="service-card atlas-sheet--arrival atlas-visual--16">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>

--- a/docs/categories/index.md
+++ b/docs/categories/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Agent-Native Collections"
-description: "Browse 217 agent-native services across 16 curated infrastructure collections."
+description: "Browse 223 agent-native services across 16 curated infrastructure collections."
 permalink: /categories/
 page_kind: document
 ---
@@ -27,7 +27,7 @@ page_kind: document
     <span class="collection-card__copy">
     <span class="collection-card__number">03</span>
     <span class="collection-card__title">Tool Access &amp; Integration</span>
-    <span class="collection-card__count">21</span>
+    <span class="collection-card__count">22</span>
     </span>
   </a>
   <a class="collection-card atlas-visual--04" href="{{ '/categories/oversight-and-approval/' | relative_url }}">
@@ -67,7 +67,7 @@ page_kind: document
     <span class="collection-card__copy">
     <span class="collection-card__number">08</span>
     <span class="collection-card__title">Memory &amp; State</span>
-    <span class="collection-card__count">26</span>
+    <span class="collection-card__count">28</span>
     </span>
   </a>
   <a class="collection-card atlas-visual--09" href="{{ '/categories/search-and-web-intelligence/' | relative_url }}">
@@ -83,7 +83,7 @@ page_kind: document
     <span class="collection-card__copy">
     <span class="collection-card__number">10</span>
     <span class="collection-card__title">Code Execution</span>
-    <span class="collection-card__count">13</span>
+    <span class="collection-card__count">16</span>
     </span>
   </a>
   <a class="collection-card atlas-visual--11" href="{{ '/categories/observability-and-tracing/' | relative_url }}">

--- a/docs/categories/memory-and-state.md
+++ b/docs/categories/memory-and-state.md
@@ -8,7 +8,7 @@ image: "/assets/images/editorial-memory.webp"
 permalink: /categories/memory-and-state/
 page_kind: collection
 collection_number: "08"
-service_count: 26
+service_count: 28
 ---
 
 <p class="collection-source"><a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/README.md">Collection notes ↗</a></p>
@@ -91,7 +91,18 @@ service_count: 26
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--08">
+  <article class="service-card service-card--new atlas-sheet--arrival atlas-visual--08">
+    <span class="service-card__image" aria-hidden="true"></span>
+    <div class="service-card__copy">
+    <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
+    <h2 class="service-card__title">Graphiti</h2>
+    <div class="service-card__actions">
+      <a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/graphiti.md">Open dossier ↗</a>
+      <a href="https://github.com/getzep/graphiti">Official repo ↗</a>
+    </div>
+    </div>
+  </article>
+  <article class="service-card atlas-sheet--arrival atlas-visual--09">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -102,7 +113,7 @@ service_count: 26
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--09">
+  <article class="service-card atlas-sheet--arrival atlas-visual--10">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -113,7 +124,7 @@ service_count: 26
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--10">
+  <article class="service-card atlas-sheet--arrival atlas-visual--11">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -124,7 +135,18 @@ service_count: 26
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--11">
+  <article class="service-card service-card--new atlas-sheet--arrival atlas-visual--12">
+    <span class="service-card__image" aria-hidden="true"></span>
+    <div class="service-card__copy">
+    <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
+    <h2 class="service-card__title">mcp-memory-service</h2>
+    <div class="service-card__actions">
+      <a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/mcp-memory-service.md">Open dossier ↗</a>
+      <a href="https://github.com/doobidoo/mcp-memory-service">Official repo ↗</a>
+    </div>
+    </div>
+  </article>
+  <article class="service-card atlas-sheet--arrival atlas-visual--13">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -135,7 +157,7 @@ service_count: 26
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--12">
+  <article class="service-card atlas-sheet--arrival atlas-visual--14">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -146,7 +168,7 @@ service_count: 26
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--13">
+  <article class="service-card atlas-sheet--arrival atlas-visual--15">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -157,7 +179,7 @@ service_count: 26
     </div>
     </div>
   </article>
-  <article class="service-card service-card--new atlas-sheet--arrival atlas-visual--14">
+  <article class="service-card service-card--new atlas-sheet--arrival atlas-visual--16">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
@@ -168,7 +190,7 @@ service_count: 26
     </div>
     </div>
   </article>
-  <article class="service-card service-card--new atlas-sheet--arrival atlas-visual--15">
+  <article class="service-card service-card--new atlas-sheet--service atlas-visual--01">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
@@ -179,7 +201,7 @@ service_count: 26
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--16">
+  <article class="service-card atlas-sheet--service atlas-visual--02">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -190,7 +212,7 @@ service_count: 26
     </div>
     </div>
   </article>
-  <article class="service-card service-card--new atlas-sheet--service atlas-visual--01">
+  <article class="service-card service-card--new atlas-sheet--service atlas-visual--03">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
@@ -201,7 +223,7 @@ service_count: 26
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--02">
+  <article class="service-card atlas-sheet--service atlas-visual--04">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -212,7 +234,7 @@ service_count: 26
     </div>
     </div>
   </article>
-  <article class="service-card service-card--new atlas-sheet--service atlas-visual--03">
+  <article class="service-card service-card--new atlas-sheet--service atlas-visual--05">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
@@ -223,7 +245,7 @@ service_count: 26
     </div>
     </div>
   </article>
-  <article class="service-card service-card--new atlas-sheet--service atlas-visual--04">
+  <article class="service-card service-card--new atlas-sheet--service atlas-visual--06">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
@@ -234,7 +256,7 @@ service_count: 26
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--05">
+  <article class="service-card atlas-sheet--service atlas-visual--07">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -245,7 +267,7 @@ service_count: 26
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--06">
+  <article class="service-card atlas-sheet--service atlas-visual--08">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -256,7 +278,7 @@ service_count: 26
     </div>
     </div>
   </article>
-  <article class="service-card service-card--new atlas-sheet--service atlas-visual--07">
+  <article class="service-card service-card--new atlas-sheet--service atlas-visual--09">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
@@ -267,7 +289,7 @@ service_count: 26
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--08">
+  <article class="service-card atlas-sheet--service atlas-visual--10">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -278,7 +300,7 @@ service_count: 26
     </div>
     </div>
   </article>
-  <article class="service-card service-card--new atlas-sheet--service atlas-visual--09">
+  <article class="service-card service-card--new atlas-sheet--service atlas-visual--11">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
@@ -289,7 +311,7 @@ service_count: 26
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--10">
+  <article class="service-card atlas-sheet--service atlas-visual--12">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>

--- a/docs/categories/tool-access-and-integration.md
+++ b/docs/categories/tool-access-and-integration.md
@@ -8,7 +8,7 @@ image: "/assets/images/editorial-tools.webp"
 permalink: /categories/tool-access-and-integration/
 page_kind: collection
 collection_number: "03"
-service_count: 21
+service_count: 22
 ---
 
 <p class="collection-source"><a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/README.md">Collection notes ↗</a></p>
@@ -145,7 +145,18 @@ service_count: 21
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--13">
+  <article class="service-card service-card--new atlas-sheet--service atlas-visual--13">
+    <span class="service-card__image" aria-hidden="true"></span>
+    <div class="service-card__copy">
+    <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
+    <h2 class="service-card__title">MetaMCP</h2>
+    <div class="service-card__actions">
+      <a href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/metamcp.md">Open dossier ↗</a>
+      <a href="https://github.com/metatool-ai/metamcp">Official repo ↗</a>
+    </div>
+    </div>
+  </article>
+  <article class="service-card atlas-sheet--service atlas-visual--14">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -156,7 +167,7 @@ service_count: 21
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--service atlas-visual--14">
+  <article class="service-card atlas-sheet--service atlas-visual--15">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -167,7 +178,7 @@ service_count: 21
     </div>
     </div>
   </article>
-  <article class="service-card service-card--new atlas-sheet--service atlas-visual--15">
+  <article class="service-card service-card--new atlas-sheet--service atlas-visual--16">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
@@ -178,7 +189,7 @@ service_count: 21
     </div>
     </div>
   </article>
-  <article class="service-card service-card--new atlas-sheet--service atlas-visual--16">
+  <article class="service-card service-card--new atlas-sheet--arrival atlas-visual--01">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>
@@ -189,7 +200,7 @@ service_count: 21
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--01">
+  <article class="service-card atlas-sheet--arrival atlas-visual--02">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -200,7 +211,7 @@ service_count: 21
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--02">
+  <article class="service-card atlas-sheet--arrival atlas-visual--03">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -211,7 +222,7 @@ service_count: 21
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--03">
+  <article class="service-card atlas-sheet--arrival atlas-visual--04">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -222,7 +233,7 @@ service_count: 21
     </div>
     </div>
   </article>
-  <article class="service-card atlas-sheet--arrival atlas-visual--04">
+  <article class="service-card atlas-sheet--arrival atlas-visual--05">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>Curated dossier</span><span>agent-native</span></div>
@@ -233,7 +244,7 @@ service_count: 21
     </div>
     </div>
   </article>
-  <article class="service-card service-card--new atlas-sheet--arrival atlas-visual--05">
+  <article class="service-card service-card--new atlas-sheet--arrival atlas-visual--06">
     <span class="service-card__image" aria-hidden="true"></span>
     <div class="service-card__copy">
     <div class="service-card__overline"><span>New · Last 30 days</span><span>agent-native</span></div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,9 +3,9 @@ title: "The Agent-Native Index"
 description: "A curated 2026 collection of agent-native infrastructure: MCP tools, harnesses, identity, memory, sandboxes, browsers, payments, and runtimes."
 image: /assets/images/social-preview-wide.webp
 page_kind: home
-service_count: 217
+service_count: 223
 collection_count: 16
-new_arrivals_count: 62
+new_arrivals_count: 68
 ---
 
 <section id="new-arrivals" aria-labelledby="new-arrivals-title">
@@ -111,7 +111,23 @@ new_arrivals_count: 62
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--13" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/memoir.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--13" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/cubesandbox.md">
+      <span class="arrival-card__image" aria-hidden="true"></span>
+      <span class="arrival-card__copy">
+        <span class="arrival-card__category">Code Execution</span>
+        <strong class="arrival-card__name">CubeSandbox</strong>
+        <span class="arrival-card__arrow" aria-hidden="true">↗</span>
+      </span>
+    </a>
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--14" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/smolvm.md">
+      <span class="arrival-card__image" aria-hidden="true"></span>
+      <span class="arrival-card__copy">
+        <span class="arrival-card__category">Code Execution</span>
+        <strong class="arrival-card__name">SmolVM</strong>
+        <span class="arrival-card__arrow" aria-hidden="true">↗</span>
+      </span>
+    </a>
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--15" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/memoir.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Memory &amp; State</span>
@@ -119,7 +135,15 @@ new_arrivals_count: 62
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--14" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/beads.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--16" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/graphiti.md">
+      <span class="arrival-card__image" aria-hidden="true"></span>
+      <span class="arrival-card__copy">
+        <span class="arrival-card__category">Memory &amp; State</span>
+        <strong class="arrival-card__name">Graphiti</strong>
+        <span class="arrival-card__arrow" aria-hidden="true">↗</span>
+      </span>
+    </a>
+    <a class="arrival-card atlas-sheet--service atlas-visual--01" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/beads.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Memory &amp; State</span>
@@ -127,7 +151,7 @@ new_arrivals_count: 62
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--15" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/mcphub.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--02" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/mcphub.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Tool Access &amp; Integration</span>
@@ -135,7 +159,7 @@ new_arrivals_count: 62
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--16" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/memorix.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--03" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/memorix.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Memory &amp; State</span>
@@ -143,7 +167,23 @@ new_arrivals_count: 62
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--01" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/compartment.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--04" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/forkd.md">
+      <span class="arrival-card__image" aria-hidden="true"></span>
+      <span class="arrival-card__copy">
+        <span class="arrival-card__category">Code Execution</span>
+        <strong class="arrival-card__name">forkd</strong>
+        <span class="arrival-card__arrow" aria-hidden="true">↗</span>
+      </span>
+    </a>
+    <a class="arrival-card atlas-sheet--service atlas-visual--05" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/mcp-memory-service.md">
+      <span class="arrival-card__image" aria-hidden="true"></span>
+      <span class="arrival-card__copy">
+        <span class="arrival-card__category">Memory &amp; State</span>
+        <strong class="arrival-card__name">mcp-memory-service</strong>
+        <span class="arrival-card__arrow" aria-hidden="true">↗</span>
+      </span>
+    </a>
+    <a class="arrival-card atlas-sheet--service atlas-visual--06" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/compartment.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Memory &amp; State</span>
@@ -151,7 +191,7 @@ new_arrivals_count: 62
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--02" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/meeting-and-conversation/joinly.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--07" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/meeting-and-conversation/joinly.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Meeting &amp; Conversation</span>
@@ -159,7 +199,7 @@ new_arrivals_count: 62
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--03" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/projectmem.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--08" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/projectmem.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Memory &amp; State</span>
@@ -167,7 +207,7 @@ new_arrivals_count: 62
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--04" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/ruflo.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--09" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/ruflo.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Agent Harnesses &amp; Operator Surfaces</span>
@@ -175,7 +215,7 @@ new_arrivals_count: 62
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--05" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/engram.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--10" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/engram.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Memory &amp; State</span>
@@ -183,7 +223,7 @@ new_arrivals_count: 62
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--06" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/claude-mem.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--11" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/claude-mem.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Memory &amp; State</span>
@@ -191,7 +231,7 @@ new_arrivals_count: 62
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--07" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/commerce-and-payments/ucp.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--12" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/commerce-and-payments/ucp.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Commerce &amp; Payments</span>
@@ -199,7 +239,7 @@ new_arrivals_count: 62
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--08" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/agent-substrate.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--13" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/agent-substrate.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Agent Runtime &amp; Infrastructure</span>
@@ -207,7 +247,7 @@ new_arrivals_count: 62
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--09" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/observability-and-tracing/agentsight.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--14" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/observability-and-tracing/agentsight.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Observability &amp; Tracing</span>
@@ -215,7 +255,7 @@ new_arrivals_count: 62
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--10" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/mempalace.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--15" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/mempalace.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Memory &amp; State</span>
@@ -223,7 +263,7 @@ new_arrivals_count: 62
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--11" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/kubernetes-agent-sandbox.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--16" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/kubernetes-agent-sandbox.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Code Execution</span>
@@ -231,7 +271,7 @@ new_arrivals_count: 62
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--12" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/contextforge.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--01" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/contextforge.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Tool Access &amp; Integration</span>
@@ -239,7 +279,7 @@ new_arrivals_count: 62
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--13" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/mcp-gateway-registry.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--02" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/mcp-gateway-registry.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Tool Access &amp; Integration</span>
@@ -247,7 +287,7 @@ new_arrivals_count: 62
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--14" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/sandbase-cli.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--03" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/sandbase-cli.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Tool Access &amp; Integration</span>
@@ -255,7 +295,7 @@ new_arrivals_count: 62
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--15" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/memsearch.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--04" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/memsearch.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Memory &amp; State</span>
@@ -263,7 +303,7 @@ new_arrivals_count: 62
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--16" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/deepseek-harness.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--05" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/deepseek-harness.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Agent Harnesses &amp; Operator Surfaces</span>
@@ -271,7 +311,7 @@ new_arrivals_count: 62
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--01" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-social-network/agentgram.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--06" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-social-network/agentgram.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Agent Social &amp; Community</span>
@@ -279,7 +319,7 @@ new_arrivals_count: 62
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--02" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/toolport.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--07" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/toolport.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Tool Access &amp; Integration</span>
@@ -287,7 +327,7 @@ new_arrivals_count: 62
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--03" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/loopx.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--08" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/loopx.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Agent Harnesses &amp; Operator Surfaces</span>
@@ -295,7 +335,7 @@ new_arrivals_count: 62
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--04" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/cloudflare-computer.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--09" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/cloudflare-computer.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Agent Runtime &amp; Infrastructure</span>
@@ -303,7 +343,7 @@ new_arrivals_count: 62
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--05" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/oversight-and-approval/preloop.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--10" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/oversight-and-approval/preloop.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Oversight &amp; Approval</span>
@@ -311,7 +351,7 @@ new_arrivals_count: 62
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--06" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/claude-hud.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--11" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/claude-hud.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Agent Harnesses &amp; Operator Surfaces</span>
@@ -319,7 +359,7 @@ new_arrivals_count: 62
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--07" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/search-and-web-intelligence/agent-search-mcp.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--12" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/search-and-web-intelligence/agent-search-mcp.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Search &amp; Web Intelligence</span>
@@ -327,7 +367,7 @@ new_arrivals_count: 62
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--08" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/agentmemory.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--13" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/agentmemory.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Memory &amp; State</span>
@@ -335,7 +375,7 @@ new_arrivals_count: 62
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--09" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/dormice.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--14" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/dormice.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Code Execution</span>
@@ -343,7 +383,7 @@ new_arrivals_count: 62
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--10" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/google-ax.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--15" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-runtime-and-infrastructure/google-ax.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Agent Runtime &amp; Infrastructure</span>
@@ -351,7 +391,7 @@ new_arrivals_count: 62
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--11" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/voice-and-phone/patter.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--16" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/voice-and-phone/patter.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Voice &amp; Phone</span>
@@ -359,7 +399,7 @@ new_arrivals_count: 62
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--12" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/clawk.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--01" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/clawk.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Code Execution</span>
@@ -367,7 +407,7 @@ new_arrivals_count: 62
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--13" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/communication/atomic-mail.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--02" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/communication/atomic-mail.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Communication</span>
@@ -375,7 +415,7 @@ new_arrivals_count: 62
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--14" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/meeting-and-conversation/agentcall.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--03" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/meeting-and-conversation/agentcall.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Meeting &amp; Conversation</span>
@@ -383,7 +423,7 @@ new_arrivals_count: 62
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--15" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/mcpjungle.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--04" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/mcpjungle.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Tool Access &amp; Integration</span>
@@ -391,7 +431,7 @@ new_arrivals_count: 62
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--arrival atlas-visual--16" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/communication/agentteam-email.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--05" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/communication/agentteam-email.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Communication</span>
@@ -399,7 +439,7 @@ new_arrivals_count: 62
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--01" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/browser-and-web-execution/stealth-browser-mcp.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--06" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/browser-and-web-execution/stealth-browser-mcp.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Browser &amp; Web Execution</span>
@@ -407,7 +447,15 @@ new_arrivals_count: 62
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--02" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/commerce-and-payments/ap2.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--07" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/tool-access-and-integration/metamcp.md">
+      <span class="arrival-card__image" aria-hidden="true"></span>
+      <span class="arrival-card__copy">
+        <span class="arrival-card__category">Tool Access &amp; Integration</span>
+        <strong class="arrival-card__name">MetaMCP</strong>
+        <span class="arrival-card__arrow" aria-hidden="true">↗</span>
+      </span>
+    </a>
+    <a class="arrival-card atlas-sheet--service atlas-visual--08" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/commerce-and-payments/ap2.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Commerce &amp; Payments</span>
@@ -415,7 +463,7 @@ new_arrivals_count: 62
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--03" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/tencentdb-agent-memory.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--09" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/tencentdb-agent-memory.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Memory &amp; State</span>
@@ -423,7 +471,7 @@ new_arrivals_count: 62
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--04" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/longhorizon-harness.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--10" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/longhorizon-harness.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Agent Harnesses &amp; Operator Surfaces</span>
@@ -431,7 +479,7 @@ new_arrivals_count: 62
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--05" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/search-and-web-intelligence/contextx.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--11" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/search-and-web-intelligence/contextx.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Search &amp; Web Intelligence</span>
@@ -439,7 +487,7 @@ new_arrivals_count: 62
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--06" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/qm.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--12" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-harnesses-and-control-planes/qm.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Agent Harnesses &amp; Operator Surfaces</span>
@@ -447,7 +495,7 @@ new_arrivals_count: 62
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--07" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/axern.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--13" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/code-execution/axern.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Code Execution</span>
@@ -455,7 +503,7 @@ new_arrivals_count: 62
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--08" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-social-network/agent-chamber.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--14" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/agent-social-network/agent-chamber.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Agent Social &amp; Community</span>
@@ -463,7 +511,7 @@ new_arrivals_count: 62
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--09" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/voice-and-phone/qwen-audio-agent.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--15" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/voice-and-phone/qwen-audio-agent.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Voice &amp; Phone</span>
@@ -471,7 +519,7 @@ new_arrivals_count: 62
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--10" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/llm-gateway-and-routing/sageroute.md">
+    <a class="arrival-card atlas-sheet--service atlas-visual--16" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/llm-gateway-and-routing/sageroute.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">LLM Gateway &amp; Routing</span>
@@ -479,7 +527,7 @@ new_arrivals_count: 62
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--11" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/observability-and-tracing/numbat.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--01" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/observability-and-tracing/numbat.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Observability &amp; Tracing</span>
@@ -487,7 +535,7 @@ new_arrivals_count: 62
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--12" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/memmy-agent.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--02" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/memory-and-state/memmy-agent.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Memory &amp; State</span>
@@ -495,7 +543,7 @@ new_arrivals_count: 62
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--13" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/meeting-and-conversation/looped-meet.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--03" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/meeting-and-conversation/looped-meet.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Meeting &amp; Conversation</span>
@@ -503,7 +551,7 @@ new_arrivals_count: 62
         <span class="arrival-card__arrow" aria-hidden="true">↗</span>
       </span>
     </a>
-    <a class="arrival-card atlas-sheet--service atlas-visual--14" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/durable-execution-and-scheduling/pi-dispatch.md">
+    <a class="arrival-card atlas-sheet--arrival atlas-visual--04" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/services/durable-execution-and-scheduling/pi-dispatch.md">
       <span class="arrival-card__image" aria-hidden="true"></span>
       <span class="arrival-card__copy">
         <span class="arrival-card__category">Durable Execution &amp; Scheduling</span>
@@ -536,7 +584,7 @@ new_arrivals_count: 62
   <div class="section-intro">
     <span class="section-number">02</span>
     <h2 class="section-title" id="collections-title">The collections</h2>
-    <p class="section-note">16 fields · 217 dossiers</p>
+    <p class="section-note">16 fields · 223 dossiers</p>
   </div>
   <div class="collection-grid">
     <a class="collection-card atlas-visual--01" href="{{ '/categories/communication/' | relative_url }}">
@@ -560,7 +608,7 @@ new_arrivals_count: 62
       <span class="collection-card__copy">
       <span class="collection-card__number">03</span>
       <span class="collection-card__title">Tool Access &amp; Integration</span>
-      <span class="collection-card__count">21</span>
+      <span class="collection-card__count">22</span>
       </span>
     </a>
     <a class="collection-card atlas-visual--04" href="{{ '/categories/oversight-and-approval/' | relative_url }}">
@@ -600,7 +648,7 @@ new_arrivals_count: 62
       <span class="collection-card__copy">
       <span class="collection-card__number">08</span>
       <span class="collection-card__title">Memory &amp; State</span>
-      <span class="collection-card__count">26</span>
+      <span class="collection-card__count">28</span>
       </span>
     </a>
     <a class="collection-card atlas-visual--09" href="{{ '/categories/search-and-web-intelligence/' | relative_url }}">
@@ -616,7 +664,7 @@ new_arrivals_count: 62
       <span class="collection-card__copy">
       <span class="collection-card__number">10</span>
       <span class="collection-card__title">Code Execution</span>
-      <span class="collection-card__count">13</span>
+      <span class="collection-card__count">16</span>
       </span>
     </a>
     <a class="collection-card atlas-visual--11" href="{{ '/categories/observability-and-tracing/' | relative_url }}">
@@ -690,6 +738,6 @@ new_arrivals_count: 62
   <div>
   <span class="section-number">03</span>
   <h2 class="section-title">Full source.</h2>
-  <a class="source-gateway__link" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/README.md">Open 217 dossiers ↗</a>
+  <a class="source-gateway__link" href="https://github.com/haoruilee/awesome-agent-native-services/blob/main/README.md">Open 223 dossiers ↗</a>
   </div>
 </section>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,6 +1,6 @@
 # Awesome Agent-Native Services
 
-> A curated catalog of 217 agent-native services across 16 collections — infrastructure designed for AI agents as first-class consumers, plus purpose-built surfaces for operating live agent systems.
+> A curated catalog of 223 agent-native services across 16 collections — infrastructure designed for AI agents as first-class consumers, plus purpose-built surfaces for operating live agent systems.
 
 Use the JSON catalog for deterministic filtering and the discovery skill for task-oriented guidance. Service dossiers contain the full evidence and caveats.
 

--- a/docs/skill.md
+++ b/docs/skill.md
@@ -61,7 +61,7 @@ These services can be joined with a single instruction, right now, with no human
 
 ---
 
-## Full Catalog — 16 Categories, 217 Services
+## Full Catalog — 16 Categories, 223 Services
 
 ### 1. Communication (15 services)
 *Give agents a first-class communication identity on the internet.*
@@ -119,7 +119,7 @@ These services can be joined with a single instruction, right now, with no human
 
 ---
 
-### 3. Tool Access & Integration (21 services)
+### 3. Tool Access & Integration (22 services)
 *Runtime tool discovery, auth, and execution without human pre-configuration.*
 
 | Service | Tagline | Onboarding |
@@ -145,6 +145,7 @@ These services can be joined with a single instruction, right now, with no human
 | [MCP Gateway & Registry](https://agentic-community.github.io/mcp-gateway-registry/) | Unified Agent & MCP Server Registry | `git clone https://github.com/agentic-community/mcp-gateway-registry && ./build_and_run.sh --prebuilt` |
 | [MCPHub](https://www.mcphub.app) | One gateway for all your MCP servers. | `docker run -p 3000:3000 -v ./data:/app/data samanhappy/mcphub` then connect to `http://localhost:3000/mcp` |
 | [MCPJungle](https://docs.mcpjungle.com) | Run all your MCP servers behind one endpoint | `docker compose up -d` then `mcpjungle register --name context7 --url https://mcp.context7.com/mcp` |
+| [MetaMCP](https://docs.metamcp.com) | MCP Aggregator, Orchestrator, Middleware, Gateway in one docker | `git clone https://github.com/metatool-ai/metamcp.git && docker compose up -d` |
 
 ---
 
@@ -236,7 +237,7 @@ These services can be joined with a single instruction, right now, with no human
 
 ---
 
-### 8. Memory & State (26 services)
+### 8. Memory & State (28 services)
 *Persistent, queryable memory across sessions — memory as infrastructure, not application logic.*
 
 | Service | Tagline | Onboarding |
@@ -246,6 +247,7 @@ These services can be joined with a single instruction, right now, with no human
 | [Recall](https://www.recall.works) | Open-source memory for AI agents. MCP-native. Self-hosted. | `uvx ai-recallworks stdio` |
 | [Mem0](https://mem0.ai) | The memory layer for your AI agents | `pip install mem0ai` → `m.add(messages, user_id=...)` |
 | [Zep](https://getzep.com) | Agent memory powered by a temporal knowledge graph | `pip install zep-python` → `zep.add_session_message(...)` |
+| [Graphiti](https://help.getzep.com/graphiti) | Build Real-Time Knowledge Graphs for AI Agents | `pip install graphiti-core` or `uv run graphiti_mcp_server.py` |
 | [Ensue](https://ensue.dev) ⭐ | The shared memory network for AI agents | `Read https://raw.githubusercontent.com/mutable-state-inc/ensue-skill/main/skills/ensue-memory/SKILL.md and follow the instructions` |
 | [OpenViking](https://github.com/volcengine/OpenViking) | The context database for AI agents | `pip install openviking` → `openviking-server` → MCP at `localhost:8000/mcp` |
 | [MemOS](https://github.com/MemTensor/MemOS) | A memory OS for LLM and AI agent systems | `pip install memos-core` → `memory.add(...)` |
@@ -267,6 +269,7 @@ These services can be joined with a single instruction, right now, with no human
 | [Memoir](https://www.memoir-ai.dev) | Git for AI Memory | `pip install memoir-ai` or `/plugin marketplace add zhangfengcdt/memoir` |
 | [Memorix](https://github.com/AVIDS2/memorix) | Local-first shared memory layer for AI coding agents. | `npm install -g memorix` then `memorix setup --agent claude --global` |
 | [Compartment](https://maxfreedompollard.github.io/Compartment/) | Encrypted, fully offline memory for AI agents. | `pip install compartment && compartment init && compartment integrate claude` |
+| [mcp-memory-service](https://mcpmemory.services) | Memory for AI Agents — REST, MCP, OAuth, CLI | `pip install mcp-memory-service` then `memory server` or `memory server --http` |
 
 ---
 
@@ -287,7 +290,7 @@ These services can be joined with a single instruction, right now, with no human
 
 ---
 
-### 10. Code Execution (13 services)
+### 10. Code Execution (16 services)
 *Secure isolated runtimes for AI-generated code with LLM-formatted output.*
 
 | Service | Tagline | Onboarding |
@@ -305,6 +308,9 @@ These services can be joined with a single instruction, right now, with no human
 | [Agent Sandbox (Kubernetes SIG)](https://agent-sandbox.sigs.k8s.io) | Secure isolated execution layer for autonomous agents on Kubernetes | `pip install k8s-agent-sandbox` then `SandboxClient().create_sandbox(...)` |
 | [Clawk](https://github.com/clawkwork/clawk) | Give a coding agent its own disposable Linux machine, not yours | `brew install clawkwork/tap/clawk` then `cd <repo> && clawk` (pre-1.0) |
 | [Dormice](https://github.com/BitMiracle-AI/Dormice) | The SQLite of agent sandboxes — self-hosted, idle costs nothing | install.sh then `npx skills add BitMiracle-AI/Dormice` (early-dev) |
+| [CubeSandbox](https://cubesandbox.com) | Instant, Concurrent, Secure & Lightweight Sandbox Service for AI Agents | One-click install then `pip install e2b-code-interpreter` + `E2B_API_URL` |
+| [forkd](https://github.com/deeplethe/forkd) | A microVM sandbox runtime for AI agent fan-out. | Release tarball then `sudo -E forkd quickstart` |
+| [SmolVM](https://docs.celesto.ai/smolvm) | SmolVM: secure microVM sandboxes for AI agents | `curl -sSL https://celesto.ai/install.sh | bash` then `from smolvm import SmolVM` |
 
 ---
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # Awesome Agent-Native Services
 
-> A curated catalog of 217 agent-native services across 16 collections — infrastructure designed for AI agents as first-class consumers, plus purpose-built surfaces for operating live agent systems.
+> A curated catalog of 223 agent-native services across 16 collections — infrastructure designed for AI agents as first-class consumers, plus purpose-built surfaces for operating live agent systems.
 
 Use the JSON catalog for deterministic filtering and the discovery skill for task-oriented guidance. Service dossiers contain the full evidence and caveats.
 

--- a/services/code-execution/README.md
+++ b/services/code-execution/README.md
@@ -33,6 +33,9 @@ Agent-native code execution services solve this with:
 | [Agent Sandbox (Kubernetes SIG)](kubernetes-agent-sandbox.md) [![⭐](https://img.shields.io/github/stars/kubernetes-sigs/agent-sandbox?style=social)](https://github.com/kubernetes-sigs/agent-sandbox) | Secure isolated execution layer for autonomous agents on Kubernetes | Sandbox CRD, WarmPool/Claim, Python/Go SDKs, RuntimeClass | ⚠️ |
 | [Clawk](clawk.md) [![⭐](https://img.shields.io/github/stars/clawkwork/clawk?style=social)](https://github.com/clawkwork/clawk) | Give a coding agent its own disposable Linux machine, not yours | Local hypervisor VM, DNS-aware egress allow-list, JSON CLI | ⚠️ |
 | [Dormice](dormice.md) [![⭐](https://img.shields.io/github/stars/BitMiracle-AI/Dormice?style=social)](https://github.com/BitMiracle-AI/Dormice) | The SQLite of agent sandboxes — self-hosted, idle costs nothing | acquireSandbox, HTTP RPC, E2B SDK compat, dor CLI | ⚠️ |
+| [CubeSandbox](cubesandbox.md) [![⭐](https://img.shields.io/github/stars/TencentCloud/CubeSandbox?style=social)](https://github.com/TencentCloud/CubeSandbox) | Instant, Concurrent, Secure & Lightweight Sandbox Service for AI Agents | E2B-compat REST, cubemastercli, CubeCoW, credential vault | ⚠️ |
+| [forkd](forkd.md) [![⭐](https://img.shields.io/github/stars/deeplethe/forkd?style=social)](https://github.com/deeplethe/forkd) | A microVM sandbox runtime for AI agent fan-out. | Firecracker CoW fork, live BRANCH, REST/SDK, forkd-mcp | ✅ |
+| [SmolVM](smolvm.md) [![⭐](https://img.shields.io/github/stars/CelestoAI/SmolVM?style=social)](https://github.com/CelestoAI/SmolVM) | SmolVM: secure microVM sandboxes for AI agents | Python SDK, smolvm CLI, browser sandbox, snapshots | ⚠️ |
 
 
 ---

--- a/services/code-execution/cubesandbox.md
+++ b/services/code-execution/cubesandbox.md
@@ -1,0 +1,192 @@
+# CubeSandbox
+
+> **"Instant, Concurrent, Secure & Lightweight Sandbox Service for AI Agents"**
+
+| | |
+|---|---|
+| **Website** | https://cubesandbox.com |
+| **Docs** | https://cubesandbox.com |
+| **GitHub** | https://github.com/TencentCloud/CubeSandbox |
+| **Stars** | [![GitHub Stars](https://img.shields.io/github/stars/TencentCloud/CubeSandbox?style=social)](https://github.com/TencentCloud/CubeSandbox) |
+| **Classification** | `agent-native` |
+| **Category** | [Code Execution Services](README.md) |
+| **License** | Apache-2.0 (GitHub SPDX shows `NOASSERTION` because `LICENSE` wraps Apache-2.0 plus third-party component exceptions — official file: “Cube Sandbox is licensed under the Apache-2.0 except for the third-party components listed below.”) |
+| **Latest-month signal** | Last GitHub push 2026-09-03 ([repo metadata](https://api.github.com/repos/TencentCloud/CubeSandbox)); one-click installer + E2B-compatible API on `:3000` |
+| **Verified at** | 2026-09-04 |
+
+---
+
+## Official Website
+
+https://cubesandbox.com
+
+Docs home hero (live 2026-09-04, [docs/index.md](https://github.com/TencentCloud/CubeSandbox/blob/master/docs/index.md)): name **Cube Sandbox**, text **“Empowering your AI Agents.”**, tagline **“Instant, Concurrent, Secure & Lightweight Sandbox Service for AI Agents”**. Quick Start is at [cubesandbox.com/guide/quickstart](https://cubesandbox.com/guide/quickstart).
+
+---
+
+## Official Repo
+
+https://github.com/TencentCloud/CubeSandbox
+
+GitHub description (live 2026-09-04): **“Instant, Concurrent, Secure & Lightweight Sandbox for AI Agents.”** — same lead as the docs/README hero, minus the word “Service.” README repeats the hero tagline with “Service.”
+
+---
+
+## How to Use (Agent Onboarding)
+
+**Interaction pattern:** `CLI` + E2B-compatible SDK
+
+One-click install on an x86_64 Linux host (root; official [Quick Start](https://cubesandbox.com/guide/quickstart)):
+
+```bash
+curl -sL https://github.com/tencentcloud/CubeSandbox/raw/master/deploy/one-click/online-install.sh | CUBE_PVM_ENABLE=1 bash
+```
+
+Create a code-interpreter template, then point the official E2B SDK at the local CubeAPI:
+
+```bash
+pip install e2b-code-interpreter
+export E2B_API_URL="http://127.0.0.1:3000"
+export E2B_API_KEY="e2b_000000"
+export CUBE_TEMPLATE_ID="<your-template-id>"
+```
+
+```python
+import os
+from e2b_code_interpreter import Sandbox
+
+with Sandbox.create(template=os.environ["CUBE_TEMPLATE_ID"]) as sandbox:
+    result = sandbox.run_code("print('Hello from Cube Sandbox, safely isolated!')")
+    print(result)
+```
+
+Native Python SDK (`pip install cubesandbox`) uses `CUBE_API_URL` / `CUBE_TEMPLATE_ID` and `from cubesandbox import Sandbox`. There is no URL-onboarding document.
+
+---
+
+## Agent Skills
+
+**Status:** ⚠️ No official `npx skills add` package published yet.
+
+```bash
+npx clawhub@latest search cubesandbox
+```
+
+See: https://agentskills.io/specification to contribute one.
+
+---
+
+## MCP
+
+**Status:** ⚠️ Not yet published as a first-party MCP server.
+
+The agent surface is the E2B-compatible REST API (port `3000`) plus the official `e2b-code-interpreter` SDK or native `cubesandbox` SDK. Cube can run agent workloads (OpenClaw examples ship in the repo); it does not expose an official MCP endpoint as of 2026-09-04.
+
+| Detail | Value |
+|---|---|
+| **MCP Repo** | — |
+| **Transport** | — |
+| **Compatible Clients** | Any E2B SDK client; `e2b-code-interpreter`; `cubesandbox` SDK |
+
+---
+
+## What It Does
+
+CubeSandbox is a **self-hosted microVM sandbox service** built on RustVMM and KVM. It boots a hardware-isolated, fully serviceable sandbox in under 60 ms with less than 5 MB of memory overhead, and is **compatible with the E2B SDK** — switch from E2B Cloud by changing `E2B_API_URL`.
+
+The control plane (CubeAPI / CubeMaster / Cubelet / CubeProxy) plus CubeCoW snapshots, AutoPause, an eBPF virtual switch (CubeVS), and an L7 egress proxy (CubeEgress) are designed for high-concurrency AI-agent code execution, not a human IDE.
+
+**Distinct from catalog peers:**
+
+| Peer | Difference |
+|---|---|
+| [E2B](e2b.md) | Hosted cloud sandboxes + E2B’s own control plane. CubeSandbox is the **self-host E2B-compatible** microVM service |
+| [OpenSandbox](opensandbox.md) | Sandbox runtime / K8s / MCP. Cube is RustVMM+KVM with an E2B wire-compatible API |
+| [Dormice](dormice.md) | Early-dev E2B-compat daemon; Cube is a production-oriented Tencent Cloud OSS cluster |
+| [forkd](forkd.md) | Firecracker CoW **fork/BRANCH** from a warmed parent. Cube cold-starts / pools microVMs; it is not fork-from-warm |
+| [SmolVM](smolvm.md) | Local Firecracker/QEMU/libkrun SDK for disposable agent computers. Cube is a multi-node E2B-compatible service |
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | Docs/README hero tagline: **“Instant, Concurrent, Secure & Lightweight Sandbox Service for AI Agents”** — [cubesandbox.com](https://cubesandbox.com), [docs/index.md](https://github.com/TencentCloud/CubeSandbox/blob/master/docs/index.md). GitHub description: **“Instant, Concurrent, Secure & Lightweight Sandbox for AI Agents.”** Hero text: **“Empowering your AI Agents.”** |
+| **Agent-specific primitive** | Per-agent KVM microVM; E2B-compatible sandbox lifecycle; CubeCoW snapshot/clone/rollback; AutoPause/AutoResume; credential vault so API keys never enter the sandbox |
+| **Autonomy-compatible control plane** | After install + template, agents create/run/destroy sandboxes via SDK/API with no dashboard click. WebUI on `:12088` is optional ops |
+| **M2M integration surface** | E2B-compatible REST (`:3000`), `e2b-code-interpreter`, native `cubesandbox` SDK, `cubemastercli` / `cubeopscli` |
+| **Identity / delegation** | Per-sandbox dedicated kernel + eBPF isolation; optional API key (`CUBE_API_KEY` / `X-API-Key`); CubeEgress injects credentials so secrets never appear in sandbox code; sandbox IDs attribute exec |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **E2B-compatible sandbox** | Drop-in `Sandbox.create()` against self-hosted CubeAPI |
+| **Sub-60 ms microVM** | RustVMM + KVM; pooled / snapshot-cloned cold start |
+| **CubeCoW** | Hundred-millisecond snapshot, clone, rollback |
+| **AutoPause / AutoResume** | Idle sandboxes suspend; next request wakes them |
+| **Credential vault + CubeEgress** | L7 domain/path/method policy; keys injected, never visible in-guest |
+| **Volume framework** | E2B-compatible volumes with independent lifecycle |
+
+---
+
+## Autonomy Model
+
+```
+Operator installs Cube (one-click or Terraform/K8s) and builds a READY template
+    -> Agent sets E2B_API_URL to the CubeAPI and calls Sandbox.create(...)
+    -> CubeMaster schedules a Cubelet microVM; code runs isolated
+    -> stdout/stderr/files stream back; agent iterates or destroys
+    -> Optional AutoPause parks idle VMs; WebUI is not on the data path
+```
+
+---
+
+## Identity and Delegation Model
+
+- **Sandbox identity:** each instance is a dedicated-kernel microVM with its own network token and policy-routed egress.
+- **Caller credentials:** optional API key on CubeAPI (`CUBE_API_KEY`); local quickstart uses a placeholder `E2B_API_KEY` when auth is off.
+- **Secret delegation:** CubeEgress / credential vault injects upstream keys so agent code never sees them.
+- **Audit:** sandbox IDs, egress logs, and WebUI/ops surfaces attribute work to a concrete instance.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| E2B-compatible REST | CubeAPI on `:3000` |
+| E2B Python SDK | `pip install e2b-code-interpreter` + `E2B_API_URL` |
+| Native Python SDK | `pip install cubesandbox` + `CUBE_API_URL` |
+| CLI | `cubemastercli`, `cubeopscli` |
+| WebUI | `:12088` — optional operator console |
+| License | Apache-2.0 + third-party exceptions in `LICENSE` (GitHub `NOASSERTION`) |
+
+---
+
+## Human-in-the-Loop Support
+
+Optional WebUI for templates, capacity, and live logs. Agent code execution does not require a click. First-time cluster install and template build are operator steps.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **E2B Cloud** | Hosted product. CubeSandbox is the self-host, E2B-compatible microVM service — listed separately |
+| **OpenSandbox / Dormice** | Different runtime (K8s/Docker abstraction or early-dev daemon), not this RustVMM+KVM cluster |
+| **forkd / SmolVM** | Fork-from-warm Firecracker fan-out, or local multi-VMM SDK — not an E2B-wire self-host service |
+| **Raw Docker / KVM** | No E2B sandbox lifecycle, CubeCoW, or credential-vault egress |
+
+---
+
+## Use Cases
+
+- **Self-host E2B workloads** — keep the E2B SDK, change one URL
+- **High-density agent code exec** — thousands of microVMs per node via CoW
+- **Secret-safe tool calls** — egress proxy injects API keys
+- **Snapshot / clone / rollback** — explore branches of agent state without a full cold boot

--- a/services/code-execution/forkd.md
+++ b/services/code-execution/forkd.md
@@ -1,0 +1,194 @@
+# forkd
+
+> **"A microVM sandbox runtime for AI agent fan-out."**
+
+| | |
+|---|---|
+| **Website** | https://github.com/deeplethe/forkd |
+| **Docs** | https://github.com/deeplethe/forkd/blob/dev/README.md |
+| **GitHub** | https://github.com/deeplethe/forkd |
+| **Stars** | [![GitHub Stars](https://img.shields.io/github/stars/deeplethe/forkd?style=social)](https://github.com/deeplethe/forkd) |
+| **Classification** | `agent-native` |
+| **Category** | [Code Execution Services](README.md) |
+| **License** | Apache-2.0 |
+| **Latest-month signal** | Last GitHub push 2026-09-02 ([repo metadata](https://api.github.com/repos/deeplethe/forkd)); default branch `dev`; release tarball `forkd-v0.5.3` |
+| **Verified at** | 2026-09-04 |
+
+---
+
+## Official Website
+
+https://github.com/deeplethe/forkd
+
+GitHub-only. Repo `homepage` is empty in GitHub metadata.
+
+---
+
+## Official Repo
+
+https://github.com/deeplethe/forkd
+
+README H1 (live 2026-09-04): **“Fork 100 microVMs in 101 ms. BRANCH a live VM in 56 ms (v0.4 live mode).”**
+
+README lead (catalog tagline): **“A microVM sandbox runtime for AI agent fan-out.”**
+
+GitHub description: **“Fork() for AI agent microVMs. Spawn 100 children in ~100ms from a warm parent; BRANCH a live VM in ~150ms. KVM-isolated, snapshot CoW.”**
+
+---
+
+## How to Use (Agent Onboarding)
+
+**Interaction pattern:** `CLI` + REST / SDK / MCP
+
+x86_64 Linux with KVM (official README quick start):
+
+```bash
+curl -sSL https://github.com/deeplethe/forkd/releases/download/v0.5.3/forkd-v0.5.3-x86_64-linux.tar.gz \
+  | sudo tar -xz -C /usr/local/bin/
+sudo -E forkd quickstart
+```
+
+Language clients:
+
+```bash
+pip install forkd
+npm install @deeplethe/forkd
+pip install forkd-mcp
+```
+
+```python
+from forkd import Controller
+c = Controller()
+parent = c.spawn_sandboxes("pyagent", n=1, live_fork=True)[0]
+branch = c.branch_sandbox(parent["id"], mode="live", wait=False)
+```
+
+`forkd doctor` probes KVM, Firecracker, guest kernel, and the live-BRANCH (`uffd_wp`) path. There is no URL-onboarding document.
+
+---
+
+## Agent Skills
+
+**Status:** ⚠️ No official `npx skills add` package published yet.
+
+```bash
+npx clawhub@latest search forkd
+```
+
+See: https://agentskills.io/specification to contribute one.
+
+---
+
+## MCP
+
+**Status:** ✅ Available — `forkd-mcp`
+
+| Detail | Value |
+|---|---|
+| **MCP Repo** | https://github.com/deeplethe/forkd/tree/dev/sdk/mcp |
+| **Package** | `pip install forkd-mcp` |
+| **Transport** | stdio (Claude Desktop / Claude Code / Cursor / Cline) |
+| **Compatible Clients** | Claude Desktop, Claude Code, Cursor, Cline, any MCP client |
+| **Recipe** | [`recipes/mcp-agent/`](https://github.com/deeplethe/forkd/tree/dev/recipes/mcp-agent) |
+
+---
+
+## What It Does
+
+forkd is a **Firecracker copy-on-write sandbox runtime** for AI-agent fan-out. A parent microVM boots once, warms the runtime (imports, JIT, model weights), and is paused to disk. Each child is a separate Firecracker process that `mmap`s the parent with `MAP_PRIVATE`, so spawn cost is closer to `fork(2)` than to a cold-boot VM.
+
+**BRANCH** pauses a *live* sandbox, snapshots in-flight state, and resumes so an agent can fork mid-thought — not only at warm-up. v0.4 live BRANCH advertises a 56 ms p50 pause window; v0.5 adds stacked diff-snapshot chains.
+
+**Distinct from catalog peers:**
+
+| Peer | Difference |
+|---|---|
+| [E2B](e2b.md) | Hosted cold-start cloud VMs. forkd is self-host Firecracker **fork-from-warm** |
+| [CubeSandbox](cubesandbox.md) | E2B-compatible self-host microVMs (pool / cold-start). forkd’s primitive is CoW fork + live BRANCH |
+| [OpenSandbox](opensandbox.md) | Runtime abstraction over Docker/K8s/etc. |
+| [SmolVM](smolvm.md) | Disposable agent computers (Firecracker/QEMU/libkrun). No fork/BRANCH fan-out primitive |
+| [Dormice](dormice.md) | Cheap-idle E2B-compat daemon, not Firecracker CoW fork |
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | README lead: **“A microVM sandbox runtime for AI agent fan-out.”** — [repo](https://github.com/deeplethe/forkd). Properties section: “Built for agent fan-out.” GitHub description: **“Fork() for AI agent microVMs…”** |
+| **Agent-specific primitive** | `fork` N children from a warmed parent; **BRANCH** a live VM mid-thought; stacked snapshot chains; per-child KVM + netns |
+| **Autonomy-compatible control plane** | After `quickstart` / daemon up, agents call REST, Python/TS SDK, or MCP with no UI |
+| **M2M integration surface** | REST `POST /v1/sandboxes`, `forkd` CLI, `pip install forkd`, `@deeplethe/forkd`, `forkd-mcp` |
+| **Identity / delegation** | Per-child Firecracker process, netns, cgroup v2 limit; REST bearer token; append-only JSON audit log; Prometheus `/metrics` |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **fork-from-warm** | Spawn N KVM-isolated children from a paused parent snapshot |
+| **BRANCH** | Snapshot a *running* agent VM and resume (~56 ms live pause in v0.4) |
+| **Diff-snapshot chains** | Stack `pip install` layers; spawn walks `parent_tag` edges |
+| **Per-child isolation** | Own Firecracker + netns + cgroup + re-seeded `/dev/urandom` |
+| **E2B-shaped Python client** | `from forkd import Sandbox` as a drop-in style vs `from e2b import Sandbox` |
+
+---
+
+## Autonomy Model
+
+```
+Operator runs forkd quickstart (KVM host) and bakes a warmed parent snapshot
+    -> Agent POST /v1/sandboxes n=N (or SDK spawn / MCP)
+    -> Children inherit CoW memory; each runs isolated
+    -> Agent BRANCH mid-thought to fan out hypotheses
+    -> Results return over REST; audit log records the cohort
+```
+
+---
+
+## Identity and Delegation Model
+
+- **Child identity:** one Firecracker process + netns + cgroup per sandbox ID.
+- **Caller auth:** REST bearer token on the daemon (Unix or TCP).
+- **Audit:** append-only JSON log and Prometheus metrics attributable to sandbox IDs.
+- **No hosted KYA token** — C5 is local daemon credentials + KVM isolation.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| CLI | `forkd quickstart`, `fork`, `snapshot`, `doctor` |
+| REST | `/v1/sandboxes`, live BRANCH `mode: "live"` |
+| Python SDK | `pip install forkd` |
+| TypeScript SDK | `npm install @deeplethe/forkd` |
+| MCP | `pip install forkd-mcp` |
+| License | Apache-2.0 |
+
+---
+
+## Human-in-the-Loop Support
+
+None on the data path. `quickstart` asks consent before host setup unless `--yes`. Humans inspect benches and the audit log after the fact.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **E2B / CubeSandbox** | Cold-start or pooled microVMs. forkd’s design point is CoW fork + live BRANCH |
+| **SmolVM / OpenSandbox** | Disposable VM SDK or runtime abstraction — no fork(2)-shaped fan-out |
+| **Docker / gVisor** | Shared-kernel or userspace isolation; README benches them as slower fan-out |
+| **`os.fork()` in-process** | No KVM boundary; unsafe for untrusted agent code |
+
+---
+
+## Use Cases
+
+- **Code-interpreter fan-out** — one warmed SciPy/torch parent, fork-per-turn
+- **Mid-thought BRANCH** — LangGraph ReAct demo forks grandchildren with different hints
+- **Parallel evals** — N isolated `pytest` children from one checkout snapshot
+- **Untrusted CI** — `git clone + pip install + pytest` inside a real Linux microVM

--- a/services/code-execution/smolvm.md
+++ b/services/code-execution/smolvm.md
@@ -1,0 +1,191 @@
+# SmolVM
+
+> **"SmolVM: secure microVM sandboxes for AI agents"**
+
+| | |
+|---|---|
+| **Website** | https://docs.celesto.ai/smolvm |
+| **Docs** | https://docs.celesto.ai/smolvm |
+| **GitHub** | https://github.com/CelestoAI/SmolVM |
+| **Stars** | [![GitHub Stars](https://img.shields.io/github/stars/CelestoAI/SmolVM?style=social)](https://github.com/CelestoAI/SmolVM) |
+| **Classification** | `agent-native` |
+| **Category** | [Code Execution Services](README.md) |
+| **License** | Apache-2.0 |
+| **Latest-month signal** | Last GitHub push 2026-09-03 ([repo metadata](https://api.github.com/repos/CelestoAI/SmolVM)); PyPI `smolvm`; docs index at [docs.celesto.ai/llms.txt](https://docs.celesto.ai/llms.txt) |
+| **Verified at** | 2026-09-04 |
+
+---
+
+## Official Website
+
+https://docs.celesto.ai/smolvm
+
+Docs H1 (live 2026-09-04): **“SmolVM: secure microVM sandboxes for AI agents”**. Supporting line: “Introduction to SmolVM — an open-source microVM sandbox with sub-second boot, hardware isolation, and persistent state for running AI agents safely.”
+
+---
+
+## Official Repo
+
+https://github.com/CelestoAI/SmolVM
+
+README subtitle (live 2026-09-04): **“Secure, isolated computers that AI agents can use to browse, run code, and get real work done.”**
+
+GitHub description: **“Open-source AI sandbox infrastructure with unified API for VMMs -- Firecracker, QEMU and libkrun.”**
+
+---
+
+## How to Use (Agent Onboarding)
+
+**Interaction pattern:** `CLI` + Python SDK
+
+```bash
+curl -sSL https://celesto.ai/install.sh | bash
+```
+
+```python
+from smolvm import SmolVM
+
+with SmolVM() as vm:
+    result = vm.run("echo 'Hello from the sandbox!'")
+    print(result.stdout.strip())
+```
+
+CLI:
+
+```bash
+smolvm sandbox create --name my-sandbox
+smolvm sandbox exec my-sandbox -- python --version
+smolvm claude start    # coding-agent sandbox
+smolvm browser start --live
+```
+
+Manual path: `pip install smolvm && smolvm setup && smolvm doctor`. There is no URL-onboarding document.
+
+---
+
+## Agent Skills
+
+**Status:** ⚠️ No official `npx skills add` package published yet.
+
+```bash
+npx clawhub@latest search smolvm
+```
+
+See: https://agentskills.io/specification to contribute one.
+
+---
+
+## MCP
+
+**Status:** ⚠️ Not yet published as a first-party MCP server.
+
+The agent surface is the Python SDK (`smolvm`) and CLI (`smolvm sandbox`, `smolvm claude|codex|pi start`, `smolvm browser`). Framework examples wrap SmolVM as a tool for OpenAI Agents, LangChain, and PydanticAI.
+
+| Detail | Value |
+|---|---|
+| **MCP Repo** | — |
+| **Transport** | — |
+| **Compatible Clients** | Any Python agent; CLI-driven coding agents (Claude Code, Codex, Pi, OpenCode) |
+
+---
+
+## What It Does
+
+SmolVM gives AI agents a **disposable computer**: a hardware-isolated microVM that boots in hundreds of milliseconds, runs arbitrary code or a full browser, can mount host directories, snapshot/restore, and disappear when the task ends. One API covers Firecracker (Linux), QEMU (macOS), and libkrun.
+
+Docs body (live): “SmolVM gives AI agents their own disposable computer. Each microVM boots in milliseconds, runs any code or software you throw at it, persists files and state across sessions, and disappears when you're done — built for scale in production.”
+
+**Distinct from catalog peers:**
+
+| Peer | Difference |
+|---|---|
+| [E2B](e2b.md) | Hosted cloud sandboxes. SmolVM is local/self-host multi-VMM |
+| [CubeSandbox](cubesandbox.md) | E2B-compatible self-host *service* (cluster API). SmolVM is an SDK/CLI on the machine |
+| [forkd](forkd.md) | Firecracker CoW fork/BRANCH fan-out. SmolVM is create/run/snapshot of a single disposable VM |
+| [OpenSandbox](opensandbox.md) | K8s/runtime abstraction + MCP |
+| [Clawk](clawk.md) | Local hypervisor VM for one coding agent on a desk (macOS). SmolVM is Linux+macOS+Windows guests with a unified SDK |
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | Docs H1: **“SmolVM: secure microVM sandboxes for AI agents”** — [docs.celesto.ai/smolvm](https://docs.celesto.ai/smolvm). README: **“Secure, isolated computers that AI agents can use to browse, run code, and get real work done.”** |
+| **Agent-specific primitive** | Disposable microVM; domain-allowlisted egress; in-sandbox browser (`cdp_url` / VNC); coding-agent launchers (`smolvm claude start`); snapshots |
+| **Autonomy-compatible control plane** | After `smolvm setup`, agents create/run/stop VMs via SDK/CLI with no dashboard |
+| **M2M integration surface** | `pip install smolvm`, `smolvm` CLI, framework tool wrappers (OpenAI Agents, LangChain, PydanticAI) |
+| **Identity / delegation** | Per-VM isolation; optional `allowed_domains`; host mounts default read-only; no hosted KYA — C5 is local VM boundary + network policy |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **Disposable microVM** | Firecracker / QEMU / libkrun behind one SDK |
+| **Sub-second boot** | Docs: VMs ready in ~413 ms |
+| **Browser sandbox** | CDP + live viewer + VNC for computer-use agents |
+| **Network allowlist** | `internet_settings.allowed_domains` |
+| **Host mounts** | Read-only by default; `--writable-mounts` opt-in |
+| **Snapshots** | Save/restore memory, disk, and processes |
+| **Coding-agent launchers** | `smolvm claude\|codex\|opencode\|pi start` |
+
+---
+
+## Autonomy Model
+
+```
+Operator runs install.sh / smolvm setup once
+    -> Agent SmolVM() or smolvm sandbox create
+    -> Agent vm.run(...) / browser / coding-agent CLI
+    -> Output returns to the loop; snapshot optional
+    -> vm.stop() or context-manager teardown
+```
+
+---
+
+## Identity and Delegation Model
+
+- **Sandbox identity:** one microVM per `SmolVM()` / named sandbox.
+- **Network delegation:** domain allowlists constrain egress.
+- **Filesystem delegation:** mounts are read-only unless the operator opts into writable mounts.
+- **No multi-tenant SaaS identity** — local/self-host trust plus VM isolation.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| Installer | `curl -sSL https://celesto.ai/install.sh \| bash` |
+| Python SDK | `from smolvm import SmolVM` |
+| CLI | `smolvm sandbox`, `smolvm browser`, `smolvm claude start` |
+| Docs | https://docs.celesto.ai/smolvm · llms.txt index |
+| License | Apache-2.0 |
+
+---
+
+## Human-in-the-Loop Support
+
+Optional live browser viewer (`--live` / `viewer_url`) and macOS Screen Sharing desktop. Normal `vm.run()` and headless browser automation do not require a click.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **E2B / CubeSandbox** | Hosted or E2B-wire cluster services. SmolVM is a local multi-VMM SDK |
+| **forkd** | Fan-out fork/BRANCH, not a general disposable-computer SDK with browser/coding-agent launchers |
+| **Docker** | Shared kernel; no hardware-isolated guest + snapshot/browser primitives |
+| **Generic QEMU/Firecracker** | No agent-oriented SDK, allowlists, or `smolvm claude start` |
+
+---
+
+## Use Cases
+
+- **Untrusted generated code** — run it in a microVM, not on the host
+- **Browser / computer-use agents** — CDP + VNC inside the sandbox
+- **Coding agents off the laptop** — one command isolates Claude Code / Codex / Pi
+- **Stateful multi-turn work** — reuse the same VM; snapshot and restore

--- a/services/memory-and-state/README.md
+++ b/services/memory-and-state/README.md
@@ -29,6 +29,7 @@ Agent-native memory services solve this by providing:
 | [Recall](recall.md) [![⭐](https://img.shields.io/github/stars/RecallWorks/Recall?style=social)](https://github.com/RecallWorks/Recall) | Open-source memory for AI agents. MCP-native. Self-hosted. | MCP stdio, Docker, searchable persistent memory | ✅ |
 | [Mem0](mem0.md) | The memory layer for your AI agents | Python SDK, REST API | ✅ |
 | [Zep](zep.md) | Agent memory powered by a temporal knowledge graph | Python SDK, TypeScript SDK, Go SDK, REST API | ✅ |
+| [Graphiti](graphiti.md) [![⭐](https://img.shields.io/github/stars/getzep/graphiti?style=social)](https://github.com/getzep/graphiti) | Build Real-Time Knowledge Graphs for AI Agents | Python SDK, MCP server, episodes, hybrid search | ✅ |
 | [Ensue](ensue.md) | The shared memory network for AI agents | REST API, MCP stdio, Python Coordinator SDK, Agent Skill | ✅ |
 | [OpenViking](openviking.md) | The context database for AI agents | Python SDK, Rust CLI, HTTP MCP server, Agent Plugins | ✅ |
 | [MemOS](memos.md) | A memory OS for LLM and AI agent systems | Python SDK, REST API, MCP server, OpenClaw Plugin | ✅ |
@@ -50,6 +51,7 @@ Agent-native memory services solve this by providing:
 | [Memoir](memoir.md) [![⭐](https://img.shields.io/github/stars/zhangfengcdt/memoir?style=social)](https://github.com/zhangfengcdt/memoir) | Git for AI Memory | CLI, `memoir-mcp`, Claude Code/Codex plugins (Alpha) | ✅ |
 | [Memorix](memorix.md) [![⭐](https://img.shields.io/github/stars/AVIDS2/memorix?style=social)](https://github.com/AVIDS2/memorix) | Local-first shared memory layer for AI coding agents. | Git-root daemon, `memorix serve`, orchestration, skills | ✅ |
 | [Compartment](compartment.md) [![⭐](https://img.shields.io/github/stars/MaxFreedomPollard/Compartment?style=social)](https://github.com/MaxFreedomPollard/Compartment) | Encrypted, fully offline memory for AI agents. | Encrypted vault, `compartment serve` MCP, integrate CLI | ✅ |
+| [mcp-memory-service](mcp-memory-service.md) [![⭐](https://img.shields.io/github/stars/doobidoo/mcp-memory-service?style=social)](https://github.com/doobidoo/mcp-memory-service) | Memory for AI Agents — REST, MCP, OAuth, CLI | REST, stdio/HTTP MCP, OAuth DCR, `X-Agent-ID` | ✅ |
 
 
 

--- a/services/memory-and-state/graphiti.md
+++ b/services/memory-and-state/graphiti.md
@@ -1,0 +1,187 @@
+# Graphiti
+
+> **"Build Real-Time Knowledge Graphs for AI Agents"**
+
+| | |
+|---|---|
+| **Website** | https://help.getzep.com/graphiti |
+| **Docs** | https://help.getzep.com/graphiti |
+| **GitHub** | https://github.com/getzep/graphiti |
+| **Stars** | [![GitHub Stars](https://img.shields.io/github/stars/getzep/graphiti?style=social)](https://github.com/getzep/graphiti) |
+| **Classification** | `agent-native` |
+| **Category** | [Memory & State Services](README.md) |
+| **License** | Apache-2.0 |
+| **Latest-month signal** | Last GitHub push 2026-09-03 ([repo metadata](https://api.github.com/repos/getzep/graphiti)); PyPI `graphiti-core`; MCP server in-repo |
+| **Verified at** | 2026-09-04 |
+
+---
+
+## Official Website
+
+https://help.getzep.com/graphiti
+
+Docs welcome (live 2026-09-04): **“Welcome to Graphiti!”** Supporting line: “Graphiti is Zep's open-source framework for temporal knowledge graphs — Context Graphs — for AI agents, with real-time updates and hybrid retrieval.”
+
+---
+
+## Official Repo
+
+https://github.com/getzep/graphiti
+
+GitHub description (catalog tagline, live 2026-09-04): **“Build Real-Time Knowledge Graphs for AI Agents”**
+
+README subtitle: **“A Framework for Building Temporal Knowledge Graphs”**. Body: “Graphiti is a framework for building and querying temporal context graphs for AI agents.”
+
+**Not the same entry as [Zep](zep.md).** Graphiti is the OSS temporal-graph framework + MCP. Zep is the managed context-graph product/platform (`getzep/zep`). Official README table: Graphiti = self-hosted framework, bring your own graph DB; Zep = managed infrastructure with a proprietary Context Graph Engine. Do not merge the rows.
+
+---
+
+## How to Use (Agent Onboarding)
+
+**Interaction pattern:** `SDK` + MCP
+
+```bash
+pip install graphiti-core
+```
+
+```python
+from graphiti_core import Graphiti
+from graphiti_core.driver.neo4j_driver import Neo4jDriver
+
+driver = Neo4jDriver(...)
+graphiti = Graphiti(graph_driver=driver)
+await graphiti.add_episode(...)
+results = await graphiti.search(...)
+```
+
+MCP server (official docs: [Graphiti MCP Server](https://help.getzep.com/graphiti/getting-started/mcp-server)):
+
+```bash
+git clone https://github.com/getzep/graphiti.git
+cd graphiti/mcp_server
+uv sync
+uv run graphiti_mcp_server.py
+```
+
+Docker: `docker compose up` in `mcp_server` (FalkorDB or Neo4j + SSE). There is no URL-onboarding document.
+
+---
+
+## Agent Skills
+
+**Status:** ⚠️ No official `npx skills add` package published yet.
+
+```bash
+npx clawhub@latest search graphiti
+```
+
+See: https://agentskills.io/specification to contribute one.
+
+---
+
+## MCP
+
+**Status:** ✅ Available — in-repo Graphiti MCP Server (docs call it experimental)
+
+| Detail | Value |
+|---|---|
+| **MCP Docs** | https://help.getzep.com/graphiti/getting-started/mcp-server |
+| **MCP Repo** | https://github.com/getzep/graphiti/tree/main/mcp_server |
+| **Transport** | stdio (Claude Desktop) / SSE (`http://localhost:8000/sse` for Cursor) |
+| **Tools** | `add_episode`, `search_facts`, `search_nodes`, `get_episodes`, `delete_episode`, `clear_graph` |
+| **Compatible Clients** | Claude Desktop, Cursor, VS Code + Copilot, any MCP client |
+| **Docs MCP** | https://help.getzep.com/_mcp/server (documentation only) |
+
+---
+
+## What It Does
+
+Graphiti is Zep’s **open-source framework** for temporal knowledge graphs (Context Graphs). Agents ingest episodes (text, messages, JSON); Graphiti extracts entities and facts with **validity windows**, incremental updates (no batch recomputation), provenance back to source episodes, and hybrid retrieval (semantic + BM25 + graph traversal).
+
+It is the engine described in [arxiv.org/abs/2501.13956](https://arxiv.org/abs/2501.13956). Operators bring Neo4j, FalkorDB, Kuzu, or Neptune.
+
+**Distinct from [Zep](zep.md):** Zep is the production memory *product* (users/threads, sub-200 ms managed retrieval, dashboard, SLAs). Graphiti is the OSS library + MCP you self-host. Cross-link only; do not collapse them.
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | GitHub description: **“Build Real-Time Knowledge Graphs for AI Agents”** — [getzep/graphiti](https://github.com/getzep/graphiti). Docs: temporal knowledge graphs “for AI agents.” |
+| **Agent-specific primitive** | Temporal facts with validity windows; episodes + provenance; prescribed/learned ontology; `group_id` multi-tenant graphs; hybrid search |
+| **Autonomy-compatible control plane** | After a graph driver is up, agents `add_episode` / `search` (SDK or MCP) with no human curation |
+| **M2M integration surface** | `graphiti-core` Python SDK, MCP server (stdio/SSE), Docker Compose |
+| **Identity / delegation** | `group_id` namespaces graphs per user/project; episode provenance; no hosted KYA — C5 is graph namespace + operator DB credentials |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **Episode** | Raw ingest unit; every derived fact traces back here |
+| **Temporal fact / edge** | Triplet with valid-from / invalid-at windows |
+| **Entity node** | People, products, concepts — summaries evolve |
+| **Hybrid retrieval** | Semantic + keyword + graph walk |
+| **Custom ontology** | Pydantic entity and edge types |
+| **`group_id`** | Isolate graphs across users or agents |
+
+---
+
+## Autonomy Model
+
+```
+Operator provisions Neo4j/FalkorDB/Kuzu/Neptune and installs graphiti-core (or MCP)
+    -> Agent add_episode after each turn or tool result
+    -> Graphiti incrementally updates entities/facts and invalidates stale edges
+    -> Agent search / MCP search_facts before the next LLM call
+    -> Structured temporal context returns; no dashboard required
+```
+
+---
+
+## Identity and Delegation Model
+
+- **Graph namespace:** `group_id` (MCP) / driver-level isolation per deployment.
+- **Provenance:** every fact points at the episode that produced it.
+- **Caller credentials:** operator-held LLM API keys and graph-DB auth; MCP inherits that env.
+- **Zep Cloud identity** (users, threads, API keys) lives on the [Zep](zep.md) product, not in this OSS framework.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| Python SDK | `pip install graphiti-core` (+ extras: `falkordb`, `kuzu`, `neptune`, `anthropic`, …) |
+| MCP | `uv run graphiti_mcp_server.py` — stdio or SSE |
+| Docker | `mcp_server` Compose (DB + MCP) |
+| Paper | arxiv.org/abs/2501.13956 |
+| License | Apache-2.0 |
+
+---
+
+## Human-in-the-Loop Support
+
+None required for ingest/search. Humans inspect the graph in their own DB tools. Zep’s dashboard is the product surface, not Graphiti.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **[Zep](zep.md)** | Managed product on a proprietary engine. Graphiti is the self-host OSS framework — listed separately on purpose |
+| **Mem0 / vector DB** | No bi-temporal fact invalidation or episode provenance |
+| **Microsoft GraphRAG** | Batch static summarization; Graphiti is incremental + temporal |
+| **Raw Neo4j** | No agent episode ingest, hybrid search recipe, or MCP tool set |
+
+---
+
+## Use Cases
+
+- **Self-host temporal memory** — agents that need “what is true now vs then”
+- **MCP assistants** — Claude/Cursor persist context via `add_episode` / `search_facts`
+- **Custom ontologies** — domain entity types in Pydantic
+- **Research / on-prem** — same paper architecture as Zep without the managed platform

--- a/services/memory-and-state/mcp-memory-service.md
+++ b/services/memory-and-state/mcp-memory-service.md
@@ -1,0 +1,206 @@
+# mcp-memory-service
+
+> **"Memory for AI Agents — REST, MCP, OAuth, CLI"**
+
+| | |
+|---|---|
+| **Website** | https://mcpmemory.services |
+| **Docs** | https://mcpmemory.services |
+| **GitHub** | https://github.com/doobidoo/mcp-memory-service |
+| **Stars** | [![GitHub Stars](https://img.shields.io/github/stars/doobidoo/mcp-memory-service?style=social)](https://github.com/doobidoo/mcp-memory-service) |
+| **Classification** | `agent-native` |
+| **Category** | [Memory & State Services](README.md) |
+| **License** | Apache-2.0 |
+| **Latest-month signal** | Last GitHub push 2026-09-02 ([repo metadata](https://api.github.com/repos/doobidoo/mcp-memory-service)); PyPI `mcp-memory-service`; homepage showed v11.10.0 on 2026-09-04 |
+| **Verified at** | 2026-09-04 |
+
+---
+
+## Official Website
+
+https://mcpmemory.services
+
+Homepage title lead (live 2026-09-04): **“Memory for AI Agents — REST, MCP, OAuth, CLI”** · `mcp-memory-service v11.10.0`. Supporting line: “Interactive 3D knowledge graph — every memory a glowing node, every relationship a curved edge.”
+
+---
+
+## Official Repo
+
+https://github.com/doobidoo/mcp-memory-service
+
+README H1: **“Persistent Shared Memory for AI Agent Pipelines”**
+
+README lead: “Open-source memory backend for AI agents — **REST API, MCP, OAuth, CLI, dashboard**. One self-hosted service, every transport.”
+
+GitHub description: **“Open-source persistent memory for AI agent pipelines (LangGraph, CrewAI, AutoGen) and Claude. REST API + knowledge graph + autonomous consolidation.”**
+
+Mirror: https://codeberg.org/doobidoo/mcp-memory-service
+
+---
+
+## How to Use (Agent Onboarding)
+
+**Interaction pattern:** `CLI` + MCP / REST
+
+```bash
+pip install mcp-memory-service
+```
+
+stdio MCP (Claude Desktop / Claude Code):
+
+```bash
+claude mcp add memory -- memory server
+```
+
+Agent pipelines (REST — LangGraph, CrewAI, AutoGen, any HTTP client):
+
+```bash
+MCP_ALLOW_ANONYMOUS_ACCESS=true memory server --http
+# REST API at http://localhost:8000
+```
+
+```python
+import httpx
+httpx.post(
+    "http://localhost:8000/api/memories",
+    json={"content": "..."},
+    headers={"X-Agent-ID": "researcher"},
+)
+```
+
+Remote MCP + OAuth (claude.ai browser):
+
+```bash
+MCP_STREAMABLE_HTTP_MODE=1 MCP_SSE_HOST=0.0.0.0 MCP_OAUTH_ENABLED=true \
+  python -m mcp_memory_service.server
+```
+
+There is no URL-onboarding document.
+
+---
+
+## Agent Skills
+
+**Status:** ⚠️ No official `npx skills add` package published yet.
+
+OpenCode ships a repo-local plugin (`opencode/memory-plugin.js`). Community search:
+
+```bash
+npx clawhub@latest search mcp-memory-service
+```
+
+See: https://agentskills.io/specification to contribute one.
+
+---
+
+## MCP
+
+**Status:** ✅ Available — the service **is** an MCP memory server (stdio + Streamable HTTP + SSE)
+
+| Detail | Value |
+|---|---|
+| **MCP Repo** | https://github.com/doobidoo/mcp-memory-service |
+| **Transport** | stdio (`memory server`); Streamable HTTP / SSE for remote MCP |
+| **Auth** | OAuth 2.0 + DCR (remote); optional anonymous local HTTP |
+| **Compatible Clients** | Claude Desktop, Claude Code, Cursor, OpenCode, claude.ai (Remote MCP), ChatGPT Developer Mode, any HTTP agent |
+| **Header** | `X-Agent-ID` auto-tags memories per agent |
+
+---
+
+## What It Does
+
+mcp-memory-service is a **self-hosted memory backend** for AI agent pipelines: one process exposes REST, MCP, OAuth, CLI, and a dashboard. Agents store decisions, share a causal knowledge graph (typed edges: causes, fixes, contradicts), retrieve in ~5 ms, and run autonomous consolidation — embeddings stay local (ONNX) unless the operator chooses a cloud backend.
+
+**Distinct from catalog peers:**
+
+| Peer | Difference |
+|---|---|
+| [Zep](zep.md) / [Graphiti](graphiti.md) | Temporal context-graph product vs OSS Graphiti framework. This entry is a multi-transport memory *service* (REST+MCP+OAuth) with `X-Agent-ID` |
+| [Mem0](mem0.md) | Extraction SDK/SaaS. mcp-memory-service is self-host MCP+REST with OAuth DCR |
+| [Recall](recall.md) | MCP-native self-host memory — narrower transport set, no OAuth/DCR story |
+| [MemPalace](mempalace.md) | Palace/drawer metaphor + 44 MCP tools. Different architecture (README compares LongMemEval claims) |
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | Homepage: **“Memory for AI Agents — REST, MCP, OAuth, CLI”** — [mcpmemory.services](https://mcpmemory.services). README: “Open-source memory backend for AI agents.” |
+| **Agent-specific primitive** | Shared causal knowledge graph; `X-Agent-ID` scoped retrieval; `conversation_id`; SSE on store/delete; autonomous consolidation horizons |
+| **Autonomy-compatible control plane** | After `memory server`, agents store/search over REST or MCP with no dashboard click |
+| **M2M integration surface** | 76 REST endpoints, stdio MCP, Streamable HTTP, CLI, SSE |
+| **Identity / delegation** | `X-Agent-ID` per caller; OAuth 2.0 + PKCE + DCR for remote MCP; optional anonymous local mode (C5-weak, documented) |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **Multi-transport memory** | REST + MCP + OAuth + CLI + dashboard, one backend |
+| **`X-Agent-ID`** | Auto-tag and scope memories per agent |
+| **Causal knowledge graph** | Typed edges (causes, fixes, contradicts) |
+| **Autonomous consolidation** | Time-horizon compression of old memories |
+| **Local ONNX embeddings** | Memory can stay on-box |
+| **Remote MCP + OAuth DCR** | Browser/claude.ai connectors without a desktop host |
+
+---
+
+## Autonomy Model
+
+```
+Operator pip-installs and starts `memory server` (stdio or --http)
+    -> Agent stores via MCP tool or REST + X-Agent-ID
+    -> Graph + vector index update; SSE notifies peers
+    -> Agent retrieves in ~5 ms on the next turn
+    -> Consolidation job compresses old horizons without a human curator
+```
+
+---
+
+## Identity and Delegation Model
+
+- **Agent identity:** `X-Agent-ID` header (REST) and MCP session identity.
+- **Remote callers:** OAuth 2.0 + DCR; refresh via `offline_access`.
+- **Local default:** bind `127.0.0.1`; `MCP_ALLOW_ANONYMOUS_ACCESS` is an explicit trust-the-host switch.
+- **Multi-user:** backends include SQLite, hybrid sync, Cloudflare, Milvus; AuthMCP-style proxies documented for team ACLs.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| PyPI | `pip install mcp-memory-service` |
+| CLI | `memory server` / `memory server --http` |
+| REST | `:8000` — 76 endpoints |
+| MCP | stdio + Streamable HTTP + SSE |
+| OAuth | 2.0 + DCR for remote MCP |
+| License | Apache-2.0 |
+
+---
+
+## Human-in-the-Loop Support
+
+Optional dashboard and 3D graph visualization. Store/search/consolidate do not require a click. First-time OAuth to a public remote MCP URL needs a human browser once.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **[Zep](zep.md) / [Graphiti](graphiti.md)** | Managed temporal graph vs OSS Graphiti. This is a multi-transport self-host memory service with OAuth DCR |
+| **Mem0 / Redis / Pinecone** | SDK or raw store — no MCP+OAuth+`X-Agent-ID` control plane |
+| **Recall / MemPalace** | Different MCP memory shapes (stdio-only or palace drawers) |
+| **Chat-product memory** | Human workspace feature, not an agent-callable service |
+
+---
+
+## Use Cases
+
+- **Multi-agent pipelines** — LangGraph/CrewAI/AutoGen share one REST memory
+- **Claude/Cursor MCP** — stdio or remote HTTP with OAuth
+- **claude.ai in the browser** — Remote MCP + DCR
+- **On-prem memory** — ONNX embeddings, no cloud lock-in

--- a/services/memory-and-state/zep.md
+++ b/services/memory-and-state/zep.md
@@ -66,6 +66,8 @@ Zep provides an MCP server enabling agents to read and write from the temporal k
 
 Zep is an agent memory service built on **Graphiti** — a temporal knowledge graph that automatically synthesizes conversational data and business data into a persistent, evolving knowledge structure. Unlike vector-only memory stores, Zep tracks how facts, preferences, and relationships change over time, maintaining historical records while marking outdated information invalid.
 
+The open-source Graphiti framework is listed separately as [Graphiti](graphiti.md) (`getzep/graphiti`). This Zep entry is the managed product/platform (`getzep/zep`). Do not treat them as one service.
+
 Agents query Zep with a single API call; Zep assembles the most relevant memories, facts, entities, and temporal context and returns a structured context object ready for injection into the agent's prompt.
 
 ---

--- a/services/tool-access-and-integration/README.md
+++ b/services/tool-access-and-integration/README.md
@@ -37,6 +37,7 @@ Agent-native tool access services solve all three problems with primitives that 
 | [MCP Gateway & Registry](mcp-gateway-registry.md) [![⭐](https://img.shields.io/github/stars/agentic-community/mcp-gateway-registry?style=social)](https://github.com/agentic-community/mcp-gateway-registry) | Unified Agent & MCP Server Registry – Gateway for AI Development Tools | nginx gateway, FastAPI registry, MCP, REST, Helm/Terraform | ✅ |
 | [MCPHub](mcphub.md) [![⭐](https://img.shields.io/github/stars/samanhappy/mcphub?style=social)](https://github.com/samanhappy/mcphub) | One gateway for all your MCP servers. | Docker hub, `/mcp` routes, `$smart`, bearer/OAuth, CLI | ✅ |
 | [MCPJungle](mcpjungle.md) [![⭐](https://img.shields.io/github/stars/mcpjungle/MCPJungle?style=social)](https://github.com/mcpjungle/MCPJungle) | Run all your MCP servers behind one endpoint | Compose `/mcp`, tool groups, enterprise tokens, MPL-2.0 | ✅ |
+| [MetaMCP](metamcp.md) [![⭐](https://img.shields.io/github/stars/metatool-ai/metamcp?style=social)](https://github.com/metatool-ai/metamcp) | MCP Aggregator, Orchestrator, Middleware, Gateway in one docker | Docker Compose, namespaces, middleware, `sk_mt_` keys | ✅ |
 
 
 

--- a/services/tool-access-and-integration/metamcp.md
+++ b/services/tool-access-and-integration/metamcp.md
@@ -1,0 +1,184 @@
+# MetaMCP
+
+> **"MCP Aggregator, Orchestrator, Middleware, Gateway in one docker"**
+
+| | |
+|---|---|
+| **Website** | https://docs.metamcp.com |
+| **Docs** | https://docs.metamcp.com |
+| **GitHub** | https://github.com/metatool-ai/metamcp |
+| **Stars** | [![GitHub Stars](https://img.shields.io/github/stars/metatool-ai/metamcp?style=social)](https://github.com/metatool-ai/metamcp) |
+| **Classification** | `agent-native` |
+| **Category** | [Tool Access & Integration Services](README.md) |
+| **License** | MIT |
+| **Latest-month signal** | Last GitHub push **2026-06-22** ([repo metadata](https://api.github.com/repos/metatool-ai/metamcp)) — quieter than MCPHub/ContextForge; default branch `ai-dev`. README notes maintenance delay while still merging PRs. Still admitted: MIT + clear MCP aggregator/gateway OSS not already listed |
+| **Verified at** | 2026-09-04 |
+
+---
+
+## Official Website
+
+https://docs.metamcp.com
+
+Docs H1 area (live 2026-09-04): **“MetaMCP Documentation”** with tagline **“MCP Aggregator, Orchestrator, Middleware, Gateway in one docker”**.
+
+---
+
+## Official Repo
+
+https://github.com/metatool-ai/metamcp
+
+README title (live 2026-09-04): **“MetaMCP (MCP Aggregator, Orchestrator, Middleware, Gateway in one docker)”**
+
+GitHub description matches that tagline exactly. Body: “MetaMCP is a MCP proxy that lets you dynamically aggregate MCP servers into a unified MCP server, and apply middlewares. MetaMCP itself is a MCP server so it can be easily plugged into ANY MCP clients.”
+
+---
+
+## How to Use (Agent Onboarding)
+
+**Interaction pattern:** `CLI` + MCP gateway
+
+```bash
+git clone https://github.com/metatool-ai/metamcp.git
+cd metamcp
+cp example.env .env
+docker compose up -d
+```
+
+Create a namespace + endpoint in the UI (or API), then point an MCP client at the Streamable HTTP or SSE URL with `Authorization: Bearer sk_mt_...`.
+
+Cursor `mcp.json` uses the MetaMCP endpoint URL. STDIO-only clients (Claude Desktop) go through `mcp-proxy` (not `mcp-remote` — MetaMCP auth is API-key, not OAuth-to-upstream).
+
+There is no URL-onboarding document.
+
+---
+
+## Agent Skills
+
+**Status:** ⚠️ No official `npx skills add` package published yet.
+
+```bash
+npx clawhub@latest search metamcp
+```
+
+See: https://agentskills.io/specification to contribute one.
+
+---
+
+## MCP
+
+**Status:** ✅ Available — the product **is** a meta-MCP server
+
+| Detail | Value |
+|---|---|
+| **MCP Repo** | https://github.com/metatool-ai/metamcp |
+| **Transport** | Streamable HTTP (standard remote); SSE (compat); STDIO via `mcp-proxy` |
+| **Auth** | API keys `sk_mt_...` (`Authorization: Bearer`); session cookies for the dashboard; optional OIDC SSO |
+| **Compatible Clients** | Cursor, Claude Desktop (via proxy), Open WebUI (OpenAPI), any MCP client |
+| **Docs index** | https://docs.metamcp.com/llms.txt |
+
+---
+
+## What It Does
+
+MetaMCP is a **self-hosted MCP proxy**: register MCP servers, group them into **namespaces**, apply **middleware**, and host them as one meta-MCP with public SSE or Streamable HTTP endpoints. Tool cherry-picking, an inspector, API-key and OIDC auth, multi-tenancy (public/private scopes), and OpenAPI for Open WebUI ship in one Docker Compose stack.
+
+Last code push as of verification: **2026-06-22**. Still listed because the docs, Compose path, MIT license, and H1 positioning remain agent-native; operators should note the quieter cadence versus [MCPHub](mcphub.md) / [ContextForge](contextforge.md).
+
+**Distinct from catalog peers:**
+
+| Peer | Difference |
+|---|---|
+| [MCPHub](mcphub.md) | Node hub with `$smart` vector routing, Apache-2.0, active 2026-09 |
+| [MCPJungle](mcpjungle.md) | Go/Compose one-`/mcp` + enterprise tokens, MPL-2.0 |
+| [ContextForge](contextforge.md) | IBM federation of MCP + **A2A + REST/gRPC** + UAID |
+| [MCP Gateway & Registry](mcp-gateway-registry.md) | Org IdP, virtual MCP, 3LO, skill scanning |
+| [ToolHive](toolhive.md) | Secure **container runtime** for launching MCP servers |
+| [Toolport](toolport.md) | Local stdio meta-gateway + OS keychain |
+| [Obot](obot.md) | Full MCP platform **plus chat client** |
+| Hosted [MCP Gateway](mcpgateway.md) | Commercial one-URL tools/skills/sandboxes |
+
+---
+
+## Why It Is Agent-Native
+
+| Criterion | Evidence |
+|---|---|
+| **Agent-first positioning** | Docs/README/GitHub: **“MCP Aggregator, Orchestrator, Middleware, Gateway in one docker”** — [docs.metamcp.com](https://docs.metamcp.com), [repo](https://github.com/metatool-ai/metamcp). “plugged into ANY MCP clients.” |
+| **Agent-specific primitive** | Namespaces as meta-MCPs; middleware around tool lists; public endpoints with API keys; tool overrides/annotations |
+| **Autonomy-compatible control plane** | After namespace + `sk_mt_` key, agents call tools through the endpoint with no dashboard click |
+| **M2M integration surface** | Docker Compose, Streamable HTTP / SSE MCP, OpenAPI, API keys |
+| **Identity / delegation** | Per-user API keys; public vs private scopes; OIDC for dashboard SSO; public keys cannot reach private MetaMCPs |
+
+---
+
+## Primary Primitives
+
+| Primitive | Description |
+|---|---|
+| **Namespace** | Group of MCP servers hosted as one meta-MCP |
+| **Endpoint** | Public SSE or Streamable HTTP URL + auth |
+| **Middleware** | Transform tool lists / requests / responses |
+| **Tool overrides** | Cherry-pick and annotate tools when remixing servers |
+| **API key** | `sk_mt_...` bearer for agents |
+| **OIDC** | Optional enterprise SSO for operators |
+
+---
+
+## Autonomy Model
+
+```
+Operator docker compose up -d, registers MCP servers into a namespace
+    -> Issues an API key for the agent
+    -> Agent connects to the Streamable HTTP / SSE endpoint
+    -> MetaMCP aggregates, applies middleware, routes tool calls
+    -> Dashboard / inspector stay off the data path
+```
+
+---
+
+## Identity and Delegation Model
+
+- **Agent callers:** `Authorization: Bearer sk_mt_...` (query `?api_key=` works for Streamable HTTP/OpenAPI only, not SSE).
+- **Scopes:** public vs private MetaMCPs; public keys cannot access private ones.
+- **Dashboard users:** session cookies; optional OIDC (Auth0, Keycloak, Azure AD).
+- **Upstream secrets:** stored with the registered MCP server config, not in every client `mcp.json`.
+
+---
+
+## Protocol Surface
+
+| Interface | Detail |
+|---|---|
+| Docker Compose | recommended path (`example.env`) |
+| HTTP MCP | Streamable HTTP + SSE |
+| OpenAPI | Open WebUI-compatible |
+| STDIO clients | `mcp-proxy` + API key |
+| License | MIT |
+| Cadence | Last push 2026-06-22 |
+
+---
+
+## Human-in-the-Loop Support
+
+Web UI for namespaces, inspector, and registration. Tool calls on the meta-MCP endpoint do not require a click. OIDC/SSO is an operator login, not per-tool approval.
+
+---
+
+## Why Generic Alternatives Do Not Qualify
+
+| Alternative | Why It Fails |
+|---|---|
+| **MCPHub / MCPJungle** | Different stacks (Node `$smart` hub; Go enterprise tokens). MetaMCP is namespace+middleware+inspector in one Docker |
+| **ContextForge / MCP Gateway & Registry** | Protocol federation + UAID, or org IdP registry |
+| **ToolHive / Toolport / Obot** | Runtime, local stdio hub, or chat+hosting platform |
+| **nginx alone** | No MCP namespace, middleware, or tool remix |
+
+---
+
+## Use Cases
+
+- **One meta-MCP URL** — Cursor/Claude share a remixed tool set
+- **Cherry-pick tools** — hide noisy upstream tools via middleware
+- **Self-host with MIT** — Compose + API keys + optional OIDC
+- **Open WebUI** — OpenAPI endpoint in front of MCP servers

--- a/skill.md
+++ b/skill.md
@@ -74,7 +74,7 @@ These services can be joined with a single instruction, right now, with no human
 
 ---
 
-## Full Catalog — 16 Categories, 217 Services
+## Full Catalog — 16 Categories, 223 Services
 
 ### 1. Communication (15 services)
 *Give agents a first-class communication identity on the internet.*
@@ -132,7 +132,7 @@ These services can be joined with a single instruction, right now, with no human
 
 ---
 
-### 3. Tool Access & Integration (21 services)
+### 3. Tool Access & Integration (22 services)
 *Runtime tool discovery, auth, and execution without human pre-configuration.*
 
 | Service | Tagline | Onboarding |
@@ -158,6 +158,7 @@ These services can be joined with a single instruction, right now, with no human
 | [MCP Gateway & Registry](https://agentic-community.github.io/mcp-gateway-registry/) | Unified Agent & MCP Server Registry | `git clone https://github.com/agentic-community/mcp-gateway-registry && ./build_and_run.sh --prebuilt` |
 | [MCPHub](https://www.mcphub.app) | One gateway for all your MCP servers. | `docker run -p 3000:3000 -v ./data:/app/data samanhappy/mcphub` then connect to `http://localhost:3000/mcp` |
 | [MCPJungle](https://docs.mcpjungle.com) | Run all your MCP servers behind one endpoint | `docker compose up -d` then `mcpjungle register --name context7 --url https://mcp.context7.com/mcp` |
+| [MetaMCP](https://docs.metamcp.com) | MCP Aggregator, Orchestrator, Middleware, Gateway in one docker | `git clone https://github.com/metatool-ai/metamcp.git && docker compose up -d` |
 
 ---
 
@@ -249,7 +250,7 @@ These services can be joined with a single instruction, right now, with no human
 
 ---
 
-### 8. Memory & State (26 services)
+### 8. Memory & State (28 services)
 *Persistent, queryable memory across sessions — memory as infrastructure, not application logic.*
 
 | Service | Tagline | Onboarding |
@@ -259,6 +260,7 @@ These services can be joined with a single instruction, right now, with no human
 | [Recall](https://www.recall.works) | Open-source memory for AI agents. MCP-native. Self-hosted. | `uvx ai-recallworks stdio` |
 | [Mem0](https://mem0.ai) | The memory layer for your AI agents | `pip install mem0ai` → `m.add(messages, user_id=...)` |
 | [Zep](https://getzep.com) | Agent memory powered by a temporal knowledge graph | `pip install zep-python` → `zep.add_session_message(...)` |
+| [Graphiti](https://help.getzep.com/graphiti) | Build Real-Time Knowledge Graphs for AI Agents | `pip install graphiti-core` or `uv run graphiti_mcp_server.py` |
 | [Ensue](https://ensue.dev) ⭐ | The shared memory network for AI agents | `Read https://raw.githubusercontent.com/mutable-state-inc/ensue-skill/main/skills/ensue-memory/SKILL.md and follow the instructions` |
 | [OpenViking](https://github.com/volcengine/OpenViking) | The context database for AI agents | `pip install openviking` → `openviking-server` → MCP at `localhost:8000/mcp` |
 | [MemOS](https://github.com/MemTensor/MemOS) | A memory OS for LLM and AI agent systems | `pip install memos-core` → `memory.add(...)` |
@@ -280,6 +282,7 @@ These services can be joined with a single instruction, right now, with no human
 | [Memoir](https://www.memoir-ai.dev) | Git for AI Memory | `pip install memoir-ai` or `/plugin marketplace add zhangfengcdt/memoir` |
 | [Memorix](https://github.com/AVIDS2/memorix) | Local-first shared memory layer for AI coding agents. | `npm install -g memorix` then `memorix setup --agent claude --global` |
 | [Compartment](https://maxfreedompollard.github.io/Compartment/) | Encrypted, fully offline memory for AI agents. | `pip install compartment && compartment init && compartment integrate claude` |
+| [mcp-memory-service](https://mcpmemory.services) | Memory for AI Agents — REST, MCP, OAuth, CLI | `pip install mcp-memory-service` then `memory server` or `memory server --http` |
 
 ---
 
@@ -300,7 +303,7 @@ These services can be joined with a single instruction, right now, with no human
 
 ---
 
-### 10. Code Execution (13 services)
+### 10. Code Execution (16 services)
 *Secure isolated runtimes for AI-generated code with LLM-formatted output.*
 
 | Service | Tagline | Onboarding |
@@ -318,6 +321,9 @@ These services can be joined with a single instruction, right now, with no human
 | [Agent Sandbox (Kubernetes SIG)](https://agent-sandbox.sigs.k8s.io) | Secure isolated execution layer for autonomous agents on Kubernetes | `pip install k8s-agent-sandbox` then `SandboxClient().create_sandbox(...)` |
 | [Clawk](https://github.com/clawkwork/clawk) | Give a coding agent its own disposable Linux machine, not yours | `brew install clawkwork/tap/clawk` then `cd <repo> && clawk` (pre-1.0) |
 | [Dormice](https://github.com/BitMiracle-AI/Dormice) | The SQLite of agent sandboxes — self-hosted, idle costs nothing | install.sh then `npx skills add BitMiracle-AI/Dormice` (early-dev) |
+| [CubeSandbox](https://cubesandbox.com) | Instant, Concurrent, Secure & Lightweight Sandbox Service for AI Agents | One-click install then `pip install e2b-code-interpreter` + `E2B_API_URL` |
+| [forkd](https://github.com/deeplethe/forkd) | A microVM sandbox runtime for AI agent fan-out. | Release tarball then `sudo -E forkd quickstart` |
+| [SmolVM](https://docs.celesto.ai/smolvm) | SmolVM: secure microVM sandboxes for AI agents | `curl -sSL https://celesto.ai/install.sh | bash` then `from smolvm import SmolVM` |
 
 ---
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Maintainer search batch (issue-first waived; same pattern as merged PR #120). Adds 6 high-confidence OSI-licensed OSS agent-native services from a 2026-09-04 live re-check.

Rebased onto current `main` after #121 (SSSNACK) landed. Catalog counts: **217 → 223** / 16 categories.
Code Execution 13 → 16; Memory & State 26 → 28; Tool Access & Integration 21 → 22. Agent Social stays at 8 (SSSNACK from main).

### Services added

| Service | Category | License | Stars (verified 2026-09-04) | Exact official tagline | GitHub |
|---|---|---|---|---|---|
| **CubeSandbox** | Code Execution | Apache-2.0 (GitHub SPDX `NOASSERTION` because `LICENSE` wraps Apache-2.0 + third-party exceptions) | ~11,748 | Instant, Concurrent, Secure & Lightweight Sandbox Service for AI Agents | https://github.com/TencentCloud/CubeSandbox |
| **forkd** | Code Execution | Apache-2.0 | ~2,829 | A microVM sandbox runtime for AI agent fan-out. | https://github.com/deeplethe/forkd |
| **SmolVM** | Code Execution | Apache-2.0 | ~874 | SmolVM: secure microVM sandboxes for AI agents | https://github.com/CelestoAI/SmolVM |
| **Graphiti** | Memory & State | Apache-2.0 | ~30,569 | Build Real-Time Knowledge Graphs for AI Agents | https://github.com/getzep/graphiti |
| **mcp-memory-service** | Memory & State | Apache-2.0 | ~1,922 | Memory for AI Agents — REST, MCP, OAuth, CLI | https://github.com/doobidoo/mcp-memory-service |
| **MetaMCP** | Tool Access & Integration | MIT | ~2,646 | MCP Aggregator, Orchestrator, Middleware, Gateway in one docker | https://github.com/metatool-ai/metamcp |

Taglines are exact homepage/README/docs H1 quotes (re-fetched live 2026-09-04; no paraphrase). Public-repo rows include GitHub star badges.

### Distinctness notes

- **CubeSandbox ≠ E2B / OpenSandbox.** Self-host E2B-compatible RustVMM+KVM microVM *service*. E2B remains the hosted cloud product.
- **forkd ≠ CubeSandbox / SmolVM / E2B.** Firecracker CoW **fork + live BRANCH** fan-out, not cold-start/pool or a disposable-computer SDK.
- **SmolVM ≠ E2B / CubeSandbox / forkd.** Local multi-VMM (Firecracker/QEMU/libkrun) SDK/CLI for disposable agent computers + browser sandboxes.
- **Graphiti ≠ Zep.** Graphiti is the OSS temporal graph framework + MCP (`getzep/graphiti`). Zep is the managed product/platform (`getzep/zep`). Cross-linked in both dossiers; rows are not merged.
- **mcp-memory-service ≠ Zep / Graphiti / Mem0 / Recall.** Multi-transport self-host memory (REST + MCP + OAuth DCR + `X-Agent-ID`).
- **MetaMCP ≠ MCPHub / MCPJungle / ContextForge.** Namespace + middleware + inspector in one Docker; MIT. Last push **2026-06-22** (quieter cadence; disclosed).
- **SSSNACK stays on main** (`agent-social-network/sssnack`) — not part of this batch.

### Disclosures

- **CubeSandbox license:** official `LICENSE` is Apache-2.0 except listed third-party components. GitHub license API returns `NOASSERTION` because of that wrapper — dossier states Apache-2.0 with that note.
- **MetaMCP:** last GitHub push 2026-06-22; README notes maintenance delay while still merging PRs. Still admitted — MIT + clear MCP gateway OSS not already listed.
- **CubeSandbox / SmolVM MCP:** no first-party MCP server yet (⚠️). Agent surface is E2B-compat SDK / `smolvm` CLI+SDK.
- **Not added (per brief):** DuraGraph; Docker/Microsoft MCP gateways; Lunar/MCPX; AgentBox; Lasso; KYA-OS; thin browsers. SSSNACK is already on main via #121. No `docs/sitemap.xml`.

## Type of change

- [x] 🆕 New service entry

## Linked issue

Maintainer (haoruilee) authorized this catalog update batch. Issue-first waived (same pattern as #120). Closes nothing.

## New service checklist

- [x] Standard five-criteria track (all six dossiers)
- [x] Created `services/{category}/{service-name}.md` with all §7 sections
- [x] Added a row to each category README
- [x] Added a row to the matching root README.md section
- [x] Classification is `agent-native`
- [x] Live GitHub star badges (no hardcoded star numbers in prose)

## Test plan

- [x] Rebased onto `origin/main` after #121; generated files regenerated (not hand-merged)
- [x] `python3 scripts/build-machine-catalog.py` clean
- [x] `bash scripts/build-github-pages.sh` clean
- [x] `python3 scripts/build-machine-catalog.py --check` → **223 services / 16 categories**
- [x] `python3 scripts/check-repository-health.py --local` → 807 links, 223 services
- [x] Generated `docs/**`, `catalog.json`, `llms.txt`, `skill.md` committed
- [x] GitHub CI green on `2baecbb` (`Validate catalog and site / validate`)

**Validated; ready to squash-merge.** Leave ready for human review. Head SHA: `2baecbbd5c9cf62e20e4ded6e6d75082c412fe29`. mergeable_state: CLEAN.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-98055d0d-9a45-4ae9-8604-e05af43e8599?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-98055d0d-9a45-4ae9-8604-e05af43e8599&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>