### PR TITLE
[Site] Keep masthead search compact on small screens

### DIFF
--- a/docs/assets/css/catalog.css
+++ b/docs/assets/css/catalog.css
@@ -173,9 +173,10 @@ a:hover {
 
 .catalog-search {
   position: relative;
-  flex: 1 1 220px;
+  flex: 1 1 auto;
   max-width: 440px;
   min-width: 0;
+  width: min(440px, 100%);
 }
 
 .catalog-search__field {
@@ -1261,6 +1262,7 @@ a:hover {
   }
 
   .catalog-search {
+    flex: none;
     width: 100%;
     max-width: none;
     order: 2;
@@ -1269,7 +1271,13 @@ a:hover {
   .catalog-search__panel {
     left: 0;
     right: 0;
+    width: 100%;
     min-width: 0;
+    max-width: 100%;
+  }
+
+  .catalog-search__option {
+    flex-wrap: wrap;
   }
 
   .wordmark-mark {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

#123 shipped layout-wide local catalog search. On stacked (narrow) mastheads, `flex: 1 1 220px` treated that 220px as **height**, so opening results stretched the header and pushed the primary nav down.

## What changed

- Search is `flex: 1 1 auto` on desktop and `flex: none` when the masthead stacks.
- The results panel stays width-constrained and can wrap option rows on small screens.

CSS-only. No catalog or dossier changes.

## Verify

- Narrow viewport: type in search; nav stays under the field; results overlay the page.
- Desktop search behavior unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-70b58e82-0c61-4c77-a413-67d4f4c23aad?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-70b58e82-0c61-4c77-a413-67d4f4c23aad&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

